### PR TITLE
Add percent characters for AP values of instance segmentation models

### DIFF
--- a/intel_models/instance-segmentation-security-0033/description/instance-segmentation-security-0033.md
+++ b/intel_models/instance-segmentation-security-0033/description/instance-segmentation-security-0033.md
@@ -14,10 +14,10 @@ Feature Pyramid Networks block for feature maps refinement.
 
 | Metric                          | Value                                     |
 |---------------------------------|-------------------------------------------|
-| MS COCO val2017 box AP (max short side 480, max long side 640)   | 38.9     |
-| MS COCO val2017 mask AP (max short side 480, max long side 640)  | 34.7     |
-| MS COCO val2017 box AP (max height 480, max width 640)           | 38.6     |
-| MS COCO val2017 mask AP (max height 480, max width 640)          | 34.3     |
+| MS COCO val2017 box AP (max short side 480, max long side 640)   | 38.9%    |
+| MS COCO val2017 mask AP (max short side 480, max long side 640)  | 34.7%    |
+| MS COCO val2017 box AP (max height 480, max width 640)           | 38.6%    |
+| MS COCO val2017 mask AP (max height 480, max width 640)          | 34.3%    |
 | Max objects to detect           | 100                                       |
 | GFlops                          | 354.274                                   |
 | MParams                         | 143.444                                   |

--- a/intel_models/instance-segmentation-security-0049/description/instance-segmentation-security-0049.md
+++ b/intel_models/instance-segmentation-security-0049/description/instance-segmentation-security-0049.md
@@ -14,10 +14,10 @@ block for feature maps refinement and relatively light segmentation head.
 
 | Metric                          | Value                                     |
 |---------------------------------|-------------------------------------------|
-| MS COCO val2017 box AP (max short side 320, max long side 480)   | 30.4     |
-| MS COCO val2017 mask AP (max short side 320, max long side 480)  | 26.8     |
-| MS COCO val2017 box AP (max height 320, max width 480)           | 29.8     |
-| MS COCO val2017 mask AP (max height 320, max width 480)          | 26.3     |
+| MS COCO val2017 box AP (max short side 320, max long side 480)   | 30.4%    |
+| MS COCO val2017 mask AP (max short side 320, max long side 480)  | 26.8%    |
+| MS COCO val2017 box AP (max height 320, max width 480)           | 29.8%    |
+| MS COCO val2017 mask AP (max height 320, max width 480)          | 26.3%    |
 | Max objects to detect           | 100                                       |
 | GFlops                          | 56.433                                    |
 | MParams                         | 44.920                                    |


### PR DESCRIPTION
@snosov1 please take a look.