### PR TITLE
 model_downloader: make postprocessing more generic 

### DIFF
--- a/model_downloader/list_topologies.yml
+++ b/model_downloader/list_topologies.yml
@@ -28,6 +28,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-121.caffemodel> --input_proto <densenet-121.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
+
   - name: "densenet-161"
     description: "DenseNet-161 (https://github.com/shicai/DenseNet-Caffe). The following Caffe patch must be used to be able to convert this model: https://github.com/BVLC/caffe/pull/3057/files"
     model: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_161.prototxt
@@ -40,6 +41,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-161.caffemodel> --input_proto <densenet-161.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
+
   - name: "densenet-169"
     description: "DenseNet-169 (https://github.com/shicai/DenseNet-Caffe). The following Caffe patch must be used to be able to convert this model: https://github.com/BVLC/caffe/pull/3057/files"
     model: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_169.prototxt
@@ -52,6 +54,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-169.caffemodel> --input_proto <densenet-169.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
+
   - name: "densenet-201"
     description: "DenseNet-201 (https://github.com/shicai/DenseNet-Caffe). The following Caffe patch must be used to be able to convert this model: https://github.com/BVLC/caffe/pull/3057/files"
     model: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_201.prototxt
@@ -64,6 +67,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-201.caffemodel> --input_proto <densenet-201.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
+
   - name: "squeezenet1.0"
     description: "SqueezeNet v1.0 (https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.0)"
     model: https://raw.githubusercontent.com/DeepScale/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/deploy.prototxt
@@ -76,6 +80,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <squeezenet1.0.caffemodel> --input_proto <squeezenet1.0.prototxt>"
     framework: caffe
     license: https://github.com/DeepScale/SqueezeNet/blob/master/LICENSE
+
   - name: "squeezenet1.1"
     description: "SqueezeNet v1.1 (https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.1)"
     model: https://raw.githubusercontent.com/DeepScale/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/deploy.prototxt
@@ -88,6 +93,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <squeezenet1.1.caffemodel> --input_proto <squeezenet1.1.prototxt>"
     framework: caffe
     license: https://github.com/DeepScale/SqueezeNet/blob/master/LICENSE
+
   - name: "mtcnn-p"
     description: "MTCNN-Proposal Network (https://github.com/DuinoDu/mtcnn/tree/master/model https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf)"
     model: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.prototxt
@@ -100,6 +106,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,720,1280] --input data --output prob1 --input_model <mtcnn-p.caffemodel> --input_proto <mtcnn-p.prototxt>"
     framework: caffe
     license: https://github.com/DuinoDu/mtcnn/blob/master/LICENSE
+
   - name: "mtcnn-r"
     description: "MTCNN-Refine Network (https://github.com/DuinoDu/mtcnn/tree/master/model https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf)"
     model: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.prototxt
@@ -110,6 +117,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,24,24] --input data --output prob1 --input_model <mtcnn-r.caffemodel> --input_proto <mtcnn-r.prototxt>"
     framework: caffe
     license: https://github.com/DuinoDu/mtcnn/blob/master/LICENSE
+
   - name: "mtcnn-o"
     description: "MTCNN-Output Network (https://github.com/DuinoDu/mtcnn/tree/master/model https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf)"
     model: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.prototxt
@@ -120,6 +128,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,48,48] --input data --output prob1 --input_model <mtcnn-o.caffemodel> --input_proto <mtcnn-o.prototxt>"
     framework: caffe
     license: https://github.com/DuinoDu/mtcnn/blob/master/LICENSE
+
   - name: "mobilenet-ssd"
     description: "Common object detection architecture (https://github.com/chuanqi305/MobileNet-SSD)"
     model: https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/ba00fc987b3eb0ba87bb99e89bf0298a2fd10765/MobileNetSSD_deploy.prototxt
@@ -132,6 +141,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[127.5,127.5,127.5] --scale_values data[127.50223128904757] --output detection_out --input_model <mobilenet-ssd.caffemodel> --input_proto <mobilenet-ssd.prototxt>"
     framework: caffe
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "vgg19"
     description: "VGG Net-E (https://arxiv.org/pdf/1409.1556.pdf)"
     model: https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/f02f8769e64494bcd3d7e97d5d747ac275825721/VGG_ILSVRC_19_layers_deploy.prototxt
@@ -144,6 +154,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.939,116.779,123.68] --output prob --input_model <vgg19.caffemodel> --input_proto <vgg19.prototxt>"
     framework: caffe
     license: https://github.com/keras-team/keras/blob/master/LICENSE
+
   - name: "vgg16"
     description: "VGG Net-D (https://arxiv.org/pdf/1409.1556.pdf)"
     model: https://gist.githubusercontent.com/ksimonyan/211839e770f7b538e2d8/raw/0067c9b32f60362c74f4c445a080beed06b07eb3/VGG_ILSVRC_16_layers_deploy.prototxt
@@ -156,6 +167,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.939,116.779,123.68] --output prob --input_model <vgg16.caffemodel> --input_proto <vgg16.prototxt>"
     framework: caffe
     license: https://github.com/keras-team/keras/blob/master/LICENSE
+
   - name: "ssd512"
     description: "SSD-512 (https://arxiv.org/pdf/1512.02325.pdf)"
     model_hash: e8a18363aeb8a74a90fda6d6c8596994aca018061765b2aa38f8e0a580ca4c70
@@ -170,6 +182,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,512,512] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <ssd512.caffemodel> --input_proto <ssd512.prototxt>"
     framework: caffe
     license: https://github.com/weiliu89/caffe/blob/ssd/LICENSE
+
   - name: "ssd300"
     description: "SSD-300 (https://arxiv.org/pdf/1512.02325.pdf)"
     model_hash: 0366cd7cb909aebe499bc23d34e1aaf5c81ff2e32c438ba87db2845c4edf1309
@@ -184,6 +197,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <ssd300.caffemodel> --input_proto <ssd300.prototxt>"
     framework: caffe
     license: https://github.com/weiliu89/caffe/blob/ssd/LICENSE
+
   - name: "inception-resnet-v2"
     description: "Inception-ResNet V2 architecture (https://arxiv.org/pdf/1602.07261.pdf)"
     model: https://drive.google.com/drive/folders/0B9mkjlmP0d7zc3A4NWlQQzdoM28
@@ -198,6 +212,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,299,299] --input data --mean_values data[128.0,128.0,128.0] --scale_values data[128.0] --output prob --input_model <inception-resnet-v2.prototxt>"
     framework: caffe
     license: https://github.com/soeaver/caffe-model/blob/master/LICENSE
+
   - name: "dilation"
     description: "Multi-Scale Context Aggregation by Dilated Convolutions (https://arxiv.org/pdf/1511.07122.pdf)"
     model: https://raw.githubusercontent.com/fyu/dilation/0f105742e8c2202af12feb54374781ba55c3e112/models/dilation10_cityscapes_deploy.prototxt
@@ -208,6 +223,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,1396,1396] --input data --mean_values data[72.39,82.91,73.16] --output prob --input_model <dilation.caffemodel> --input_proto <dilation.prototxt>"
     framework: caffe
     license: https://github.com/fyu/dilation/blob/master/LICENSE
+
   - name: "googlenet-v1"
     description: "GoogleNet v1 (Inception v1) (https://arxiv.org/pdf/1409.4842.pdf)"
     model: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_googlenet/deploy.prototxt
@@ -220,6 +236,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <googlenet-v1.caffemodel> --input_proto <googlenet-v1.prototxt>"
     framework: caffe
     license: https://github.com/BVLC/caffe/blob/master/LICENSE
+
   - name: "googlenet-v2"
     description: "GoogleNet v2 (Inception v2) (https://arxiv.org/pdf/1502.03167.pdf)"
     model: https://raw.githubusercontent.com/lim0606/caffe-googlenet-bn/d19caf526b7d8cad873ff91ba4cea602eadd58b3/deploy.prototxt
@@ -233,6 +250,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <googlenet-v2.caffemodel> --input_proto <googlenet-v2.prototxt>"
     framework: caffe
     license: https://github.com/lim0606/caffe-googlenet-bn/blob/master/README.md
+
   - name: "googlenet-v4"
     description: "GoogleNet v4 (Inception v4)"
     model: https://drive.google.com/drive/folders/0B9mkjlmP0d7zUEJ3aEJ2b3J0RFU
@@ -247,6 +265,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,299,299] --input data --mean_values data[128.0,128.0,128.0] --scale_values data[128.0] --output prob --input_model <googlenet-v4.caffemodel> --input_proto <googlenet-v4.prototxt>"
     framework: caffe
     license: https://github.com/soeaver/caffe-model/blob/master/LICENSE
+
   - name: "alexnet"
     description: "AlexNet (http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf)"
     model: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_alexnet/deploy.prototxt
@@ -259,6 +278,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <alexnet.caffemodel> --input_proto <alexnet.prototxt>"
     framework: caffe
     license: https://github.com/BVLC/caffe/blob/master/models/bvlc_alexnet/readme.md
+
   - name: "ssd_mobilenet_v2_coco"
     description: "MobileNetV2 object detection architecture (https://arxiv.org/pdf/1801.04381.pdf) pre-trained on the COCO dataset"
     model_hash: 10dd7ebd618a5dd0d7a95081320e64b86358b09a906faafc13a0de793998dbfc
@@ -270,6 +290,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --tensorflow_use_custom_operations_config ./extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <ssd_mobilenet_v2_coco.config> --output detection_classes,detection_scores,detection_boxes,num_detections --input_model <ssd_mobilenet_v2_coco.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "resnet-50"
     description: "ResNet-50 (https://arxiv.org/pdf/1512.03385.pdf)"
     model: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117891&authkey=AAFW2-FVoxeVRck
@@ -282,6 +303,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-50.caffemodel> --input_proto <resnet-50.prototxt>"
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
+
   - name: "resnet-101"
     description: "ResNet-101 (https://arxiv.org/pdf/1512.03385.pdf)"
     model: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117892&authkey=AAFW2-FVoxeVRck
@@ -294,6 +316,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-101.caffemodel> --input_proto <resnet-101.prototxt>"
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
+
   - name: "resnet-152"
     description: "ResNet-152 (https://arxiv.org/pdf/1512.03385.pdf)"
     model: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117893&authkey=AAFW2-FVoxeVRck
@@ -306,6 +329,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-152.caffemodel> --input_proto <resnet-152.prototxt>"
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
+
   - name: "googlenet-v3"
     description: "GoogleNet v3 (Inception v3) (https://arxiv.org/pdf/1512.00567.pdf)"
     weights_hash: f5ce67052687aba5bc35250b51e8d0f127d3fd140eac67b47c07d012d20d55a3
@@ -315,6 +339,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,299,299,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.50000414375013] --output InceptionV3/Predictions/Softmax --input_model <googlenet-v3.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "se-inception"
     description: "BN-Inception with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
     model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-BN-Inception.prototxt
@@ -327,6 +352,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-inception.caffemodel> --input_proto <se-inception.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
+
   - name: "se-resnet-101"
     description: "ResNet-101 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
     model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-101.prototxt
@@ -339,6 +365,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-101.caffemodel> --input_proto <se-resnet-101.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
+
   - name: "se-resnet-152"
     description: "ResNet-152 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
     model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-152.prototxt
@@ -351,6 +378,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-152.caffemodel> --input_proto <se-resnet-152.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
+
   - name: "se-resnet-50"
     description: "ResNet-50 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
     model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-50.prototxt
@@ -363,6 +391,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-50.caffemodel> --input_proto <se-resnet-50.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
+
   - name: "se-resnext-50"
     description: "ResNeXt-50 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
     model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-50.prototxt
@@ -375,6 +404,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnext-50.caffemodel> --input_proto <se-resnext-50.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
+
   - name: "se-resnext-101"
     description: "ResNeXt-101 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
     model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-101.prototxt
@@ -387,6 +417,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnext-101.caffemodel> --input_proto <se-resnext-101.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
+
   - name: "Sphereface"
     description: "Deep face recognition under open-set protocol (https://arxiv.org/pdf/1704.08063.pdf)"
     model: https://raw.githubusercontent.com/wy1iu/sphereface/7f9acb157c78a99dbefd041fce9f188400bbb4e5/train/code/sphereface_deploy.prototxt
@@ -399,6 +430,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,112,96] --input data --mean_values data[127.5,127.5,127.5] --scale_values data[128.0] --output fc5 --input_model <Sphereface.caffemodel> --input_proto <Sphereface.prototxt>"
     framework: caffe
     license: https://github.com/wy1iu/sphereface/blob/master/LICENSE
+
   - name: "license-plate-recognition-barrier-0007"
     description: "TensorFlow LPRNet"
     weights_hash: 613b6011ad86a2d792e04b64b6ce0d763064319b5240440fa57b571b65c0b595
@@ -408,6 +440,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,24,94,3] --input input --scale_values input[254.99997577500233] --output d_predictions --input_model <license-plate-recognition-barrier-0007.frozen>"
     framework: tf
     license: https://github.com/opencv/training_toolbox_tensorflow/blob/develop/LICENSE
+
   - name: "face-detection-retail-0044"
     description: "Face Detection (SqNet1.0modif+single scale) with BatchNormalization trained with negatives"
     model: https://raw.githubusercontent.com/opencv/training_toolbox_caffe/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/deploy.prototxt
@@ -418,6 +451,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --input_model <face-detection-retail-0044.caffemodel> --input_proto <face-detection-retail-0044.prototxt>"
     framework: caffe
     license: https://github.com/opencv/training_toolbox_caffe/blob/develop/LICENSE
+
   - name: "mobilenet-v1-1.0-224"
     description: "MobileNet V1 architecture with the width multiplier 1.0 and resolution 224 (https://arxiv.org/pdf/1704.04861.pdf)"
     model: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_deploy.prototxt
@@ -428,6 +462,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output prob --input_model <mobilenet-v1-1.0-224.caffemodel> --input_proto <mobilenet-v1-1.0-224.prototxt>"
     framework: caffe
     license: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE
+
   - name: "mobilenet-v2"
     description: "MobileNet V2 (https://arxiv.org/pdf/1801.04381.pdf)"
     model: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2_deploy.prototxt
@@ -438,6 +473,7 @@ topologies:
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output prob --input_model <mobilenet-v2.caffemodel> --input_proto <mobilenet-v2.prototxt>"
     framework: caffe
     license: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE
+
   - name: "faster_rcnn_inception_v2_coco"
     description: "Faster R-CNN with Inception v2 (https://arxiv.org/pdf/1801.04381.pdf) pre-trained on the COCO dataset"
     model_hash: 1795389f43c17930b9ab0febf507fea329c37b1c1ce2ff077cfcfcc5d30be340
@@ -449,6 +485,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <faster_rcnn_inception_v2_coco.config> --input_model <faster_rcnn_inception_v2_coco.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "deeplabv3"
     description: "Rethinking Atrous Convolution for Semantic Image Segmentation (https://arxiv.org/pdf/1706.05587.pdf)"
     weights_hash: b3b7c39d1010c6da1dd0e87973ca24a78fa7dc70d4136fbcf50b9585469b6d9a
@@ -458,6 +495,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --input_shape [1,513,513,3] --input 1:mul_1 --output ArgMax --input_model <deeplabv3.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "ctpn"
     description: "Detecting Text in Natural Image with Connectionist Text Proposal Network (https://arxiv.org/pdf/1609.03605.pdf)"
     weights: https://github.com/eragonruan/text-detection-ctpn/releases/download/untagged-48d74c6337a71b6b5f87/ctpn.pb
@@ -466,6 +504,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input Placeholder --mean_values Placeholder[102.9801,115.9465,122.7717] --output Reshape_2,rpn_bbox_pred/Reshape_1 --input_model <ctpn.pb>"
     framework: tf
     license: https://github.com/eragonruan/text-detection-ctpn/blob/banjin-dev/LICENSE
+
   - name: "ssd_mobilenet_v1_coco"
     description: "MobileNetV1 object detection architecture (https://arxiv.org/pdf/1807.03284.pdf) pre-trained on the COCO dataset"
     model_hash: aec63661e0c561ef6de5c8a9b463cada7c639a8ed1c160b8903cd5d121d078ce
@@ -477,6 +516,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <ssd_mobilenet_v1_coco.config> --input_model <ssd_mobilenet_v1_coco.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "faster_rcnn_resnet101_coco"
     description: "Faster R-CNN Resnet-101 (https://arxiv.org/pdf/1801.04381.pdf) pre-trained on the COCO dataset"
     model_hash: 9147a34bdee5bf2c1e8bfb8fa8945463024e0974ef9dae65b17837e23ee804fe
@@ -488,6 +528,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <faster_rcnn_resnet101_coco.pb> --input_model <faster_rcnn_resnet101_coco.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "mobilenet-v2-1.4-224"
     description: "MobileNet V2 architecture with the width multiplier 1.4 and resolution 224 (https://arxiv.org/abs/1801.04381)"
     weights_hash: 111479258f3841c93d0a7a377c976c24e8281077818991931429d2277dd88590
@@ -497,6 +538,7 @@ topologies:
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,224,224,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.00001206500114] --output MobilenetV2/Predictions/Reshape_1 --input_model <mobilenet-v2-1.4-224.pb>"
     framework: "tf"
     license: https://github.com/tensorflow/models/blob/master/LICENSE
+
   - name: "age-gender-recognition-retail-0013"
     description: "Age & gender classification."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
@@ -506,6 +548,7 @@ topologies:
     output: "Retail/object_attributes/age_gender/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "age-gender-recognition-retail-0013-fp16"
     description: "Age & gender classification."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
@@ -515,6 +558,7 @@ topologies:
     output: "Retail/object_attributes/age_gender/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "emotions-recognition-retail-0003"
     description: "Recognizes 5 emotions for a face."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
@@ -524,6 +568,7 @@ topologies:
     output: "Retail/object_attributes/emotions_recognition/0003/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "emotions-recognition-retail-0003-fp16"
     description: "Recognizes 5 emotions for a face."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
@@ -533,6 +578,7 @@ topologies:
     output: "Retail/object_attributes/emotions_recognition/0003/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "emotions-recognition-retail-0003-int8"
     description: "Recognizes 5 emotions for a face."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.xml
@@ -542,6 +588,7 @@ topologies:
     output: "Retail/object_attributes/emotions_recognition/0003/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-detection-adas-0001"
     description: "Face Detection (MobileNet with reduced channels + SSD with weights sharing)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
@@ -551,6 +598,7 @@ topologies:
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-detection-adas-0001-fp16"
     description: "Face Detection (MobileNet with reduced channels + SSD with weights sharing)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
@@ -560,6 +608,7 @@ topologies:
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-detection-adas-0001-int8"
     description: "Face Detection (MobileNet with reduced channels + SSD with weights sharing)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/INT8/face-detection-adas-0001.xml
@@ -569,6 +618,7 @@ topologies:
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-detection-retail-0004"
     description: "Face Detection (SqNet1.0modif+single scale) without BatchNormalization trained with negatives."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
@@ -578,6 +628,7 @@ topologies:
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-detection-retail-0004-fp16"
     description: "Face Detection (SqNet1.0modif+single scale) without BatchNormalization trained with negatives."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
@@ -587,6 +638,7 @@ topologies:
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-detection-retail-0004-int8"
     description: "Face Detection (SqNet1.0modif+single scale) without BatchNormalization trained with negatives."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/INT8/face-detection-retail-0004.xml
@@ -596,6 +648,7 @@ topologies:
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-person-detection-retail-0002"
     description: "Simultaneous detection of Pedestrians and Faces (RMNet with lrelu + SSSSD)."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP32/face-person-detection-retail-0002.xml
@@ -605,6 +658,7 @@ topologies:
     output: "Retail/object_detection/face_pedestrian/rmnet-ssssd-2heads/0002/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-person-detection-retail-0002-fp16"
     description: "Simultaneous detection of Pedestrians and Faces (RMNet with lrelu + SSSSD)."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP16/face-person-detection-retail-0002.xml
@@ -614,6 +668,7 @@ topologies:
     output: "Retail/object_detection/face_pedestrian/rmnet-ssssd-2heads/0002/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-reidentification-retail-0095"
     description: "Single embedding-based face verification model"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
@@ -623,6 +678,7 @@ topologies:
     output: "Retail/object_reidentification/face/mobilenet_based/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-reidentification-retail-0095-fp16"
     description: "Single embedding-based face verification model"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
@@ -632,6 +688,7 @@ topologies:
     output: "Retail/object_reidentification/face/mobilenet_based/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "facial-landmarks-35-adas-0002"
     description: "Custom-architecture convolutional neural network for 35 facial landmarks estimation."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
@@ -641,6 +698,7 @@ topologies:
     output: "Transportation/object_attributes/facial_landmarks/custom-35-facial-landmarks/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "facial-landmarks-35-adas-0002-fp16"
     description: "Custom-architecture convolutional neural network for 35 facial landmarks estimation."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
@@ -650,6 +708,7 @@ topologies:
     output: "Transportation/object_attributes/facial_landmarks/custom-35-facial-landmarks/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "head-pose-estimation-adas-0001"
     description: "Vanilla CNN trained from scratch yaw + pitch + roll + landmarks"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
@@ -659,6 +718,7 @@ topologies:
     output: "Transportation/object_attributes/headpose/vanilla_cnn/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "head-pose-estimation-adas-0001-fp16"
     description: "Vanilla CNN trained from scratch yaw + pitch + roll + landmarks"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
@@ -668,6 +728,7 @@ topologies:
     output: "Transportation/object_attributes/headpose/vanilla_cnn/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "head-pose-estimation-adas-0001-int8"
     description: "Vanilla CNN trained from scratch yaw + pitch + roll + landmarks"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/INT8/head-pose-estimation-adas-0001.xml
@@ -677,6 +738,7 @@ topologies:
     output: "Transportation/object_attributes/headpose/vanilla_cnn/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "human-pose-estimation-0001"
     description: "2D human pose estimation with tuned mobilenet backbone (based on OpenPose)."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
@@ -686,6 +748,7 @@ topologies:
     output: "Transportation/human_pose_estimation/mobilenet-v1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "human-pose-estimation-0001-fp16"
     description: "2D human pose estimation with tuned mobilenet backbone (based on OpenPose)."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
@@ -695,6 +758,7 @@ topologies:
     output: "Transportation/human_pose_estimation/mobilenet-v1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "human-pose-estimation-0001-int8"
     description: "2D human pose estimation with tuned mobilenet backbone (based on OpenPose)."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/INT8/human-pose-estimation-0001.xml
@@ -704,6 +768,7 @@ topologies:
     output: "Transportation/human_pose_estimation/mobilenet-v1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "landmarks-regression-retail-0009"
     description: "Landmark's detection."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
@@ -713,6 +778,7 @@ topologies:
     output: "Retail/object_attributes/landmarks_regression/0009/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "landmarks-regression-retail-0009-fp16"
     description: "Landmark's detection."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
@@ -722,6 +788,7 @@ topologies:
     output: "Retail/object_attributes/landmarks_regression/0009/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "license-plate-recognition-barrier-0001"
     description: "Chinese license plate recognition"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
@@ -731,6 +798,7 @@ topologies:
     output: "Security/optical_character_recognition/license_plate/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "license-plate-recognition-barrier-0001-fp16"
     description: "Chinese license plate recognition"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
@@ -740,6 +808,7 @@ topologies:
     output: "Security/optical_character_recognition/license_plate/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "pedestrian-and-vehicle-detector-adas-0001"
     description: "Pedestrian and Vehicle detector based on ssd + mobilenet with reduced channels number."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
@@ -749,6 +818,7 @@ topologies:
     output: "Transportation/object_detection/pedestrian-and-vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "pedestrian-and-vehicle-detector-adas-0001-fp16"
     description: "Pedestrian and Vehicle detector based on ssd + mobilenet with reduced channels number."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
@@ -758,6 +828,7 @@ topologies:
     output: "Transportation/object_detection/pedestrian-and-vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "pedestrian-and-vehicle-detector-adas-0001-int8"
     description: "Pedestrian and Vehicle detector based on ssd + mobilenet with reduced channels number."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.xml
@@ -767,6 +838,7 @@ topologies:
     output: "Transportation/object_detection/pedestrian-and-vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "pedestrian-detection-adas-0002"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
@@ -776,6 +848,7 @@ topologies:
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "pedestrian-detection-adas-0002-fp16"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
@@ -785,6 +858,7 @@ topologies:
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "pedestrian-detection-adas-0002-int8"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.xml
@@ -794,6 +868,7 @@ topologies:
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-attributes-recognition-crossroad-0230"
     description: "Pedestrian attributes recognition based on a PVANet with hyperfeatures backbone + classification head"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
@@ -803,6 +878,7 @@ topologies:
     output: "Security/object_attributes/pedestrian/person-attributes-recognition-crossroad-0230/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-attributes-recognition-crossroad-0230-fp16"
     description: "Pedestrian attributes recognition based on a PVANet with hyperfeatures backbone + classification head"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
@@ -812,6 +888,7 @@ topologies:
     output: "Security/object_attributes/pedestrian/person-attributes-recognition-crossroad-0230/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-action-recognition-0005"
     description: "Action detection (SSD-based) model."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
@@ -821,6 +898,7 @@ topologies:
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-action-recognition-0005-fp16"
     description: "Action detection (SSD-based) model."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
@@ -830,6 +908,7 @@ topologies:
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-retail-0002"
     description: "Person detection (HyperNet+RFCN)."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
@@ -839,6 +918,7 @@ topologies:
     output: "Retail/object_detection/pedestrian/hypernet-rfcn/0026/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-retail-0002-fp16"
     description: "Person detection (HyperNet+RFCN+DetectionOutput)."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
@@ -848,6 +928,7 @@ topologies:
     output: "Retail/object_detection/pedestrian/hypernet-rfcn/0026/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-retail-0013"
     description: "Pedestrian detection (RMNet with lrelu + SSD)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
@@ -857,6 +938,7 @@ topologies:
     output: "Retail/object_detection/pedestrian/rmnet_ssd/0013/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-retail-0013-fp16"
     description: "Pedestrian detection (RMNet with lrelu + SSD)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
@@ -866,6 +948,7 @@ topologies:
     output: "Retail/object_detection/pedestrian/rmnet_ssd/0013/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-reidentification-retail-0031"
     description: "Single embedding-based person reidentification model (fastest person ReID model)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
@@ -875,6 +958,7 @@ topologies:
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0031/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-reidentification-retail-0031-fp16"
     description: "Single embedding-based person reidentification model (fastest person ReID model)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
@@ -884,6 +968,7 @@ topologies:
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0031/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-reidentification-retail-0076"
     description: "Single embedding-based person reidentification model (most accurate person ReID model)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP32/person-reidentification-retail-0076.xml
@@ -893,6 +978,7 @@ topologies:
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0076/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-reidentification-retail-0076-fp16"
     description: "Single embedding-based person reidentification model (most accurate person ReID model)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP16/person-reidentification-retail-0076.xml
@@ -902,6 +988,7 @@ topologies:
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0076/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-reidentification-retail-0079"
     description: "Single embedding-based person reidentification model (the model is trade-off between performance and accuracy)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP32/person-reidentification-retail-0079.xml
@@ -911,6 +998,7 @@ topologies:
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0079/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-reidentification-retail-0079-fp16"
     description: "Single embedding-based person reidentification model (the model is trade-off between performance and accuracy)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP16/person-reidentification-retail-0079.xml
@@ -920,6 +1008,7 @@ topologies:
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0079/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-vehicle-bike-detection-crossroad-0078"
     description: "Multiclass (person, vehicle, non-vehicle) detector based on SSD detection architecture, RMNet backbone and learnable image downscale block"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
@@ -929,6 +1018,7 @@ topologies:
     output: "Security/object_detection/crossroad/0078/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-vehicle-bike-detection-crossroad-0078-fp16"
     description: "Multiclass (person, vehicle, non-vehicle) detector based on SSD detection architecture, RMNet backbone and learnable image downscale block"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
@@ -938,6 +1028,7 @@ topologies:
     output: "Security/object_detection/crossroad/0078/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "road-segmentation-adas-0001"
     description: "Multiclass (BG, road, curbs, marks) segmentation based on ENET, using depthwise convolutions and without ELU operations and without concatenation"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
@@ -947,6 +1038,7 @@ topologies:
     output: "Transportation/segmentation/curbs/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "road-segmentation-adas-0001-fp16"
     description: "Multiclass (BG, road, curbs, marks) segmentation based on ENET, using depthwise convolutions and without ELU operations and without concatenation"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
@@ -956,6 +1048,7 @@ topologies:
     output: "Transportation/segmentation/curbs/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "road-segmentation-adas-0001-int8"
     description: "Multiclass (BG, road, curbs, marks) segmentation based on ENET, using depthwise convolutions and without ELU operations and without concatenation"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/INT8/road-segmentation-adas-0001.xml
@@ -965,6 +1058,7 @@ topologies:
     output: "Transportation/segmentation/curbs/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "semantic-segmentation-adas-0001"
     description: "Multiclass (road, sidewalk, building, wall, fence, pole, traffic light, traffic sign, vegetation, terrain, sky, person, rider, car, truck, bus, train, motorcycle, bicycle, ego-vehicle) segmentation based on ICNet"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
@@ -974,6 +1068,7 @@ topologies:
     output: "Transportation/segmentation/semantic_segmentation/icnet_icv/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "semantic-segmentation-adas-0001-fp16"
     description: "Multiclass (road, sidewalk, building, wall, fence, pole, traffic light, traffic sign, vegetation, terrain, sky, person, rider, car, truck, bus, train, motorcycle, bicycle, ego-vehicle) segmentation based on ICNet"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
@@ -983,6 +1078,7 @@ topologies:
     output: "Transportation/segmentation/semantic_segmentation/icnet_icv/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "single-image-super-resolution-1033"
     description: "Super resolution model based on SRResNet architecture (see https://arxiv.org/pdf/1609.04802.pdf)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
@@ -992,6 +1088,7 @@ topologies:
     output: "Security/super_resolution/srresnet/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "single-image-super-resolution-1033-fp16"
     description: "Super resolution model based on SRResNet architecture (see https://arxiv.org/pdf/1609.04802.pdf)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
@@ -1001,6 +1098,7 @@ topologies:
     output: "Security/super_resolution/srresnet/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "text-detection-0002"
     description: "Detects oriented text."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP32/text-detection-0002.xml
@@ -1010,6 +1108,7 @@ topologies:
     output: "Retail/object_detection/text/pixel_link_mobilenet_v2/0001/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "text-detection-0002-fp16"
     description: "Detects oriented text."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP16/text-detection-0002.xml
@@ -1019,6 +1118,7 @@ topologies:
     output: "Retail/object_detection/text/pixel_link_mobilenet_v2/0001/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-attributes-recognition-barrier-0039"
     description: "Vehicle attributes recognition with modified ResNet10 backbone"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
@@ -1028,6 +1128,7 @@ topologies:
     output: "Security/object_attributes/vehicle/resnet10_update_1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-attributes-recognition-barrier-0039-fp16"
     description: "Vehicle attributes recognition with modified ResNet10 backbone"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
@@ -1037,6 +1138,7 @@ topologies:
     output: "Security/object_attributes/vehicle/resnet10_update_1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-attributes-recognition-barrier-0039-int8"
     description: "Vehicle attributes recognition with modified ResNet10 backbone"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/INT8/vehicle-attributes-recognition-barrier-0039.xml
@@ -1046,6 +1148,7 @@ topologies:
     output: "Security/object_attributes/vehicle/resnet10_update_1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-detection-adas-0002"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
@@ -1055,6 +1158,7 @@ topologies:
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-detection-adas-0002-fp16"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
@@ -1064,6 +1168,7 @@ topologies:
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-detection-adas-0002-int8"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.xml
@@ -1073,6 +1178,7 @@ topologies:
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-license-plate-detection-barrier-0106"
     description: "Multiclass (vehicle, license plates) detector based on MobileNetV2+SSD"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
@@ -1082,6 +1188,7 @@ topologies:
     output: "Security/object_detection/barrier/0106/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-license-plate-detection-barrier-0106-fp16"
     description: "Multiclass (vehicle, license plates) detector based on MobileNetV2+SSD"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
@@ -1091,6 +1198,7 @@ topologies:
     output: "Security/object_detection/barrier/0106/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "face-detection-adas-binary-0001"
     description: "Face Detection (MobileNet with reduced channels and binary convolution + SSD with weights sharing)"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-binary-0001/INT1/face-detection-adas-binary-0001.xml
@@ -1100,6 +1208,7 @@ topologies:
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights_binary/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "single-image-super-resolution-1032"
     description: "Super resolution model"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
@@ -1109,6 +1218,7 @@ topologies:
     output: "Security/super_resolution/srresnet/dldt/1032/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "single-image-super-resolution-1032-fp16"
     description: "Super resolution model"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
@@ -1118,6 +1228,7 @@ topologies:
     output: "Security/super_resolution/srresnet/dldt/1032/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "action-recognition-0001-encoder"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Encoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
@@ -1127,6 +1238,7 @@ topologies:
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "action-recognition-0001-encoder-fp16"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Encoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
@@ -1136,6 +1248,7 @@ topologies:
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "instance-segmentation-security-0049"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNet50 backbone, FPN block and light segmentation head."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP32/instance-segmentation-security-0049.xml
@@ -1145,6 +1258,7 @@ topologies:
     output: "Security/instance_segmentation/common/0049/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "instance-segmentation-security-0049-fp16"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNet50 backbone, FPN block and light segmentation head."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP16/instance-segmentation-security-0049.xml
@@ -1154,6 +1268,7 @@ topologies:
     output: "Security/instance_segmentation/common/0049/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "vehicle-detection-adas-binary-0001"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head and binary layers."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.xml
@@ -1163,6 +1278,7 @@ topologies:
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd-binary/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "driver-action-recognition-adas-0002-decoder"
     description: "Video Transformer Network for driver action recognition. Decoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
@@ -1172,6 +1288,7 @@ topologies:
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "driver-action-recognition-adas-0002-decoder-fp16"
     description: "Video Transformer Network for driver action recognition. Decoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
@@ -1181,6 +1298,7 @@ topologies:
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "pedestrian-detection-adas-binary-0001"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number binary layers."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.xml
@@ -1190,6 +1308,7 @@ topologies:
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd-binary/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-action-recognition-teacher-0002"
     description: "Second generation of action detection (SSD-based) model to use in Smart Classroom for classification teacher's actions."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
@@ -1199,6 +1318,7 @@ topologies:
     output:  "Retail/action_detection/teacher/rmnet_ssd/0005_cut/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-action-recognition-teacher-0002-fp16"
     description: "Second generation of action detection (SSD-based) model to use in Smart Classroom for classification teacher's actions."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
@@ -1208,6 +1328,7 @@ topologies:
     output:  "Retail/action_detection/teacher/rmnet_ssd/0005_cut/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "instance-segmentation-security-0033"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNeXt152 backbone and FPN block."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP32/instance-segmentation-security-0033.xml
@@ -1217,6 +1338,7 @@ topologies:
     output: "Security/instance_segmentation/common/0033/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "instance-segmentation-security-0033-fp16"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNeXt152 backbone and FPN block."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP16/instance-segmentation-security-0033.xml
@@ -1226,6 +1348,7 @@ topologies:
     output: "Security/instance_segmentation/common/0033/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "action-recognition-0001-decoder"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Decoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
@@ -1235,6 +1358,7 @@ topologies:
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "action-recognition-0001-decoder-fp16"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Decoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
@@ -1244,6 +1368,7 @@ topologies:
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "text-recognition-0012"
     description: "Recognizes alphanumeric text. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP32/text-recognition-0012.xml
@@ -1253,6 +1378,7 @@ topologies:
     output: "Retail/text_recognition/bilstm_crnn_bilstm_decoder/0012/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "text-recognition-0012-fp16"
     description: "Recognizes alphanumeric text. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP16/text-recognition-0012.xml
@@ -1262,6 +1388,7 @@ topologies:
     output: "Retail/text_recognition/bilstm_crnn_bilstm_decoder/0012/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "driver-action-recognition-adas-0002-encoder"
     description: "Video Transformer Network for driver action recognition. Encoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
@@ -1271,6 +1398,7 @@ topologies:
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "driver-action-recognition-adas-0002-encoder-fp16"
     description: "Video Transformer Network for driver action recognition. Encoder part"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
@@ -1280,6 +1408,7 @@ topologies:
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "gaze-estimation-adas-0002"
     description: "Gaze estimation for ADAS"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
@@ -1289,6 +1418,7 @@ topologies:
     output: "Transportation/object_attributes/gaze/custom-architecture/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "gaze-estimation-adas-0002-fp16"
     description: "Gaze estimation for ADAS"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
@@ -1298,6 +1428,7 @@ topologies:
     output: "Transportation/object_attributes/gaze/custom-architecture/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "gaze-estimation-adas-0002-int8"
     description: "Gaze estimation for ADAS"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/INT8/gaze-estimation-adas-0002.xml
@@ -1307,6 +1438,7 @@ topologies:
     output: "Transportation/object_attributes/gaze/custom-architecture/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "resnet50-binary-0001"
     description: "ResNet-50 Binary"
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/resnet50-binary-0001/INT1/resnet50-binary-0001.xml
@@ -1316,6 +1448,7 @@ topologies:
     output: "PublicCompressed/classification/resnet50_binary/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-raisinghand-recognition-0001"
     description: "Raising-hand action detection (SSD-based) model to use in Smart Classroom environment."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
@@ -1325,6 +1458,7 @@ topologies:
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165_cut_2cl/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "person-detection-raisinghand-recognition-0001-fp16"
     description: "Raising-hand action detection (SSD-based) model to use in Smart Classroom environment."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
@@ -1334,6 +1468,7 @@ topologies:
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165_cut_2cl/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "handwritten-score-recognition-0001"
     description: "Recognizes school marks (e.g '4' or '3.5'). Alphabet is '0123456789._'. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP32/handwritten-score-recognition-0001.xml
@@ -1343,6 +1478,7 @@ topologies:
     output: "Retail/handwritten-score-recognition/0001/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
+
   - name: "handwritten-score-recognition-0001-fp16"
     description: "Recognizes school marks (e.g '4' or '3.5'). Alphabet is '0123456789._'. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
     model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP16/handwritten-score-recognition-0001.xml

--- a/model_downloader/list_topologies.yml
+++ b/model_downloader/list_topologies.yml
@@ -75,8 +75,11 @@ topologies:
     weights: https://github.com/DeepScale/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/squeezenet_v1.0.caffemodel
     weights_hash: 9ff8035aada1f9ffa880b35252680d971434b141ec9fbacbe88309f0f9a675ce
     output: "classification/squeezenet/1.0/caffe"
-    old_dims: [10,3,227,227]
-    new_dims: [1,3,227,227]
+    postprocessing:
+      - $type: regex_replace
+        file: squeezenet1.0.prototxt
+        pattern: 'dim: 10'
+        replacement: 'dim: 1'
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <squeezenet1.0.caffemodel> --input_proto <squeezenet1.0.prototxt>"
     framework: caffe
     license: https://github.com/DeepScale/SqueezeNet/blob/master/LICENSE
@@ -88,8 +91,11 @@ topologies:
     weights: https://github.com/DeepScale/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/squeezenet_v1.1.caffemodel
     weights_hash: 72b912ace512e8621f8ff168a7d72af55910d3c7c9445af8dfbff4c2ee960142
     output: "classification/squeezenet/1.1/caffe"
-    old_dims: [10,3,227,227]
-    new_dims: [1,3,227,227]
+    postprocessing:
+      - $type: regex_replace
+        file: squeezenet1.1.prototxt
+        pattern: 'dim: 10'
+        replacement: 'dim: 1'
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <squeezenet1.1.caffemodel> --input_proto <squeezenet1.1.prototxt>"
     framework: caffe
     license: https://github.com/DeepScale/SqueezeNet/blob/master/LICENSE
@@ -101,8 +107,17 @@ topologies:
     weights: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.caffemodel
     weights_hash: d6085e7f48ba7e6b6f1b58964595f6bce5b97bcc4866751f7b4bdc98f920c096
     output: "object_detection/common/mtcnn/p/caffe"
-    old_dims: [1,3,12,12]
-    new_dims: [1,3,720,1280]
+    postprocessing:
+      - $type: regex_replace
+        file: mtcnn-p.prototxt
+        pattern: 'dim: 12'
+        replacement: 'dim: 720'
+        count: 1
+      - $type: regex_replace
+        file: mtcnn-p.prototxt
+        pattern: 'dim: 12'
+        replacement: 'dim: 1280'
+        count: 1
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,720,1280] --input data --output prob1 --input_model <mtcnn-p.caffemodel> --input_proto <mtcnn-p.prototxt>"
     framework: caffe
     license: https://github.com/DuinoDu/mtcnn/blob/master/LICENSE
@@ -149,8 +164,11 @@ topologies:
     weights: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel
     weights_hash: 31b4c627c40c6ee151325f079b7ac557fddbd1f79af932888796127a4f4f6954
     output: "classification/vgg/19/caffe"
-    old_dims: [10,3,224,224]
-    new_dims: [1,3,224,224]
+    postprocessing:
+      - $type: regex_replace
+        file: vgg19.prototxt
+        pattern: 'dim: 10'
+        replacement: 'dim: 1'
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.939,116.779,123.68] --output prob --input_model <vgg19.caffemodel> --input_proto <vgg19.prototxt>"
     framework: caffe
     license: https://github.com/keras-team/keras/blob/master/LICENSE
@@ -162,8 +180,11 @@ topologies:
     weights: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_16_layers.caffemodel
     weights_hash: a6196bc498e45ea4cb2637114ae8db9410cf1556fd60a55ae93272371beba197
     output: "classification/vgg/16/caffe"
-    old_dims: [10,3,224,224]
-    new_dims: [1,3,224,224]
+    postprocessing:
+      - $type: regex_replace
+        file: vgg16.prototxt
+        pattern: 'dim: 10'
+        replacement: 'dim: 1'
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.939,116.779,123.68] --output prob --input_model <vgg16.caffemodel> --input_proto <vgg16.prototxt>"
     framework: caffe
     license: https://github.com/keras-team/keras/blob/master/LICENSE
@@ -177,7 +198,11 @@ topologies:
     tar_google_drive_id: 0BzKzrI_SkD1_MjFjNTlnempHNWs
     model_path_prefix: "models/VGGNet/VOC0712Plus/SSD_512x512/deploy.prototxt"
     weights_path_prefix: "models/VGGNet/VOC0712Plus/SSD_512x512/VGG_VOC0712Plus_SSD_512x512_iter_240000.caffemodel"
-    delete_output_param: True
+    postprocessing:
+      - $type: regex_replace
+        file: ssd512.prototxt
+        pattern: ' +save_output_param \{.*\n.*\n +\}\n'
+        replacement: ''
     tar_size: 100991061
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,512,512] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <ssd512.caffemodel> --input_proto <ssd512.prototxt>"
     framework: caffe
@@ -192,7 +217,11 @@ topologies:
     tar_google_drive_id: 0BzKzrI_SkD1_TkFPTEQ1Z091SUE
     model_path_prefix: "models/VGGNet/VOC0712Plus/SSD_300x300_ft/deploy.prototxt"
     weights_path_prefix: "models/VGGNet/VOC0712Plus/SSD_300x300_ft/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.caffemodel"
-    delete_output_param: True
+    postprocessing:
+      - $type: regex_replace
+        file: ssd300.prototxt
+        pattern: ' +save_output_param \{.*\n.*\n +\}\n'
+        replacement: ''
     tar_size: 97789219
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <ssd300.caffemodel> --input_proto <ssd300.prototxt>"
     framework: caffe
@@ -231,8 +260,11 @@ topologies:
     weights: http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel
     weights_hash: 6f7101e3a2183738a7125a0c5021ba82a1feb4228c5ca0924d991b6daf6f6fad
     output: "classification/googlenet/v1/caffe"
-    old_dims: [10,3,224,224]
-    new_dims: [1,3,224,224]
+    postprocessing:
+      - $type: regex_replace
+        file: googlenet-v1.prototxt
+        pattern: 'dim: 10'
+        replacement: 'dim: 1'
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <googlenet-v1.caffemodel> --input_proto <googlenet-v1.prototxt>"
     framework: caffe
     license: https://github.com/BVLC/caffe/blob/master/LICENSE
@@ -244,9 +276,15 @@ topologies:
     weights: https://github.com/lim0606/caffe-googlenet-bn/raw/d19caf526b7d8cad873ff91ba4cea602eadd58b3/snapshots/googlenet_bn_stepsize_6400_iter_1200000.caffemodel
     weights_hash: c6581a8e60e5ae8962183ff019986fc9dfacc5e5bd5247d76a0ff7fae8e0409a
     output: "classification/googlenet/v2/caffe"
-    old_dims: [10,3,224,224]
-    new_dims: [1,3,224,224]
-    layers_to_layer: True
+    postprocessing:
+      - $type: regex_replace
+        file: googlenet-v2.prototxt
+        pattern: 'dim: 10'
+        replacement: 'dim: 1'
+      - $type: regex_replace
+        file: googlenet-v2.prototxt
+        pattern: 'layers \{'
+        replacement: 'layer {'
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <googlenet-v2.caffemodel> --input_proto <googlenet-v2.prototxt>"
     framework: caffe
     license: https://github.com/lim0606/caffe-googlenet-bn/blob/master/README.md
@@ -273,8 +311,11 @@ topologies:
     weights: http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel
     weights_hash: 4bff209a9837298157915ef50a4831a59636a6ca1a6b8ebacd990c3a5f3053e0
     output: "classification/alexnet/caffe"
-    old_dims: [10,3,227,227]
-    new_dims: [1,3,227,227]
+    postprocessing:
+      - $type: regex_replace
+        file: alexnet.prototxt
+        pattern: 'dim: 10'
+        replacement: 'dim: 1'
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <alexnet.caffemodel> --input_proto <alexnet.prototxt>"
     framework: caffe
     license: https://github.com/BVLC/caffe/blob/master/models/bvlc_alexnet/readme.md


### PR DESCRIPTION
Instead of hard-coding specific types of patches, allow defining per-file
regex replacements. This decouples the downloader from specifics of data
formats, making it more flexible.

Also, add some improvements to the postprocessing process:

* check that the file we're supposed to post-process exists and is located
  inside the output directory;

* check that at least one replacement actually took place (because if not,
  that indicates an error in the config);

* back up the original file, so that the user can examine the difference.

----

This is the first half of a series of changes that decouple the downloader from framework specifics. The second half will make downloading more generic, as well.