### PR TITLE
model_downloader: make the specification of files to download more generic

### DIFF
--- a/model_downloader/list_topologies.yml
+++ b/model_downloader/list_topologies.yml
@@ -18,62 +18,81 @@ topologies:
 #
   - name: "densenet-121"
     description: "DenseNet-121 (https://github.com/shicai/DenseNet-Caffe). The following Caffe patch must be used to be able to convert this model: https://github.com/BVLC/caffe/pull/3057/files"
-    model: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_121.prototxt
-    model_hash: baeed2a423794c2c8dc1a80ad96e961112224fa1d319d535735ba93a2b535170
-    weights: https://drive.google.com/uc?id=0B7ubpZO7HnlCcHlfNmJkU2VPelE&export=download
-    weights_hash: c6a6ec988d76c468c3f67501a23a39ec7bf6ebe6729fd99496a15d0e845478b2
+    files:
+      - name: densenet-121.prototxt
+        sha256: baeed2a423794c2c8dc1a80ad96e961112224fa1d319d535735ba93a2b535170
+        source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_121.prototxt
+      - name: densenet-121.caffemodel
+        size: 32303870
+        sha256: c6a6ec988d76c468c3f67501a23a39ec7bf6ebe6729fd99496a15d0e845478b2
+        source:
+          $type: google_drive
+          id: 0B7ubpZO7HnlCcHlfNmJkU2VPelE
     output: "classification/densenet/121/caffe/"
-    weights_google_drive_id: 0B7ubpZO7HnlCcHlfNmJkU2VPelE
-    weights_size: 32303870
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-121.caffemodel> --input_proto <densenet-121.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
   - name: "densenet-161"
     description: "DenseNet-161 (https://github.com/shicai/DenseNet-Caffe). The following Caffe patch must be used to be able to convert this model: https://github.com/BVLC/caffe/pull/3057/files"
-    model: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_161.prototxt
-    model_hash: a193e029d66112b077ed29e8b8d36d0bae0593a7f3c64125a433937b5f035b69
-    weights: https://drive.google.com/uc?export=download&confirm=qlti&id=0B7ubpZO7HnlCa0phRGJIRERoTXM
-    weights_hash: e124d9a8f2284f4ab160569139217f709f21be6fc132c865b6a55cb8cae7d6b5
+    files:
+      - name: densenet-161.prototxt
+        sha256: a193e029d66112b077ed29e8b8d36d0bae0593a7f3c64125a433937b5f035b69
+        source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_161.prototxt
+      - name: densenet-161.caffemodel
+        size: 115676075
+        sha256: e124d9a8f2284f4ab160569139217f709f21be6fc132c865b6a55cb8cae7d6b5
+        source:
+          $type: google_drive
+          id: 0B7ubpZO7HnlCa0phRGJIRERoTXM
     output: "classification/densenet/161/caffe"
-    weights_google_drive_id: 0B7ubpZO7HnlCa0phRGJIRERoTXM
-    weights_size: 115676075
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-161.caffemodel> --input_proto <densenet-161.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
   - name: "densenet-169"
     description: "DenseNet-169 (https://github.com/shicai/DenseNet-Caffe). The following Caffe patch must be used to be able to convert this model: https://github.com/BVLC/caffe/pull/3057/files"
-    model: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_169.prototxt
-    model_hash: dfb577c17d67327be70dba8f2810dbeec4f7edb836779c8055ec8f408b0a2cbc
-    weights: https://drive.google.com/uc?id=0B7ubpZO7HnlCRWVVdUJjVVAyQXc&export=download
-    weights_hash: 8d45f2ab15f6329e2f80004692c58129cc4875ffe43ddf59433ebc2216189f15
+    files:
+      - name: densenet-169.prototxt
+        sha256: dfb577c17d67327be70dba8f2810dbeec4f7edb836779c8055ec8f408b0a2cbc
+        source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_169.prototxt
+      - name: densenet-169.caffemodel
+        size: 57307526
+        sha256: 8d45f2ab15f6329e2f80004692c58129cc4875ffe43ddf59433ebc2216189f15
+        source:
+          $type: google_drive
+          id: 0B7ubpZO7HnlCRWVVdUJjVVAyQXc
     output: "classification/densenet/169/caffe"
-    weights_google_drive_id: 0B7ubpZO7HnlCRWVVdUJjVVAyQXc
-    weights_size: 57307526
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-169.caffemodel> --input_proto <densenet-169.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
   - name: "densenet-201"
     description: "DenseNet-201 (https://github.com/shicai/DenseNet-Caffe). The following Caffe patch must be used to be able to convert this model: https://github.com/BVLC/caffe/pull/3057/files"
-    model: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_201.prototxt
-    model_hash: 8edf61f867491315bc3780a41f74392c2a31042d20932eb145424a2dc8c6f8f7
-    weights: https://drive.google.com/uc?export=download&confirm=JWFY&id=0B7ubpZO7HnlCV3pud2oyR3lNMWs
-    weights_hash: ba464965293d4dd5557085d57ec810bf353de362dd90e1b8293e6f0707978e4a
+    files:
+      - name: densenet-201.prototxt
+        sha256: 8edf61f867491315bc3780a41f74392c2a31042d20932eb145424a2dc8c6f8f7
+        source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_201.prototxt
+      - name: densenet-201.caffemodel
+        size: 81062969
+        sha256: ba464965293d4dd5557085d57ec810bf353de362dd90e1b8293e6f0707978e4a
+        source:
+          $type: google_drive
+          id: 0B7ubpZO7HnlCV3pud2oyR3lNMWs
     output: "classification/densenet/201/caffe"
-    weights_google_drive_id: 0B7ubpZO7HnlCV3pud2oyR3lNMWs
-    weights_size: 81062969
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-201.caffemodel> --input_proto <densenet-201.prototxt>"
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
   - name: "squeezenet1.0"
     description: "SqueezeNet v1.0 (https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.0)"
-    model: https://raw.githubusercontent.com/DeepScale/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/deploy.prototxt
-    model_hash: 6e4ecef2a27347e226a5ef8be31d6d1b9d19f5a40afa1986ec259fd5fa3bd91c
-    weights: https://github.com/DeepScale/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/squeezenet_v1.0.caffemodel
-    weights_hash: 9ff8035aada1f9ffa880b35252680d971434b141ec9fbacbe88309f0f9a675ce
+    files:
+      - name: squeezenet1.0.prototxt
+        sha256: 6e4ecef2a27347e226a5ef8be31d6d1b9d19f5a40afa1986ec259fd5fa3bd91c
+        source: https://raw.githubusercontent.com/DeepScale/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/deploy.prototxt
+      - name: squeezenet1.0.caffemodel
+        sha256: 9ff8035aada1f9ffa880b35252680d971434b141ec9fbacbe88309f0f9a675ce
+        source: https://github.com/DeepScale/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/squeezenet_v1.0.caffemodel
     output: "classification/squeezenet/1.0/caffe"
     postprocessing:
       - $type: regex_replace
@@ -86,10 +105,13 @@ topologies:
 
   - name: "squeezenet1.1"
     description: "SqueezeNet v1.1 (https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.1)"
-    model: https://raw.githubusercontent.com/DeepScale/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/deploy.prototxt
-    model_hash: d041bfb2ab4b32fda4ff6c6966684132f2924e329916aa5bfe9285c6b23e3d1c
-    weights: https://github.com/DeepScale/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/squeezenet_v1.1.caffemodel
-    weights_hash: 72b912ace512e8621f8ff168a7d72af55910d3c7c9445af8dfbff4c2ee960142
+    files:
+      - name: squeezenet1.1.prototxt
+        sha256: d041bfb2ab4b32fda4ff6c6966684132f2924e329916aa5bfe9285c6b23e3d1c
+        source: https://raw.githubusercontent.com/DeepScale/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/deploy.prototxt
+      - name: squeezenet1.1.caffemodel
+        sha256: 72b912ace512e8621f8ff168a7d72af55910d3c7c9445af8dfbff4c2ee960142
+        source: https://github.com/DeepScale/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/squeezenet_v1.1.caffemodel
     output: "classification/squeezenet/1.1/caffe"
     postprocessing:
       - $type: regex_replace
@@ -102,10 +124,13 @@ topologies:
 
   - name: "mtcnn-p"
     description: "MTCNN-Proposal Network (https://github.com/DuinoDu/mtcnn/tree/master/model https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf)"
-    model: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.prototxt
-    model_hash: adc1756d8515d3ca3a6a186c0fadab66fcae04bd8d3c6388e2fe8797a626dde4
-    weights: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.caffemodel
-    weights_hash: d6085e7f48ba7e6b6f1b58964595f6bce5b97bcc4866751f7b4bdc98f920c096
+    files:
+      - name: mtcnn-p.prototxt
+        sha256: adc1756d8515d3ca3a6a186c0fadab66fcae04bd8d3c6388e2fe8797a626dde4
+        source: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.prototxt
+      - name: mtcnn-p.caffemodel
+        sha256: d6085e7f48ba7e6b6f1b58964595f6bce5b97bcc4866751f7b4bdc98f920c096
+        source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.caffemodel
     output: "object_detection/common/mtcnn/p/caffe"
     postprocessing:
       - $type: regex_replace
@@ -124,10 +149,13 @@ topologies:
 
   - name: "mtcnn-r"
     description: "MTCNN-Refine Network (https://github.com/DuinoDu/mtcnn/tree/master/model https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf)"
-    model: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.prototxt
-    model_hash: 077686e89e606354f425366afdb2018777d93c6450b50e2c12301f8a97f6bb47
-    weights: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.caffemodel
-    weights_hash: 39b20f7a57bb8176cc9466cea4dfd52da6a6f876de60c7ab222a309f2d0ca08c
+    files:
+      - name: mtcnn-r.prototxt
+        sha256: 077686e89e606354f425366afdb2018777d93c6450b50e2c12301f8a97f6bb47
+        source: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.prototxt
+      - name: mtcnn-r.caffemodel
+        sha256: 39b20f7a57bb8176cc9466cea4dfd52da6a6f876de60c7ab222a309f2d0ca08c
+        source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.caffemodel
     output: "object_detection/common/mtcnn/r/caffe"
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,24,24] --input data --output prob1 --input_model <mtcnn-r.caffemodel> --input_proto <mtcnn-r.prototxt>"
     framework: caffe
@@ -135,10 +163,13 @@ topologies:
 
   - name: "mtcnn-o"
     description: "MTCNN-Output Network (https://github.com/DuinoDu/mtcnn/tree/master/model https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf)"
-    model: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.prototxt
-    model_hash: a8385a3aad241acf5902b79466f9a359ea9f03a3b6dcbe1e1efa050908cf7d04
-    weights: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.caffemodel
-    weights_hash: 9d6098829a4d6d318f37cec42142465637fafe4c673f2e93b69495bf7ca23d2d
+    files:
+      - name: mtcnn-o.prototxt
+        sha256: a8385a3aad241acf5902b79466f9a359ea9f03a3b6dcbe1e1efa050908cf7d04
+        source: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.prototxt
+      - name: mtcnn-o.caffemodel
+        sha256: 9d6098829a4d6d318f37cec42142465637fafe4c673f2e93b69495bf7ca23d2d
+        source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.caffemodel
     output: "object_detection/common/mtcnn/o/caffe"
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,48,48] --input data --output prob1 --input_model <mtcnn-o.caffemodel> --input_proto <mtcnn-o.prototxt>"
     framework: caffe
@@ -146,23 +177,30 @@ topologies:
 
   - name: "mobilenet-ssd"
     description: "Common object detection architecture (https://github.com/chuanqi305/MobileNet-SSD)"
-    model: https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/ba00fc987b3eb0ba87bb99e89bf0298a2fd10765/MobileNetSSD_deploy.prototxt
-    model_hash: e781559c4f5beaec2a486ccd952af5b6fa408e9498761bf5f4fb80b4e9f0d25e
-    weights: https://drive.google.com/uc?id=0B3gersZ2cHIxRm5PMWRoTkdHdHc&export=download
-    weights_hash: 761c86fbae3d8361dd454f7c740a964f62975ed32f4324b8b85994edec30f6af
+    files:
+      - name: mobilenet-ssd.prototxt
+        sha256: e781559c4f5beaec2a486ccd952af5b6fa408e9498761bf5f4fb80b4e9f0d25e
+        source: https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/ba00fc987b3eb0ba87bb99e89bf0298a2fd10765/MobileNetSSD_deploy.prototxt
+      - name: mobilenet-ssd.caffemodel
+        size: 23147564
+        sha256: 761c86fbae3d8361dd454f7c740a964f62975ed32f4324b8b85994edec30f6af
+        source:
+          $type: google_drive
+          id: 0B3gersZ2cHIxRm5PMWRoTkdHdHc
     output: "object_detection/common/mobilenet-ssd/caffe"
-    weights_google_drive_id: 0B3gersZ2cHIxRm5PMWRoTkdHdHc
-    weights_size: 23147564
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[127.5,127.5,127.5] --scale_values data[127.50223128904757] --output detection_out --input_model <mobilenet-ssd.caffemodel> --input_proto <mobilenet-ssd.prototxt>"
     framework: caffe
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "vgg19"
     description: "VGG Net-E (https://arxiv.org/pdf/1409.1556.pdf)"
-    model: https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/f02f8769e64494bcd3d7e97d5d747ac275825721/VGG_ILSVRC_19_layers_deploy.prototxt
-    model_hash: e7c9da46d837dd91049ddab46a57933a488e3d8a42162cdef51ab1edeff99725
-    weights: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel
-    weights_hash: 31b4c627c40c6ee151325f079b7ac557fddbd1f79af932888796127a4f4f6954
+    files:
+      - name: vgg19.prototxt
+        sha256: e7c9da46d837dd91049ddab46a57933a488e3d8a42162cdef51ab1edeff99725
+        source: https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/f02f8769e64494bcd3d7e97d5d747ac275825721/VGG_ILSVRC_19_layers_deploy.prototxt
+      - name: vgg19.caffemodel
+        sha256: 31b4c627c40c6ee151325f079b7ac557fddbd1f79af932888796127a4f4f6954
+        source: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel
     output: "classification/vgg/19/caffe"
     postprocessing:
       - $type: regex_replace
@@ -175,10 +213,13 @@ topologies:
 
   - name: "vgg16"
     description: "VGG Net-D (https://arxiv.org/pdf/1409.1556.pdf)"
-    model: https://gist.githubusercontent.com/ksimonyan/211839e770f7b538e2d8/raw/0067c9b32f60362c74f4c445a080beed06b07eb3/VGG_ILSVRC_16_layers_deploy.prototxt
-    model_hash: 9fdb04e3f5b9224af473e82441b05b76368dfa6dc841e80655303823e9770962
-    weights: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_16_layers.caffemodel
-    weights_hash: a6196bc498e45ea4cb2637114ae8db9410cf1556fd60a55ae93272371beba197
+    files:
+      - name: vgg16.prototxt
+        sha256: 9fdb04e3f5b9224af473e82441b05b76368dfa6dc841e80655303823e9770962
+        source: https://gist.githubusercontent.com/ksimonyan/211839e770f7b538e2d8/raw/0067c9b32f60362c74f4c445a080beed06b07eb3/VGG_ILSVRC_16_layers_deploy.prototxt
+      - name: vgg16.caffemodel
+        sha256: a6196bc498e45ea4cb2637114ae8db9410cf1556fd60a55ae93272371beba197
+        source: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_16_layers.caffemodel
     output: "classification/vgg/16/caffe"
     postprocessing:
       - $type: regex_replace
@@ -191,63 +232,77 @@ topologies:
 
   - name: "ssd512"
     description: "SSD-512 (https://arxiv.org/pdf/1512.02325.pdf)"
-    model_hash: e8a18363aeb8a74a90fda6d6c8596994aca018061765b2aa38f8e0a580ca4c70
-    weights_hash: 60670be0b28cbde887c99d01c8aa5b10c9e1b7ae6e572da0901aa632da678b3b
+    files:
+      - name: ssd512.tar.gz
+        size: 100991061
+        sha256: 2d98a6ddd5b4cb0ba59a37fe5d50020457cfe104d45873c3ea43d1e6dcddd12d
+        source:
+          $type: google_drive
+          id: 0BzKzrI_SkD1_MjFjNTlnempHNWs
     output: "object_detection/common/ssd/512/caffe"
-    tar: https://drive.google.com/uc?export=download&confirm=MPr8&id=0BzKzrI_SkD1_MjFjNTlnempHNWs
-    tar_google_drive_id: 0BzKzrI_SkD1_MjFjNTlnempHNWs
-    model_path_prefix: "models/VGGNet/VOC0712Plus/SSD_512x512/deploy.prototxt"
-    weights_path_prefix: "models/VGGNet/VOC0712Plus/SSD_512x512/VGG_VOC0712Plus_SSD_512x512_iter_240000.caffemodel"
     postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: ssd512.tar.gz
       - $type: regex_replace
-        file: ssd512.prototxt
+        file: models/VGGNet/VOC0712Plus/SSD_512x512/deploy.prototxt
         pattern: ' +save_output_param \{.*\n.*\n +\}\n'
         replacement: ''
-    tar_size: 100991061
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,512,512] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <ssd512.caffemodel> --input_proto <ssd512.prototxt>"
+    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,512,512] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <VGG_VOC0712Plus_SSD_512x512_iter_240000.caffemodel> --input_proto <deploy.prototxt>"
     framework: caffe
     license: https://github.com/weiliu89/caffe/blob/ssd/LICENSE
 
   - name: "ssd300"
     description: "SSD-300 (https://arxiv.org/pdf/1512.02325.pdf)"
-    model_hash: 0366cd7cb909aebe499bc23d34e1aaf5c81ff2e32c438ba87db2845c4edf1309
-    weights_hash: 08cab67129496a99c3ef6ca9ae52a955e8ec770075a9d7e15ac8bf0b14c02ef1
+    files:
+      - name: ssd300.tar.gz
+        size: 97789219
+        sha256: e3eb9794a33eb77e6798f396df453123c249a1df554e42a3302eb4aa20a8f2ee
+        source:
+          $type: google_drive
+          id: 0BzKzrI_SkD1_TkFPTEQ1Z091SUE
     output: "object_detection/common/ssd/300/caffe"
-    tar: https://drive.google.com/uc?export=download&confirm=YQb1&id=0BzKzrI_SkD1_TkFPTEQ1Z091SUE
-    tar_google_drive_id: 0BzKzrI_SkD1_TkFPTEQ1Z091SUE
-    model_path_prefix: "models/VGGNet/VOC0712Plus/SSD_300x300_ft/deploy.prototxt"
-    weights_path_prefix: "models/VGGNet/VOC0712Plus/SSD_300x300_ft/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.caffemodel"
     postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: ssd300.tar.gz
       - $type: regex_replace
-        file: ssd300.prototxt
+        file: models/VGGNet/VOC0712Plus/SSD_300x300_ft/deploy.prototxt
         pattern: ' +save_output_param \{.*\n.*\n +\}\n'
         replacement: ''
-    tar_size: 97789219
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <ssd300.caffemodel> --input_proto <ssd300.prototxt>"
+    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.caffemodel> --input_proto <deploy.prototxt>"
     framework: caffe
     license: https://github.com/weiliu89/caffe/blob/ssd/LICENSE
 
   - name: "inception-resnet-v2"
     description: "Inception-ResNet V2 architecture (https://arxiv.org/pdf/1602.07261.pdf)"
-    model: https://drive.google.com/drive/folders/0B9mkjlmP0d7zc3A4NWlQQzdoM28
-    model_hash: 8d53ee1f4112716e3e53d65ddc1936eeb6ca8f26d49cdb1129aba3bb78bdc209
-    weights: https://drive.google.com/drive/folders/0B9mkjlmP0d7zc3A4NWlQQzdoM28
-    weights_hash: 1027d403ba8bf6211ca0d25f4b9ec6d4357d1407a812835b741004d5ad308b92
+    files:
+      - name: inception-resnet-v2.prototxt
+        size: 192362
+        sha256: 8d53ee1f4112716e3e53d65ddc1936eeb6ca8f26d49cdb1129aba3bb78bdc209
+        source:
+          $type: google_drive
+          id: 0B9mkjlmP0d7zUXhsMmI4cWR6MmM
+      - name: inception-resnet-v2.caffemodel
+        size: 223511172
+        sha256: 1027d403ba8bf6211ca0d25f4b9ec6d4357d1407a812835b741004d5ad308b92
+        source:
+          $type: google_drive
+          id: 0B9mkjlmP0d7zNmY5eXZhLUhzQVE
     output: "classification/inception-resnet/v2/caffe"
-    weights_google_drive_id: 0B9mkjlmP0d7zNmY5eXZhLUhzQVE
-    model_google_drive_id: 0B9mkjlmP0d7zUXhsMmI4cWR6MmM
-    weights_size: 223511172
-    model_size: 192362
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,299,299] --input data --mean_values data[128.0,128.0,128.0] --scale_values data[128.0] --output prob --input_model <inception-resnet-v2.prototxt>"
     framework: caffe
     license: https://github.com/soeaver/caffe-model/blob/master/LICENSE
 
   - name: "dilation"
     description: "Multi-Scale Context Aggregation by Dilated Convolutions (https://arxiv.org/pdf/1511.07122.pdf)"
-    model: https://raw.githubusercontent.com/fyu/dilation/0f105742e8c2202af12feb54374781ba55c3e112/models/dilation10_cityscapes_deploy.prototxt
-    weights: http://dl.yf.io/dilation/models/dilation10_cityscapes.caffemodel
-    model_hash: 7b1adfc35901b5626504b44fbf3567bcf81926b9482b031925012e8fbef8f219
-    weights_hash: ec6cec2bfa0f1b199f11e73f0e030ae29326bc5648f3ddf9127feb3367b68b92
+    files:
+      - name: dilation.prototxt
+        sha256: 7b1adfc35901b5626504b44fbf3567bcf81926b9482b031925012e8fbef8f219
+        source: https://raw.githubusercontent.com/fyu/dilation/0f105742e8c2202af12feb54374781ba55c3e112/models/dilation10_cityscapes_deploy.prototxt
+      - name: dilation.caffemodel
+        sha256: ec6cec2bfa0f1b199f11e73f0e030ae29326bc5648f3ddf9127feb3367b68b92
+        source: http://dl.yf.io/dilation/models/dilation10_cityscapes.caffemodel
     output: "semantic_segmentation/dilation/cityscapes/caffe"
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,1396,1396] --input data --mean_values data[72.39,82.91,73.16] --output prob --input_model <dilation.caffemodel> --input_proto <dilation.prototxt>"
     framework: caffe
@@ -255,10 +310,13 @@ topologies:
 
   - name: "googlenet-v1"
     description: "GoogleNet v1 (Inception v1) (https://arxiv.org/pdf/1409.4842.pdf)"
-    model: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_googlenet/deploy.prototxt
-    model_hash: fa36cd4112a3240a29600a5aa35333f31bec33daa1a6085b0af308a9f50f0c50
-    weights: http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel
-    weights_hash: 6f7101e3a2183738a7125a0c5021ba82a1feb4228c5ca0924d991b6daf6f6fad
+    files:
+      - name: googlenet-v1.prototxt
+        sha256: fa36cd4112a3240a29600a5aa35333f31bec33daa1a6085b0af308a9f50f0c50
+        source: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_googlenet/deploy.prototxt
+      - name: googlenet-v1.caffemodel
+        sha256: 6f7101e3a2183738a7125a0c5021ba82a1feb4228c5ca0924d991b6daf6f6fad
+        source: http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel
     output: "classification/googlenet/v1/caffe"
     postprocessing:
       - $type: regex_replace
@@ -271,10 +329,13 @@ topologies:
 
   - name: "googlenet-v2"
     description: "GoogleNet v2 (Inception v2) (https://arxiv.org/pdf/1502.03167.pdf)"
-    model: https://raw.githubusercontent.com/lim0606/caffe-googlenet-bn/d19caf526b7d8cad873ff91ba4cea602eadd58b3/deploy.prototxt
-    model_hash: 18c77f01cca83c4cee973bfd8739968210dd6a1e5af1b857faaec230c5aa7d5a
-    weights: https://github.com/lim0606/caffe-googlenet-bn/raw/d19caf526b7d8cad873ff91ba4cea602eadd58b3/snapshots/googlenet_bn_stepsize_6400_iter_1200000.caffemodel
-    weights_hash: c6581a8e60e5ae8962183ff019986fc9dfacc5e5bd5247d76a0ff7fae8e0409a
+    files:
+      - name: googlenet-v2.prototxt
+        sha256: 18c77f01cca83c4cee973bfd8739968210dd6a1e5af1b857faaec230c5aa7d5a
+        source: https://raw.githubusercontent.com/lim0606/caffe-googlenet-bn/d19caf526b7d8cad873ff91ba4cea602eadd58b3/deploy.prototxt
+      - name: googlenet-v2.caffemodel
+        sha256: c6581a8e60e5ae8962183ff019986fc9dfacc5e5bd5247d76a0ff7fae8e0409a
+        source: https://github.com/lim0606/caffe-googlenet-bn/raw/d19caf526b7d8cad873ff91ba4cea602eadd58b3/snapshots/googlenet_bn_stepsize_6400_iter_1200000.caffemodel
     output: "classification/googlenet/v2/caffe"
     postprocessing:
       - $type: regex_replace
@@ -291,25 +352,33 @@ topologies:
 
   - name: "googlenet-v4"
     description: "GoogleNet v4 (Inception v4)"
-    model: https://drive.google.com/drive/folders/0B9mkjlmP0d7zUEJ3aEJ2b3J0RFU
-    model_hash: 2213d8729839cd015c4b0335d91da1cf4a034627fadedcdb5bf8ac347c4896d9
-    weights: https://drive.google.com/drive/folders/0B9mkjlmP0d7zUEJ3aEJ2b3J0RFU
-    weights_hash: 6ff248c1215a9fc14ac7ccd44b03da35e41e50bde054ba201bd9c737522996c3
+    files:
+      - name: googlenet-v4.prototxt
+        size: 86534
+        sha256: 2213d8729839cd015c4b0335d91da1cf4a034627fadedcdb5bf8ac347c4896d9
+        source:
+          $type: google_drive
+          id: 0B9mkjlmP0d7zWEJsRl9zeTQ1NzA
+      - name: googlenet-v4.caffemodel
+        size: 170777072
+        sha256: 6ff248c1215a9fc14ac7ccd44b03da35e41e50bde054ba201bd9c737522996c3
+        source:
+          $type: google_drive
+          id: 0B9mkjlmP0d7zeG1HREVMR2F3WmM
     output: "classification/googlenet/v4/caffe"
-    weights_google_drive_id: 0B9mkjlmP0d7zeG1HREVMR2F3WmM
-    model_google_drive_id: 0B9mkjlmP0d7zWEJsRl9zeTQ1NzA
-    weights_size: 170777072
-    model_size: 86534
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,299,299] --input data --mean_values data[128.0,128.0,128.0] --scale_values data[128.0] --output prob --input_model <googlenet-v4.caffemodel> --input_proto <googlenet-v4.prototxt>"
     framework: caffe
     license: https://github.com/soeaver/caffe-model/blob/master/LICENSE
 
   - name: "alexnet"
     description: "AlexNet (http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf)"
-    model: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_alexnet/deploy.prototxt
-    model_hash: b564ba76416b4ac1e062c6621cbd80d9c19304ba152d9d791c75870f3182c4fa
-    weights: http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel
-    weights_hash: 4bff209a9837298157915ef50a4831a59636a6ca1a6b8ebacd990c3a5f3053e0
+    files:
+      - name: alexnet.prototxt
+        sha256: b564ba76416b4ac1e062c6621cbd80d9c19304ba152d9d791c75870f3182c4fa
+        source: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_alexnet/deploy.prototxt
+      - name: alexnet.caffemodel
+        sha256: 4bff209a9837298157915ef50a4831a59636a6ca1a6b8ebacd990c3a5f3053e0
+        source: http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel
     output: "classification/alexnet/caffe"
     postprocessing:
       - $type: regex_replace
@@ -322,172 +391,225 @@ topologies:
 
   - name: "ssd_mobilenet_v2_coco"
     description: "MobileNetV2 object detection architecture (https://arxiv.org/pdf/1801.04381.pdf) pre-trained on the COCO dataset"
-    model_hash: 10dd7ebd618a5dd0d7a95081320e64b86358b09a906faafc13a0de793998dbfc
-    weights_hash: 2a8d8a89d695842e60d8c6d144181100555563e21acf2fa1e8f561fec5c3c6ad
-    tar: http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v2_coco_2018_03_29.tar.gz
+    files:
+      - name: ssd_mobilenet_v2_coco.tar.gz
+        sha256: b9380178b2e35333f1a735e39745928488bdabeb9ed20bc6fa07af8172cb5adc
+        source: http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v2_coco_2018_03_29.tar.gz
     output: "object_detection/common/ssd_mobilenet_v2_coco/tf"
-    model_path_prefix: "ssd_mobilenet_v2_coco_2018_03_29/pipeline.config"
-    weights_path_prefix: "ssd_mobilenet_v2_coco_2018_03_29/frozen_inference_graph.pb"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --tensorflow_use_custom_operations_config ./extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <ssd_mobilenet_v2_coco.config> --output detection_classes,detection_scores,detection_boxes,num_detections --input_model <ssd_mobilenet_v2_coco.pb>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: ssd_mobilenet_v2_coco.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --tensorflow_use_custom_operations_config ./extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <pipeline.config> --output detection_classes,detection_scores,detection_boxes,num_detections --input_model <frozen_inference_graph.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "resnet-50"
     description: "ResNet-50 (https://arxiv.org/pdf/1512.03385.pdf)"
-    model: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117891&authkey=AAFW2-FVoxeVRck
-    model_hash: 2f8fb64f68c6bcda94eb2640f80aed94efb91664122e72a6b7587012cc57dedc
-    weights: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117895&authkey=AAFW2-FVoxeVRck
-    weights_hash: 44ee2b08816cede2b7aaa047888df07dcab52f73399aa1c8bef05a17bfdd4888
+    files:
+      - name: resnet-50.prototxt
+        size: 32500
+        sha256: 2f8fb64f68c6bcda94eb2640f80aed94efb91664122e72a6b7587012cc57dedc
+        source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117891&authkey=AAFW2-FVoxeVRck
+      - name: resnet-50.caffemodel
+        size: 102462397
+        sha256: 44ee2b08816cede2b7aaa047888df07dcab52f73399aa1c8bef05a17bfdd4888
+        source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117895&authkey=AAFW2-FVoxeVRck
     output: "classification/resnet/v1/50/caffe/"
-    weights_size: 102462397
-    model_size: 32500
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-50.caffemodel> --input_proto <resnet-50.prototxt>"
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
 
   - name: "resnet-101"
     description: "ResNet-101 (https://arxiv.org/pdf/1512.03385.pdf)"
-    model: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117892&authkey=AAFW2-FVoxeVRck
-    model_hash: 5df4375748076544e6cc4bfde7885e633312b5ed529d65cc2ff6573a819ea972
-    weights: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117896&authkey=AAFW2-FVoxeVRck
-    weights_hash: 2847d93346d7928ec1f257f49f60ea53e9075c15265c494469610e67ffb7f2e2
+    files:
+      - name: resnet-101.prototxt
+        size: 65439
+        sha256: 5df4375748076544e6cc4bfde7885e633312b5ed529d65cc2ff6573a819ea972
+        source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117892&authkey=AAFW2-FVoxeVRck
+      - name: resnet-101.caffemodel
+        size: 178662602
+        sha256: 2847d93346d7928ec1f257f49f60ea53e9075c15265c494469610e67ffb7f2e2
+        source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117896&authkey=AAFW2-FVoxeVRck
     output: "classification/resnet/v1/101/caffe/"
-    weights_size: 178662602
-    model_size: 65439
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-101.caffemodel> --input_proto <resnet-101.prototxt>"
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
 
   - name: "resnet-152"
     description: "ResNet-152 (https://arxiv.org/pdf/1512.03385.pdf)"
-    model: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117893&authkey=AAFW2-FVoxeVRck
-    model_hash: 9e0fc0df6ac038048a87c63d56fd534471b6b4f39d55651beaf201763e028489
-    weights: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117897&authkey=AAFW2-FVoxeVRck
-    weights_hash: 6253c4c4132c0b25c112b166629aa57dcaeec044a4c68ac9f003b6c801329d55
+    files:
+      - name: resnet-152.prototxt
+        size: 98034
+        sha256: 9e0fc0df6ac038048a87c63d56fd534471b6b4f39d55651beaf201763e028489
+        source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117893&authkey=AAFW2-FVoxeVRck
+      - name: resnet-152.caffemodel
+        size: 241444171
+        sha256: 6253c4c4132c0b25c112b166629aa57dcaeec044a4c68ac9f003b6c801329d55
+        source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117897&authkey=AAFW2-FVoxeVRck
     output: "classification/resnet/v1/152/caffe/"
-    weights_size: 241444171
-    model_size: 98034
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-152.caffemodel> --input_proto <resnet-152.prototxt>"
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
 
   - name: "googlenet-v3"
     description: "GoogleNet v3 (Inception v3) (https://arxiv.org/pdf/1512.00567.pdf)"
-    weights_hash: f5ce67052687aba5bc35250b51e8d0f127d3fd140eac67b47c07d012d20d55a3
-    tar: https://storage.googleapis.com/download.tensorflow.org/models/inception_v3_2016_08_28_frozen.pb.tar.gz
+    files:
+      - name: googlenet-v3.tar.gz
+        sha256: 7045b72a954af4dce36346f478610acdccbf149168fa25c78e54e32f0c723d6d
+        source: https://storage.googleapis.com/download.tensorflow.org/models/inception_v3_2016_08_28_frozen.pb.tar.gz
     output: "classification/googlenet/v3/tf/"
-    weights_path_prefix: "inception_v3_2016_08_28_frozen.pb"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,299,299,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.50000414375013] --output InceptionV3/Predictions/Softmax --input_model <googlenet-v3.pb>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: googlenet-v3.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,299,299,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.50000414375013] --output InceptionV3/Predictions/Softmax --input_model <inception_v3_2016_08_28_frozen.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "se-inception"
     description: "BN-Inception with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
-    model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-BN-Inception.prototxt
-    model_hash: 57813dfc27113ce1bc714b069d574f80643ad58480e6f35bdf1dec690075c6b3
-    weights: https://drive.google.com/file/u/1/d/0BwHV3BlNKkWlTWRRbDZYbVB2WWc/view
-    weights_hash: 0660aa2b867f7353794d3ac02081d9178ac0709e8d8d75c29290dba4bc10ce03
+    files:
+      - name: se-inception.prototxt
+        sha256: 57813dfc27113ce1bc714b069d574f80643ad58480e6f35bdf1dec690075c6b3
+        source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-BN-Inception.prototxt
+      - name: se-inception.caffemodel
+        size: 47855246
+        sha256: 0660aa2b867f7353794d3ac02081d9178ac0709e8d8d75c29290dba4bc10ce03
+        source:
+          $type: google_drive
+          id: 0BwHV3BlNKkWlTWRRbDZYbVB2WWc
     output: "classification/se-networks/se-inception/caffe/"
-    weights_google_drive_id: 0BwHV3BlNKkWlTWRRbDZYbVB2WWc
-    weights_size: 47855246
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-inception.caffemodel> --input_proto <se-inception.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
   - name: "se-resnet-101"
     description: "ResNet-101 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
-    model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-101.prototxt
-    model_hash: c97375db60ad04e1196966c7149bd5cc98fbb9a34bdde511c26c922ba791903d
-    weights: https://drive.google.com/file/d/0BwHV3BlNKkWlTEg4YmcwQ0FoZFU/view
-    weights_hash: 09777ce1202087954ee34ae2566cf611d03d2d8195ced0fe51b612ebf951d729
+    files:
+      - name: se-resnet-101.prototxt
+        sha256: c97375db60ad04e1196966c7149bd5cc98fbb9a34bdde511c26c922ba791903d
+        source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-101.prototxt
+      - name: se-resnet-101.caffemodel
+        size: 197806200
+        sha256: 09777ce1202087954ee34ae2566cf611d03d2d8195ced0fe51b612ebf951d729
+        source:
+          $type: google_drive
+          id: 0BwHV3BlNKkWlTEg4YmcwQ0FoZFU
     output: "classification/se-networks/se-resnet-101/caffe/"
-    weights_google_drive_id: 0BwHV3BlNKkWlTEg4YmcwQ0FoZFU
-    weights_size: 197806200
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-101.caffemodel> --input_proto <se-resnet-101.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
   - name: "se-resnet-152"
     description: "ResNet-152 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
-    model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-152.prototxt
-    model_hash: 9cfe789f971c3418e50e435f494d6479a5a0f263a07bf9c13e434a0e5919b2f2
-    weights: https://drive.google.com/file/d/0BwHV3BlNKkWlcFE0Q2NTcWl3WUE/view
-    weights_hash: bbe7fc5b5068b7cd4b12ce1bb78f61bd3f48238a372e70ab9c0724afa778e5d1
+    files:
+      - name: se-resnet-152.prototxt
+        sha256: 9cfe789f971c3418e50e435f494d6479a5a0f263a07bf9c13e434a0e5919b2f2
+        source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-152.prototxt
+      - name: se-resnet-152.caffemodel
+        size: 268009578
+        sha256: bbe7fc5b5068b7cd4b12ce1bb78f61bd3f48238a372e70ab9c0724afa778e5d1
+        source:
+          $type: google_drive
+          id: 0BwHV3BlNKkWlcFE0Q2NTcWl3WUE
     output: "classification/se-networks/se-resnet-152/caffe/"
-    weights_google_drive_id: 0BwHV3BlNKkWlcFE0Q2NTcWl3WUE
-    weights_size: 268009578
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-152.caffemodel> --input_proto <se-resnet-152.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
   - name: "se-resnet-50"
     description: "ResNet-50 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
-    model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-50.prototxt
-    model_hash: eebbe3c64201f34492caf501498f6031152edbd4a44ed106de69441060ff117c
-    weights: https://drive.google.com/file/d/0BwHV3BlNKkWlS2QwZHFzM3RjNzg/view
-    weights_hash: 72880fde3bd29b324bb302c80f49a098b8970597494c56525fd410a8d2ed5993
+    files:
+      - name: se-resnet-50.prototxt
+        sha256: eebbe3c64201f34492caf501498f6031152edbd4a44ed106de69441060ff117c
+        source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-50.prototxt
+      - name: se-resnet-50.caffemodel
+        size: 112602669
+        sha256: 72880fde3bd29b324bb302c80f49a098b8970597494c56525fd410a8d2ed5993
+        source:
+          $type: google_drive
+          id: 0BwHV3BlNKkWlS2QwZHFzM3RjNzg
     output: "classification/se-networks/se-resnet-50/caffe"
-    weights_google_drive_id: 0BwHV3BlNKkWlS2QwZHFzM3RjNzg
-    weights_size: 112602669
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-50.caffemodel> --input_proto <se-resnet-50.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
   - name: "se-resnext-50"
     description: "ResNeXt-50 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
-    model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-50.prototxt
-    model_hash: a44865802483b8e20fcc712540c4995ef27c3dc809d9235f5882a13ef5c16e67
-    weights: https://drive.google.com/file/d/0BwHV3BlNKkWlQ2Z0Q204V1RITjA/view
-    weights_hash: f12c6b53c2dcd0f38f388d3d5f98cbfc039357e84842e661f28a49719dd52219
+    files:
+      - name: se-resnext-50.prototxt
+        sha256: a44865802483b8e20fcc712540c4995ef27c3dc809d9235f5882a13ef5c16e67
+        source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-50.prototxt
+      - name: se-resnext-50.caffemodel
+        size: 110550637
+        sha256: f12c6b53c2dcd0f38f388d3d5f98cbfc039357e84842e661f28a49719dd52219
+        source:
+          $type: google_drive
+          id: 0BwHV3BlNKkWlQ2Z0Q204V1RITjA
     output: "classification/se-networks/se-resnext-50/caffe/"
-    weights_google_drive_id: 0BwHV3BlNKkWlQ2Z0Q204V1RITjA
-    weights_size: 110550637
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnext-50.caffemodel> --input_proto <se-resnext-50.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
   - name: "se-resnext-101"
     description: "ResNeXt-101 with Squeeze-and-Excitation blocks (https://arxiv.org/pdf/1709.01507.pdf)"
-    model: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-101.prototxt
-    model_hash: 8a23f1488f5dad2bc4e11b3e7733bc95783301d8c426677989fb11eb7ea2de8b
-    weights: https://drive.google.com/file/d/0BwHV3BlNKkWleklsNzBiZlprblk/view
-    weights_hash: 78dc95c9b768fdb32a0a3981a686edaf655df82973b051d818bae523c9a93c90
+    files:
+      - name: se-resnext-101.prototxt
+        sha256: 8a23f1488f5dad2bc4e11b3e7733bc95783301d8c426677989fb11eb7ea2de8b
+        source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-101.prototxt
+      - name: se-resnext-101.caffemodel
+        size: 196447403
+        sha256: 78dc95c9b768fdb32a0a3981a686edaf655df82973b051d818bae523c9a93c90
+        source:
+          $type: google_drive
+          id: 0BwHV3BlNKkWleklsNzBiZlprblk
     output: "classification/se-networks/se-resnext-101/caffe"
-    weights_google_drive_id: 0BwHV3BlNKkWleklsNzBiZlprblk
-    weights_size: 196447403
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnext-101.caffemodel> --input_proto <se-resnext-101.prototxt>"
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
   - name: "Sphereface"
     description: "Deep face recognition under open-set protocol (https://arxiv.org/pdf/1704.08063.pdf)"
-    model: https://raw.githubusercontent.com/wy1iu/sphereface/7f9acb157c78a99dbefd041fce9f188400bbb4e5/train/code/sphereface_deploy.prototxt
-    model_hash: 7cf5808fd0561db20daae862b83677b7437e788420fae68ab8d97c935e67d82c
-    weights: https://drive.google.com/file/d/0B_geeR2lTMegb2F6dmlmOXhWaVk/edit
-    weights_hash: 092d8fb00291d80ed7e43f7c9323693581cd75e734be3c52764525043288a20d
+    files:
+      - name: Sphereface.prototxt
+        sha256: 7cf5808fd0561db20daae862b83677b7437e788420fae68ab8d97c935e67d82c
+        source: https://raw.githubusercontent.com/wy1iu/sphereface/7f9acb157c78a99dbefd041fce9f188400bbb4e5/train/code/sphereface_deploy.prototxt
+      - name: Sphereface.caffemodel
+        size: 90688218
+        sha256: 092d8fb00291d80ed7e43f7c9323693581cd75e734be3c52764525043288a20d
+        source:
+          $type: google_drive
+          id: 0B_geeR2lTMegb2F6dmlmOXhWaVk
     output: "face_recognition/sphereface/caffe/"
-    weights_google_drive_id: 0B_geeR2lTMegb2F6dmlmOXhWaVk
-    weights_size: 90688218
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,112,96] --input data --mean_values data[127.5,127.5,127.5] --scale_values data[128.0] --output fc5 --input_model <Sphereface.caffemodel> --input_proto <Sphereface.prototxt>"
     framework: caffe
     license: https://github.com/wy1iu/sphereface/blob/master/LICENSE
 
   - name: "license-plate-recognition-barrier-0007"
     description: "TensorFlow LPRNet"
-    weights_hash: 613b6011ad86a2d792e04b64b6ce0d763064319b5240440fa57b571b65c0b595
-    tar: https://download.01.org/openvinotoolkit/training_toolbox_tensorflow/models/lpr/chinese_lp/license-plate-recognition-barrier-0007.tar.gz
+    files:
+      - name: license-plate-recognition-barrier-0007.tar.gz
+        sha256: 6c0b8651f0eead6de43e07491fd41809a4a7da141f1b5002dfd8dd207bdb1018
+        source: https://download.01.org/openvinotoolkit/training_toolbox_tensorflow/models/lpr/chinese_lp/license-plate-recognition-barrier-0007.tar.gz
     output: "optical_character_recognition/license_plate_recognition/tf/"
-    weights_path_prefix: "license-plate-recognition-barrier-0007/graph.pb.frozen"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,24,94,3] --input input --scale_values input[254.99997577500233] --output d_predictions --input_model <license-plate-recognition-barrier-0007.frozen>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: license-plate-recognition-barrier-0007.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,24,94,3] --input input --scale_values input[254.99997577500233] --output d_predictions --input_model <graph.pb.frozen>"
     framework: tf
     license: https://github.com/opencv/training_toolbox_tensorflow/blob/develop/LICENSE
 
   - name: "face-detection-retail-0044"
     description: "Face Detection (SqNet1.0modif+single scale) with BatchNormalization trained with negatives"
-    model: https://raw.githubusercontent.com/opencv/training_toolbox_caffe/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/deploy.prototxt
-    model_hash: 89ea5bb9c293ebabb56b9f6dfb4cfc6c46cd146cdce307a2f5a2755bf904fc79
-    weights: https://github.com/opencv/training_toolbox_caffe/raw/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/face-detection-retail-0044.caffemodel
-    weights_hash: 10f68b73f3b68db89fab151be51fc90a0bc1e2a18a87ac642e88aa9e94d53f8f
+    files:
+      - name: face-detection-retail-0044.prototxt
+        sha256: 89ea5bb9c293ebabb56b9f6dfb4cfc6c46cd146cdce307a2f5a2755bf904fc79
+        source: https://raw.githubusercontent.com/opencv/training_toolbox_caffe/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/deploy.prototxt
+      - name: face-detection-retail-0044.caffemodel
+        sha256: 10f68b73f3b68db89fab151be51fc90a0bc1e2a18a87ac642e88aa9e94d53f8f
+        source: https://github.com/opencv/training_toolbox_caffe/raw/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/face-detection-retail-0044.caffemodel
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0044/caffe/"
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --input_model <face-detection-retail-0044.caffemodel> --input_proto <face-detection-retail-0044.prototxt>"
     framework: caffe
@@ -495,10 +617,13 @@ topologies:
 
   - name: "mobilenet-v1-1.0-224"
     description: "MobileNet V1 architecture with the width multiplier 1.0 and resolution 224 (https://arxiv.org/pdf/1704.04861.pdf)"
-    model: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_deploy.prototxt
-    model_hash: 8e6a26b8f2c7cf7a066d571660cfd8a1544a5a25399df33ad499f3d733f16729
-    weights: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet.caffemodel
-    weights_hash: 8d6edcd3dbd1356f2f19dd220c362c2ba8f44233a9b6c12ca6d0351cb0c446b6 
+    files:
+      - name: mobilenet-v1-1.0-224.prototxt
+        sha256: 8e6a26b8f2c7cf7a066d571660cfd8a1544a5a25399df33ad499f3d733f16729
+        source: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_deploy.prototxt
+      - name: mobilenet-v1-1.0-224.caffemodel
+        sha256: 8d6edcd3dbd1356f2f19dd220c362c2ba8f44233a9b6c12ca6d0351cb0c446b6
+        source: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet.caffemodel
     output: "classification/mobilenet/v1/1.0/224/cf/"
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output prob --input_model <mobilenet-v1-1.0-224.caffemodel> --input_proto <mobilenet-v1-1.0-224.prototxt>"
     framework: caffe
@@ -506,10 +631,13 @@ topologies:
 
   - name: "mobilenet-v2"
     description: "MobileNet V2 (https://arxiv.org/pdf/1801.04381.pdf)"
-    model: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2_deploy.prototxt
-    model_hash: 06a0820a5edc6d2c24e83e0b95824d0dae464ced3d5db82f51e461098a03b887
-    weights: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2.caffemodel
-    weights_hash: a3124ce7abd258c7f35a2c586576bee8116934fa2a8556e4e528041859dd753f
+    files:
+      - name: mobilenet-v2.prototxt
+        sha256: 06a0820a5edc6d2c24e83e0b95824d0dae464ced3d5db82f51e461098a03b887
+        source: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2_deploy.prototxt
+      - name: mobilenet-v2.caffemodel
+        sha256: a3124ce7abd258c7f35a2c586576bee8116934fa2a8556e4e528041859dd753f
+        source: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2.caffemodel
     output: "classification/mobilenet/v2/cf/"
     model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output prob --input_model <mobilenet-v2.caffemodel> --input_proto <mobilenet-v2.prototxt>"
     framework: caffe
@@ -517,30 +645,40 @@ topologies:
 
   - name: "faster_rcnn_inception_v2_coco"
     description: "Faster R-CNN with Inception v2 (https://arxiv.org/pdf/1801.04381.pdf) pre-trained on the COCO dataset"
-    model_hash: 1795389f43c17930b9ab0febf507fea329c37b1c1ce2ff077cfcfcc5d30be340
-    weights_hash: fa2cef2ed0543933f132539bd037fa9b66a73d9a33c660cedf68961a880a068f
-    tar: http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_v2_coco_2018_01_28.tar.gz
+    files:
+      - name: faster_rcnn_inception_v2_coco.tar.gz
+        sha256: db3295e9a52d406540e84bdd056edeedbf938782a7bc4af7918aaa5dc30f0df5
+        source: http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_v2_coco_2018_01_28.tar.gz
     output: "object_detection/common/faster_rcnn/faster_rcnn_inception_v2_coco/tf/"
-    model_path_prefix: "faster_rcnn_inception_v2_coco_2018_01_28/pipeline.config"
-    weights_path_prefix: "faster_rcnn_inception_v2_coco_2018_01_28/frozen_inference_graph.pb"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <faster_rcnn_inception_v2_coco.config> --input_model <faster_rcnn_inception_v2_coco.pb>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: faster_rcnn_inception_v2_coco.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <pipeline.config> --input_model <frozen_inference_graph.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "deeplabv3"
     description: "Rethinking Atrous Convolution for Semantic Image Segmentation (https://arxiv.org/pdf/1706.05587.pdf)"
-    weights_hash: b3b7c39d1010c6da1dd0e87973ca24a78fa7dc70d4136fbcf50b9585469b6d9a
-    tar: http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_train_aug_2018_01_29.tar.gz
+    files:
+      - name: deeplabv3.tar.gz
+        sha256: cd506941e4f88fd053903913761df2e76ea00c01079cecfd35855304a4a5fb48
+        source: http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_train_aug_2018_01_29.tar.gz
     output: "semantic_segmentation/deeplab/v3/"
-    weights_path_prefix: "deeplabv3_mnv2_pascal_train_aug/frozen_inference_graph.pb"
-    model_optimizer_args: "--framework tf --data_type FP32 --input_shape [1,513,513,3] --input 1:mul_1 --output ArgMax --input_model <deeplabv3.pb>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: deeplabv3.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --input_shape [1,513,513,3] --input 1:mul_1 --output ArgMax --input_model <frozen_inference_graph.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "ctpn"
     description: "Detecting Text in Natural Image with Connectionist Text Proposal Network (https://arxiv.org/pdf/1609.03605.pdf)"
-    weights: https://github.com/eragonruan/text-detection-ctpn/releases/download/untagged-48d74c6337a71b6b5f87/ctpn.pb
-    weights_hash: 09b3a0cc57eb826dd6b6fa95a03e078ad435b7b5fb0186dad2abdb98a4fdf64a
+    files:
+      - name: ctpn.pb
+        sha256: 09b3a0cc57eb826dd6b6fa95a03e078ad435b7b5fb0186dad2abdb98a4fdf64a
+        source: https://github.com/eragonruan/text-detection-ctpn/releases/download/untagged-48d74c6337a71b6b5f87/ctpn.pb
     output: "text_detection/ctpn/tf/"
     model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input Placeholder --mean_values Placeholder[102.9801,115.9465,122.7717] --output Reshape_2,rpn_bbox_pred/Reshape_1 --input_model <ctpn.pb>"
     framework: tf
@@ -548,984 +686,1280 @@ topologies:
 
   - name: "ssd_mobilenet_v1_coco"
     description: "MobileNetV1 object detection architecture (https://arxiv.org/pdf/1807.03284.pdf) pre-trained on the COCO dataset"
-    model_hash: aec63661e0c561ef6de5c8a9b463cada7c639a8ed1c160b8903cd5d121d078ce
-    weights_hash: 0cb4161a6310632814cd25afe11c261cff9a7d55487a813acd54772285b54850
-    tar: http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz
+    files:
+      - name: ssd_mobilenet_v1_coco.tar.gz
+        sha256: 8788f89108519fd1102b8a5c2ac861cf6d86603571b6ce5bbd1c245b7fe005e3
+        source: http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz
     output: "object_detection/common/ssd_mobilenet/ssd_mobilenet_v1_coco/tf/"
-    model_path_prefix: "ssd_mobilenet_v1_coco_2018_01_28/pipeline.config"
-    weights_path_prefix: "ssd_mobilenet_v1_coco_2018_01_28/frozen_inference_graph.pb"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <ssd_mobilenet_v1_coco.config> --input_model <ssd_mobilenet_v1_coco.pb>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: ssd_mobilenet_v1_coco.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <pipeline.config> --input_model <frozen_inference_graph.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "faster_rcnn_resnet101_coco"
     description: "Faster R-CNN Resnet-101 (https://arxiv.org/pdf/1801.04381.pdf) pre-trained on the COCO dataset"
-    model_hash: 9147a34bdee5bf2c1e8bfb8fa8945463024e0974ef9dae65b17837e23ee804fe
-    weights_hash: cfa9a1483faf30c7d073188a337721a1ed489998262f6adef0cbf6c5b7a72fb5
-    tar: http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_coco_2018_01_28.tar.gz
+    files:
+      - name: faster_rcnn_resnet101_coco.tar.gz
+        sha256: ef3b36b3bc3c4057362a62e40b89dbdbef3dbb0c91f2f7df43967920d24821e5
+        source: http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_coco_2018_01_28.tar.gz
     output: "object_detection/common/faster_rcnn/faster_rcnn_resnet101_coco/tf/"
-    model_path_prefix: "faster_rcnn_resnet101_coco_2018_01_28/pipeline.config"
-    weights_path_prefix: "faster_rcnn_resnet101_coco_2018_01_28/frozen_inference_graph.pb"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <faster_rcnn_resnet101_coco.pb> --input_model <faster_rcnn_resnet101_coco.pb>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: faster_rcnn_resnet101_coco.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <faster_rcnn_resnet101_coco.pb> --input_model <frozen_inference_graph.pb>"
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "mobilenet-v2-1.4-224"
     description: "MobileNet V2 architecture with the width multiplier 1.4 and resolution 224 (https://arxiv.org/abs/1801.04381)"
-    weights_hash: 111479258f3841c93d0a7a377c976c24e8281077818991931429d2277dd88590
-    tar: https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz
+    files:
+      - name: mobilenet-v2-1.4-224.tar.gz
+        sha256: a20d0c8d698502dc6a620528871c97a588885df7737556243a3412b39fce85e0
+        source: https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz
     output: "classification/mobilenet/v2/tf/mobilenet_v2_1.4_224/"
-    weights_path_prefix: "./mobilenet_v2_1.4_224_frozen.pb"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,224,224,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.00001206500114] --output MobilenetV2/Predictions/Reshape_1 --input_model <mobilenet-v2-1.4-224.pb>"
+    postprocessing:
+      - $type: unpack_archive
+        format: gztar
+        file: mobilenet-v2-1.4-224.tar.gz
+    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,224,224,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.00001206500114] --output MobilenetV2/Predictions/Reshape_1 --input_model <mobilenet_v2_1.4_224_frozen.pb>"
     framework: "tf"
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
   - name: "age-gender-recognition-retail-0013"
     description: "Age & gender classification."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
-    model_hash: 110126ae5e77bccc694dcfe9064af8c4cff93c0452ae265574f12170de356348
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
-    weights_hash: 4dab79cfedebd628f3327367a91c9736a32fbf9cc733cbbf1629d16910d4ace7
+    files:
+      - name: age-gender-recognition-retail-0013.xml
+        sha256: 110126ae5e77bccc694dcfe9064af8c4cff93c0452ae265574f12170de356348
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
+      - name: age-gender-recognition-retail-0013.bin
+        sha256: 4dab79cfedebd628f3327367a91c9736a32fbf9cc733cbbf1629d16910d4ace7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
     output: "Retail/object_attributes/age_gender/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "age-gender-recognition-retail-0013-fp16"
     description: "Age & gender classification."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
-    model_hash: 885c3fbc32f2f42b37f09dd4f6d309c3aa12996737433164b5d1c59816b8b4e1
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
-    weights_hash: 401101e0a01b3d68add39deae833bcf9f54238d37dd13e3fb1534aa8fbe4719d
+    files:
+      - name: age-gender-recognition-retail-0013-fp16.xml
+        sha256: 885c3fbc32f2f42b37f09dd4f6d309c3aa12996737433164b5d1c59816b8b4e1
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
+      - name: age-gender-recognition-retail-0013-fp16.bin
+        sha256: 401101e0a01b3d68add39deae833bcf9f54238d37dd13e3fb1534aa8fbe4719d
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
     output: "Retail/object_attributes/age_gender/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "emotions-recognition-retail-0003"
     description: "Recognizes 5 emotions for a face."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
-    model_hash: 946571833aeb9488ea5202f806d5a07e7d2acc25e7cc29206e36e66530a963d9
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
-    weights_hash: bcb9b1a910fa3cd18a638bb1dbb0597c4ef7a080d1b83008c8e8c2c3c42b99dd
+    files:
+      - name: emotions-recognition-retail-0003.xml
+        sha256: 946571833aeb9488ea5202f806d5a07e7d2acc25e7cc29206e36e66530a963d9
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
+      - name: emotions-recognition-retail-0003.bin
+        sha256: bcb9b1a910fa3cd18a638bb1dbb0597c4ef7a080d1b83008c8e8c2c3c42b99dd
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
     output: "Retail/object_attributes/emotions_recognition/0003/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "emotions-recognition-retail-0003-fp16"
     description: "Recognizes 5 emotions for a face."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
-    model_hash: 5450c027ac54c42527ffbe91379c2cbbf7c656a118968411f138445acd508266
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
-    weights_hash: e62fb4b819b3b3ad8aafcd308d4353db2f164a1a31d78de6cf5970837aeb6f7b
+    files:
+      - name: emotions-recognition-retail-0003-fp16.xml
+        sha256: 5450c027ac54c42527ffbe91379c2cbbf7c656a118968411f138445acd508266
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
+      - name: emotions-recognition-retail-0003-fp16.bin
+        sha256: e62fb4b819b3b3ad8aafcd308d4353db2f164a1a31d78de6cf5970837aeb6f7b
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
     output: "Retail/object_attributes/emotions_recognition/0003/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "emotions-recognition-retail-0003-int8"
     description: "Recognizes 5 emotions for a face."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.xml
-    model_hash: 81a2697a0d4c718d00a78bcf2ec9a35470cc6a48f44b66dd7a2d8968e869048b
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.bin
-    weights_hash: 61203cb3b7318101637b444c12c9e050cb3447f682c44bc343e8926f9bfe6130
+    files:
+      - name: emotions-recognition-retail-0003-int8.xml
+        sha256: 81a2697a0d4c718d00a78bcf2ec9a35470cc6a48f44b66dd7a2d8968e869048b
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.xml
+      - name: emotions-recognition-retail-0003-int8.bin
+        sha256: 61203cb3b7318101637b444c12c9e050cb3447f682c44bc343e8926f9bfe6130
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.bin
     output: "Retail/object_attributes/emotions_recognition/0003/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-detection-adas-0001"
     description: "Face Detection (MobileNet with reduced channels + SSD with weights sharing)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
-    model_hash: 4c46152ca5b2dbaec38a96ab610336f5ed84d750bafbc605cb0aa44a707830f1
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
-    weights_hash: 044fbca5222245ea8623eee4dd9475112a562f3b644f47e136f87660f5da4958
+    files:
+      - name: face-detection-adas-0001.xml
+        sha256: 4c46152ca5b2dbaec38a96ab610336f5ed84d750bafbc605cb0aa44a707830f1
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
+      - name: face-detection-adas-0001.bin
+        sha256: 044fbca5222245ea8623eee4dd9475112a562f3b644f47e136f87660f5da4958
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-detection-adas-0001-fp16"
     description: "Face Detection (MobileNet with reduced channels + SSD with weights sharing)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
-    model_hash: b2d7ebc94c56f75ebfabeab7142464bf56c6c809aa1942d58925fcba6b80c314
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
-    weights_hash: a2486566011e77bfa3180c437911c71f164a9f0a8039498ed1ef7237f612559f
+    files:
+      - name: face-detection-adas-0001-fp16.xml
+        sha256: b2d7ebc94c56f75ebfabeab7142464bf56c6c809aa1942d58925fcba6b80c314
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
+      - name: face-detection-adas-0001-fp16.bin
+        sha256: a2486566011e77bfa3180c437911c71f164a9f0a8039498ed1ef7237f612559f
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-detection-adas-0001-int8"
     description: "Face Detection (MobileNet with reduced channels + SSD with weights sharing)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/INT8/face-detection-adas-0001.xml
-    model_hash: 86f664283b69479d1dd48ad7fcb5fb4e255b505cbb13e0df4b512d0718d56d1c
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/INT8/face-detection-adas-0001.bin
-    weights_hash: 0c4c0d53c12cd36b946e36a4b97a0271d1b1f46dc6feb7241d08a611724b04e2
+    files:
+      - name: face-detection-adas-0001-int8.xml
+        sha256: 86f664283b69479d1dd48ad7fcb5fb4e255b505cbb13e0df4b512d0718d56d1c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/INT8/face-detection-adas-0001.xml
+      - name: face-detection-adas-0001-int8.bin
+        sha256: 0c4c0d53c12cd36b946e36a4b97a0271d1b1f46dc6feb7241d08a611724b04e2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-0001/INT8/face-detection-adas-0001.bin
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-detection-retail-0004"
     description: "Face Detection (SqNet1.0modif+single scale) without BatchNormalization trained with negatives."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
-    model_hash: f3e74c6e0e0d119623907d3ef95ceca6d06a50f8d98d2a8f5f5b5c1b5177c372
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
-    weights_hash: 6bca00dde8f950df941b02e70e4152c701b9e8cbffed50432eab3d797d1e080c
+    files:
+      - name: face-detection-retail-0004.xml
+        sha256: f3e74c6e0e0d119623907d3ef95ceca6d06a50f8d98d2a8f5f5b5c1b5177c372
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
+      - name: face-detection-retail-0004.bin
+        sha256: 6bca00dde8f950df941b02e70e4152c701b9e8cbffed50432eab3d797d1e080c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-detection-retail-0004-fp16"
     description: "Face Detection (SqNet1.0modif+single scale) without BatchNormalization trained with negatives."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
-    model_hash: 2e93db782f42c63740e43d5f0a4327e85d6e811d1123abf41eeb4ee41d602f24
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
-    weights_hash: 5c33fe026afe0a7b0c88603b4f826b7e319fa42740d576bf14aafd0b7cbb44d2
+    files:
+      - name: face-detection-retail-0004-fp16.xml
+        sha256: 2e93db782f42c63740e43d5f0a4327e85d6e811d1123abf41eeb4ee41d602f24
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
+      - name: face-detection-retail-0004-fp16.bin
+        sha256: 5c33fe026afe0a7b0c88603b4f826b7e319fa42740d576bf14aafd0b7cbb44d2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-detection-retail-0004-int8"
     description: "Face Detection (SqNet1.0modif+single scale) without BatchNormalization trained with negatives."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/INT8/face-detection-retail-0004.xml
-    model_hash: ba1a7c1c72156ecfef2eff7594ee22515cd88393242f78f72fb07fbcc0a0fee7
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/INT8/face-detection-retail-0004.bin
-    weights_hash: 9abed3810ba767675751f9ebaf6c7b4915535a6d1af3b0254c85e4237e01b8c2
+    files:
+      - name: face-detection-retail-0004-int8.xml
+        sha256: ba1a7c1c72156ecfef2eff7594ee22515cd88393242f78f72fb07fbcc0a0fee7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/INT8/face-detection-retail-0004.xml
+      - name: face-detection-retail-0004-int8.bin
+        sha256: 9abed3810ba767675751f9ebaf6c7b4915535a6d1af3b0254c85e4237e01b8c2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-retail-0004/INT8/face-detection-retail-0004.bin
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0004/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-person-detection-retail-0002"
     description: "Simultaneous detection of Pedestrians and Faces (RMNet with lrelu + SSSSD)."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP32/face-person-detection-retail-0002.xml
-    model_hash: c0ef457a3ef9fb13011cae262e6351a5b9e033792a06b22c4b1f0c74a9f95584
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP32/face-person-detection-retail-0002.bin
-    weights_hash: 1800bb993c31dafeb8670f0b3a6f67d456881096a25e246471b5e2924262cfff
+    files:
+      - name: face-person-detection-retail-0002.xml
+        sha256: c0ef457a3ef9fb13011cae262e6351a5b9e033792a06b22c4b1f0c74a9f95584
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP32/face-person-detection-retail-0002.xml
+      - name: face-person-detection-retail-0002.bin
+        sha256: 1800bb993c31dafeb8670f0b3a6f67d456881096a25e246471b5e2924262cfff
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP32/face-person-detection-retail-0002.bin
     output: "Retail/object_detection/face_pedestrian/rmnet-ssssd-2heads/0002/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-person-detection-retail-0002-fp16"
     description: "Simultaneous detection of Pedestrians and Faces (RMNet with lrelu + SSSSD)."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP16/face-person-detection-retail-0002.xml
-    model_hash: 6568876cf2852eeb9ace251e4728b23dfc6c1428e6b77c9c3076dad2c1cbe99e
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP16/face-person-detection-retail-0002.bin
-    weights_hash: 4adffe5bf9c964ef2219b5271a7e4ceab332d6fd6c0a753cde2daa1ee5a2ce76
+    files:
+      - name: face-person-detection-retail-0002-fp16.xml
+        sha256: 6568876cf2852eeb9ace251e4728b23dfc6c1428e6b77c9c3076dad2c1cbe99e
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP16/face-person-detection-retail-0002.xml
+      - name: face-person-detection-retail-0002-fp16.bin
+        sha256: 4adffe5bf9c964ef2219b5271a7e4ceab332d6fd6c0a753cde2daa1ee5a2ce76
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-person-detection-retail-0002/FP16/face-person-detection-retail-0002.bin
     output: "Retail/object_detection/face_pedestrian/rmnet-ssssd-2heads/0002/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-reidentification-retail-0095"
     description: "Single embedding-based face verification model"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
-    model_hash: 6c28a0155e022b04756c31f3992a64237085def07a213563fad1cbede543eb8a
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
-    weights_hash: 03836a6a1d03828322491b0608a579b1c47e5097d355c489b5b8aaf5fce1ef48
+    files:
+      - name: face-reidentification-retail-0095.xml
+        sha256: 6c28a0155e022b04756c31f3992a64237085def07a213563fad1cbede543eb8a
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
+      - name: face-reidentification-retail-0095.bin
+        sha256: 03836a6a1d03828322491b0608a579b1c47e5097d355c489b5b8aaf5fce1ef48
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
     output: "Retail/object_reidentification/face/mobilenet_based/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-reidentification-retail-0095-fp16"
     description: "Single embedding-based face verification model"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
-    model_hash: b0d6a49d3d1d623003e78e58aba2b2884237ed0d9d591c0255bb5d5d75c91548
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
-    weights_hash: 3289078133e40e4263f682ded2a26a500905abb0fd7b943f41ca8037a4f3fe21
+    files:
+      - name: face-reidentification-retail-0095-fp16.xml
+        sha256: b0d6a49d3d1d623003e78e58aba2b2884237ed0d9d591c0255bb5d5d75c91548
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
+      - name: face-reidentification-retail-0095-fp16.bin
+        sha256: 3289078133e40e4263f682ded2a26a500905abb0fd7b943f41ca8037a4f3fe21
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
     output: "Retail/object_reidentification/face/mobilenet_based/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "facial-landmarks-35-adas-0002"
     description: "Custom-architecture convolutional neural network for 35 facial landmarks estimation."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
-    model_hash: d3f7f1e0b84708247424630c7523426a81a9884070e084f2b9cf8f11c07cb4f0
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
-    weights_hash: 232b1a25de480227f36428fdb11a7a1f623acf37eb4232ced5fabac9b7dd2ad7
+    files:
+      - name: facial-landmarks-35-adas-0002.xml
+        sha256: d3f7f1e0b84708247424630c7523426a81a9884070e084f2b9cf8f11c07cb4f0
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
+      - name: facial-landmarks-35-adas-0002.bin
+        sha256: 232b1a25de480227f36428fdb11a7a1f623acf37eb4232ced5fabac9b7dd2ad7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
     output: "Transportation/object_attributes/facial_landmarks/custom-35-facial-landmarks/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "facial-landmarks-35-adas-0002-fp16"
     description: "Custom-architecture convolutional neural network for 35 facial landmarks estimation."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
-    model_hash: d9e3e98918d15320aac8f5550f4e9f2a6f33ee5bccd6398f042b59084b71abac
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
-    weights_hash: b8945ba897072289c8cb44357bd211e728ecd1c093c1d4777b79d118a19ab58a
+    files:
+      - name: facial-landmarks-35-adas-0002-fp16.xml
+        sha256: d9e3e98918d15320aac8f5550f4e9f2a6f33ee5bccd6398f042b59084b71abac
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
+      - name: facial-landmarks-35-adas-0002-fp16.bin
+        sha256: b8945ba897072289c8cb44357bd211e728ecd1c093c1d4777b79d118a19ab58a
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
     output: "Transportation/object_attributes/facial_landmarks/custom-35-facial-landmarks/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "head-pose-estimation-adas-0001"
     description: "Vanilla CNN trained from scratch yaw + pitch + roll + landmarks"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
-    model_hash: 5cc24273db0aedbf44ee5671135228cea7187fb5bec81be216af74aac3d5e8d9
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
-    weights_hash: e4047e643bd39d97288dc5d22abe8ead850e05ac1bc44605443bbb2abfc2e246
+    files:
+      - name: head-pose-estimation-adas-0001.xml
+        sha256: 5cc24273db0aedbf44ee5671135228cea7187fb5bec81be216af74aac3d5e8d9
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
+      - name: head-pose-estimation-adas-0001.bin
+        sha256: e4047e643bd39d97288dc5d22abe8ead850e05ac1bc44605443bbb2abfc2e246
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
     output: "Transportation/object_attributes/headpose/vanilla_cnn/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "head-pose-estimation-adas-0001-fp16"
     description: "Vanilla CNN trained from scratch yaw + pitch + roll + landmarks"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
-    model_hash: d570c7b43a20428ac41915c6b915860d6a141d0057b0091c22fe014b79ee5ea7
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
-    weights_hash: 535a6af806999e22cca5e4071e55841a694a6b60370a6f8fb3b9d0cda5f81c41
+    files:
+      - name: head-pose-estimation-adas-0001-fp16.xml
+        sha256: d570c7b43a20428ac41915c6b915860d6a141d0057b0091c22fe014b79ee5ea7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
+      - name: head-pose-estimation-adas-0001-fp16.bin
+        sha256: 535a6af806999e22cca5e4071e55841a694a6b60370a6f8fb3b9d0cda5f81c41
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
     output: "Transportation/object_attributes/headpose/vanilla_cnn/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "head-pose-estimation-adas-0001-int8"
     description: "Vanilla CNN trained from scratch yaw + pitch + roll + landmarks"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/INT8/head-pose-estimation-adas-0001.xml
-    model_hash: 3d820d5aede971aef3b760328bfe1edd96d395b272622cea816c573003ae2b89
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/INT8/head-pose-estimation-adas-0001.bin
-    weights_hash: abc0fb7f08e782301c4ffccf9fc5ce626e608a1e7f9c179baf6513519fa38416
+    files:
+      - name: head-pose-estimation-adas-0001-int8.xml
+        sha256: 3d820d5aede971aef3b760328bfe1edd96d395b272622cea816c573003ae2b89
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/INT8/head-pose-estimation-adas-0001.xml
+      - name: head-pose-estimation-adas-0001-int8.bin
+        sha256: abc0fb7f08e782301c4ffccf9fc5ce626e608a1e7f9c179baf6513519fa38416
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/head-pose-estimation-adas-0001/INT8/head-pose-estimation-adas-0001.bin
     output: "Transportation/object_attributes/headpose/vanilla_cnn/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "human-pose-estimation-0001"
     description: "2D human pose estimation with tuned mobilenet backbone (based on OpenPose)."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
-    model_hash: 93cb893d1ffc0bb7bb6825bd0cc64f626057da1e16e22ed3835d753f2526e068
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
-    weights_hash: 9790da47abf072c509ff843695a7b9b96283729731ba4d711fb50201f376b2fc
+    files:
+      - name: human-pose-estimation-0001.xml
+        sha256: 93cb893d1ffc0bb7bb6825bd0cc64f626057da1e16e22ed3835d753f2526e068
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
+      - name: human-pose-estimation-0001.bin
+        sha256: 9790da47abf072c509ff843695a7b9b96283729731ba4d711fb50201f376b2fc
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
     output: "Transportation/human_pose_estimation/mobilenet-v1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "human-pose-estimation-0001-fp16"
     description: "2D human pose estimation with tuned mobilenet backbone (based on OpenPose)."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
-    model_hash: 5dbd78dec8ea4a9283bb78640a3ba2c3878535286471ed7b80bce30070684046
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
-    weights_hash: 48c607a55b22b540c38b6ed295eba211aaa6cd4acd47776f0a1259829cb51196
+    files:
+      - name: human-pose-estimation-0001-fp16.xml
+        sha256: 5dbd78dec8ea4a9283bb78640a3ba2c3878535286471ed7b80bce30070684046
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
+      - name: human-pose-estimation-0001-fp16.bin
+        sha256: 48c607a55b22b540c38b6ed295eba211aaa6cd4acd47776f0a1259829cb51196
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
     output: "Transportation/human_pose_estimation/mobilenet-v1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "human-pose-estimation-0001-int8"
     description: "2D human pose estimation with tuned mobilenet backbone (based on OpenPose)."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/INT8/human-pose-estimation-0001.xml
-    model_hash: a77eb5ad3423d41b5f26acf01c8549db892cbb32f903342d6c1dc7640e1902c4
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/INT8/human-pose-estimation-0001.bin
-    weights_hash: 0d252f0fd98c598fb38eaa907fa8b3d15cf2d420d743649b4b6c5dbdbbe5f1ac
+    files:
+      - name: human-pose-estimation-0001-int8.xml
+        sha256: a77eb5ad3423d41b5f26acf01c8549db892cbb32f903342d6c1dc7640e1902c4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/INT8/human-pose-estimation-0001.xml
+      - name: human-pose-estimation-0001-int8.bin
+        sha256: 0d252f0fd98c598fb38eaa907fa8b3d15cf2d420d743649b4b6c5dbdbbe5f1ac
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/human-pose-estimation-0001/INT8/human-pose-estimation-0001.bin
     output: "Transportation/human_pose_estimation/mobilenet-v1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "landmarks-regression-retail-0009"
     description: "Landmark's detection."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
-    model_hash: db495316e343dc5cdb3edaf6ca5853c4a478c96772eb6da042ccdddeeefd0936
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
-    weights_hash: 46795837d35e8199b7c5b57e1f76297827bf516a150c0d5643197d8c325f1dbc
+    files:
+      - name: landmarks-regression-retail-0009.xml
+        sha256: db495316e343dc5cdb3edaf6ca5853c4a478c96772eb6da042ccdddeeefd0936
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
+      - name: landmarks-regression-retail-0009.bin
+        sha256: 46795837d35e8199b7c5b57e1f76297827bf516a150c0d5643197d8c325f1dbc
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
     output: "Retail/object_attributes/landmarks_regression/0009/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "landmarks-regression-retail-0009-fp16"
     description: "Landmark's detection."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
-    model_hash: bcf274a704031d24af7fdd7f868f052e346cf96029b6b6e85cdc168beddbe401
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
-    weights_hash: 5d74c26cbb836b3de358ab05d4cbd92c4eb713dc74484cff9de82b2deb3d8527
+    files:
+      - name: landmarks-regression-retail-0009-fp16.xml
+        sha256: bcf274a704031d24af7fdd7f868f052e346cf96029b6b6e85cdc168beddbe401
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
+      - name: landmarks-regression-retail-0009-fp16.bin
+        sha256: 5d74c26cbb836b3de358ab05d4cbd92c4eb713dc74484cff9de82b2deb3d8527
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
     output: "Retail/object_attributes/landmarks_regression/0009/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "license-plate-recognition-barrier-0001"
     description: "Chinese license plate recognition"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
-    model_hash: 19fc9d960f1d18aa0f45c6a3018f5bb3422d2a7ff0db870aaa46a1bc1f13b74a
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
-    weights_hash: 16f07102e8e936f80d36e77126723b7ca1c4eaf99f0f4b9762d48aeb4e452a90
+    files:
+      - name: license-plate-recognition-barrier-0001.xml
+        sha256: 19fc9d960f1d18aa0f45c6a3018f5bb3422d2a7ff0db870aaa46a1bc1f13b74a
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
+      - name: license-plate-recognition-barrier-0001.bin
+        sha256: 16f07102e8e936f80d36e77126723b7ca1c4eaf99f0f4b9762d48aeb4e452a90
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
     output: "Security/optical_character_recognition/license_plate/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "license-plate-recognition-barrier-0001-fp16"
     description: "Chinese license plate recognition"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
-    model_hash: e7607025021490c84950f211ef6480547b7a30d0ffd3b72c43ebe0c04de315c8
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
-    weights_hash: 67f79aa7fe46b35b13a7c083520c2dcc1218b6104292a4a00da46fa8fcaf3fcf
+    files:
+      - name: license-plate-recognition-barrier-0001-fp16.xml
+        sha256: e7607025021490c84950f211ef6480547b7a30d0ffd3b72c43ebe0c04de315c8
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
+      - name: license-plate-recognition-barrier-0001-fp16.bin
+        sha256: 67f79aa7fe46b35b13a7c083520c2dcc1218b6104292a4a00da46fa8fcaf3fcf
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
     output: "Security/optical_character_recognition/license_plate/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "pedestrian-and-vehicle-detector-adas-0001"
     description: "Pedestrian and Vehicle detector based on ssd + mobilenet with reduced channels number."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
-    model_hash: 6455b1836781e62ccc5d699eeb4e1eb4adf598d7c4e6e1638d066ae08dda7007
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
-    weights_hash: 5919c7c49b557b389aa502894d3b2e6c213d36166e554d9a0726d2b06485acc6
+    files:
+      - name: pedestrian-and-vehicle-detector-adas-0001.xml
+        sha256: 6455b1836781e62ccc5d699eeb4e1eb4adf598d7c4e6e1638d066ae08dda7007
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
+      - name: pedestrian-and-vehicle-detector-adas-0001.bin
+        sha256: 5919c7c49b557b389aa502894d3b2e6c213d36166e554d9a0726d2b06485acc6
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
     output: "Transportation/object_detection/pedestrian-and-vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "pedestrian-and-vehicle-detector-adas-0001-fp16"
     description: "Pedestrian and Vehicle detector based on ssd + mobilenet with reduced channels number."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
-    model_hash: a9a6cf98fe6dbc033db0b8a7d57bcbe215d69447b28c32cb02dd9a9665e9b356
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
-    weights_hash: 8d162bdaf55d289cc8ce792b49d1416eff345ec58097f6231a5ec8dba9d2722e
+    files:
+      - name: pedestrian-and-vehicle-detector-adas-0001-fp16.xml
+        sha256: a9a6cf98fe6dbc033db0b8a7d57bcbe215d69447b28c32cb02dd9a9665e9b356
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
+      - name: pedestrian-and-vehicle-detector-adas-0001-fp16.bin
+        sha256: 8d162bdaf55d289cc8ce792b49d1416eff345ec58097f6231a5ec8dba9d2722e
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
     output: "Transportation/object_detection/pedestrian-and-vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "pedestrian-and-vehicle-detector-adas-0001-int8"
     description: "Pedestrian and Vehicle detector based on ssd + mobilenet with reduced channels number."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.xml
-    model_hash: 166849d75fc273fc3459d67258683153119ebabb95ce7556d5f883b395a73fbc
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.bin
-    weights_hash: 43d91e778368ec13aee4d1883bb70324f196a600b77d18d889c6568ebcda6e4e
+    files:
+      - name: pedestrian-and-vehicle-detector-adas-0001-int8.xml
+        sha256: 166849d75fc273fc3459d67258683153119ebabb95ce7556d5f883b395a73fbc
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.xml
+      - name: pedestrian-and-vehicle-detector-adas-0001-int8.bin
+        sha256: 43d91e778368ec13aee4d1883bb70324f196a600b77d18d889c6568ebcda6e4e
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.bin
     output: "Transportation/object_detection/pedestrian-and-vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "pedestrian-detection-adas-0002"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
-    model_hash: 255b8d15b0f424bda0ad206c0908e6fa46394f9d8f61018f175676af806e8854
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
-    weights_hash: cdf00f3882285d646d2e77b43bd2eef05d1ca88de048d352a3339c79b63767ff
+    files:
+      - name: pedestrian-detection-adas-0002.xml
+        sha256: 255b8d15b0f424bda0ad206c0908e6fa46394f9d8f61018f175676af806e8854
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
+      - name: pedestrian-detection-adas-0002.bin
+        sha256: cdf00f3882285d646d2e77b43bd2eef05d1ca88de048d352a3339c79b63767ff
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "pedestrian-detection-adas-0002-fp16"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
-    model_hash: be00995bfbd482115bcf4bb4ddc69322f1d92bff6eef064d8575f49f1e9248d2
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
-    weights_hash: ebc3f941934f1df17faf9379b4686745c5d2553ffa469c95e1cc950ea1d013c7
+    files:
+      - name: pedestrian-detection-adas-0002-fp16.xml
+        sha256: be00995bfbd482115bcf4bb4ddc69322f1d92bff6eef064d8575f49f1e9248d2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
+      - name: pedestrian-detection-adas-0002-fp16.bin
+        sha256: ebc3f941934f1df17faf9379b4686745c5d2553ffa469c95e1cc950ea1d013c7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "pedestrian-detection-adas-0002-int8"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.xml
-    model_hash: e4251d56e11da101e05a7fe273b27971cdc82abc351773bc0b42f58cbdbf0dc2
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.bin
-    weights_hash: 34753fc4edbbf5f0e7aaedf625000ffe74f443bf20b80cb49a7d2bfc45775e19
+    files:
+      - name: pedestrian-detection-adas-0002-int8.xml
+        sha256: e4251d56e11da101e05a7fe273b27971cdc82abc351773bc0b42f58cbdbf0dc2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.xml
+      - name: pedestrian-detection-adas-0002-int8.bin
+        sha256: 34753fc4edbbf5f0e7aaedf625000ffe74f443bf20b80cb49a7d2bfc45775e19
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.bin
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-attributes-recognition-crossroad-0230"
     description: "Pedestrian attributes recognition based on a PVANet with hyperfeatures backbone + classification head"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
-    model_hash: 2c5aaf5ded5ad7108b36333c0885e63a6b5200d59fdecc311502f2befc8a7c07
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
-    weights_hash: 1d1c392826e77373d87fd1d7c65ce238c615f729e5524f1dfbc07a3a6c0cf8db
+    files:
+      - name: person-attributes-recognition-crossroad-0230.xml
+        sha256: 2c5aaf5ded5ad7108b36333c0885e63a6b5200d59fdecc311502f2befc8a7c07
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
+      - name: person-attributes-recognition-crossroad-0230.bin
+        sha256: 1d1c392826e77373d87fd1d7c65ce238c615f729e5524f1dfbc07a3a6c0cf8db
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
     output: "Security/object_attributes/pedestrian/person-attributes-recognition-crossroad-0230/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-attributes-recognition-crossroad-0230-fp16"
     description: "Pedestrian attributes recognition based on a PVANet with hyperfeatures backbone + classification head"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
-    model_hash: 0ee68005a9703b32628b2b1d68c4abee815ab4667fcd2478e9517fbac9ca225b
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
-    weights_hash: 033c56ba8e93c03604e78b99f9b7e5ab07fa57cfd1d865cb62fc001744fc6e72
+    files:
+      - name: person-attributes-recognition-crossroad-0230-fp16.xml
+        sha256: 0ee68005a9703b32628b2b1d68c4abee815ab4667fcd2478e9517fbac9ca225b
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
+      - name: person-attributes-recognition-crossroad-0230-fp16.bin
+        sha256: 033c56ba8e93c03604e78b99f9b7e5ab07fa57cfd1d865cb62fc001744fc6e72
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
     output: "Security/object_attributes/pedestrian/person-attributes-recognition-crossroad-0230/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-action-recognition-0005"
     description: "Action detection (SSD-based) model."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
-    model_hash: d39d16f5f8de90e6f4a2eae51e3ecc44ebd1a78bf4f0bd113d39592166c14f7c
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
-    weights_hash: 57a2481289ab817945fc93b18fe4f15f45ae154f974d72f8e92e428a5b86bb5f
+    files:
+      - name: person-detection-action-recognition-0005.xml
+        sha256: d39d16f5f8de90e6f4a2eae51e3ecc44ebd1a78bf4f0bd113d39592166c14f7c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
+      - name: person-detection-action-recognition-0005.bin
+        sha256: 57a2481289ab817945fc93b18fe4f15f45ae154f974d72f8e92e428a5b86bb5f
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-action-recognition-0005-fp16"
     description: "Action detection (SSD-based) model."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
-    model_hash: b33df7fdc11a71eb05c63eb23cdb0fa3935bbfca85e8ac867e1610778e03396e
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
-    weights_hash: e76f97d714c7eae3bd9007e91e0906cb239ae0260a46efde860d95d6da84a6bc
+    files:
+      - name: person-detection-action-recognition-0005-fp16.xml
+        sha256: b33df7fdc11a71eb05c63eb23cdb0fa3935bbfca85e8ac867e1610778e03396e
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
+      - name: person-detection-action-recognition-0005-fp16.bin
+        sha256: e76f97d714c7eae3bd9007e91e0906cb239ae0260a46efde860d95d6da84a6bc
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-retail-0002"
     description: "Person detection (HyperNet+RFCN)."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
-    model_hash: bfacb328e853120e5fc8c42b7d123e3da64170eaf8ce72ddc067af1a6d74ddc7
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
-    weights_hash: c510c14c7d41c20782e288f60a955faf4a0fcc7cb6d92a7db6c0013431e01673
+    files:
+      - name: person-detection-retail-0002.xml
+        sha256: bfacb328e853120e5fc8c42b7d123e3da64170eaf8ce72ddc067af1a6d74ddc7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
+      - name: person-detection-retail-0002.bin
+        sha256: c510c14c7d41c20782e288f60a955faf4a0fcc7cb6d92a7db6c0013431e01673
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
     output: "Retail/object_detection/pedestrian/hypernet-rfcn/0026/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-retail-0002-fp16"
     description: "Person detection (HyperNet+RFCN+DetectionOutput)."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
-    model_hash: a209128472a8ce16e37305a13e54587754219ab472247830f813f835b4f5d68a
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
-    weights_hash: f14c44ebfec32e7aede4ebc1435e46e7ee8191f7c9c7bdc728c96560e6d45834
+    files:
+      - name: person-detection-retail-0002-fp16.xml
+        sha256: a209128472a8ce16e37305a13e54587754219ab472247830f813f835b4f5d68a
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
+      - name: person-detection-retail-0002-fp16.bin
+        sha256: f14c44ebfec32e7aede4ebc1435e46e7ee8191f7c9c7bdc728c96560e6d45834
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
     output: "Retail/object_detection/pedestrian/hypernet-rfcn/0026/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-retail-0013"
     description: "Pedestrian detection (RMNet with lrelu + SSD)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
-    model_hash: 0f6fc8657b45ba7216cada7546ba8bdd489e357578ee017386dad555b34e1ed6
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
-    weights_hash: 3d2c6572e6b6f845a1f2c23c32de958333f40b4ee6c3448201f00450a5b8c8d3
+    files:
+      - name: person-detection-retail-0013.xml
+        sha256: 0f6fc8657b45ba7216cada7546ba8bdd489e357578ee017386dad555b34e1ed6
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
+      - name: person-detection-retail-0013.bin
+        sha256: 3d2c6572e6b6f845a1f2c23c32de958333f40b4ee6c3448201f00450a5b8c8d3
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
     output: "Retail/object_detection/pedestrian/rmnet_ssd/0013/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-retail-0013-fp16"
     description: "Pedestrian detection (RMNet with lrelu + SSD)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
-    model_hash: f0a9f7d819dd79a4e03ee77d530ad822035817121abeff547dcacc736f0ce206
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
-    weights_hash: 5b65ddc561b86e48420f7942cd5762deebc8691d1d11dc7567842a8b4548bf93
+    files:
+      - name: person-detection-retail-0013-fp16.xml
+        sha256: f0a9f7d819dd79a4e03ee77d530ad822035817121abeff547dcacc736f0ce206
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
+      - name: person-detection-retail-0013-fp16.bin
+        sha256: 5b65ddc561b86e48420f7942cd5762deebc8691d1d11dc7567842a8b4548bf93
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
     output: "Retail/object_detection/pedestrian/rmnet_ssd/0013/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-reidentification-retail-0031"
     description: "Single embedding-based person reidentification model (fastest person ReID model)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
-    model_hash: cd8cd51352b6f5f5d734733c357d7505dc36d7db6e79e61d97a3ad80083aba4a
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.bin
-    weights_hash: 8b9d349d330909815d2e75b57654c4cd6c27eb37c87d3280dfeaae03d166a4f4
+    files:
+      - name: person-reidentification-retail-0031.xml
+        sha256: cd8cd51352b6f5f5d734733c357d7505dc36d7db6e79e61d97a3ad80083aba4a
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
+      - name: person-reidentification-retail-0031.bin
+        sha256: 8b9d349d330909815d2e75b57654c4cd6c27eb37c87d3280dfeaae03d166a4f4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.bin
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0031/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-reidentification-retail-0031-fp16"
     description: "Single embedding-based person reidentification model (fastest person ReID model)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
-    model_hash: c52a06b1c9332e5c1a87ad5eec35b46ed781f09faefa80bcbd090673273b814a
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.bin
-    weights_hash: 833c136bcce82bcba6de6289fc21ee24f24d4597e52c41717c2602ee275b2f7d
+    files:
+      - name: person-reidentification-retail-0031-fp16.xml
+        sha256: c52a06b1c9332e5c1a87ad5eec35b46ed781f09faefa80bcbd090673273b814a
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
+      - name: person-reidentification-retail-0031-fp16.bin
+        sha256: 833c136bcce82bcba6de6289fc21ee24f24d4597e52c41717c2602ee275b2f7d
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.bin
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0031/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-reidentification-retail-0076"
     description: "Single embedding-based person reidentification model (most accurate person ReID model)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP32/person-reidentification-retail-0076.xml
-    model_hash: d8ae8edd22583d518cd7322aee3dd4743e1dbdb7ab2ff4d8af2f782d2e9dfc6c
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP32/person-reidentification-retail-0076.bin
-    weights_hash: acd718a8e6bd0c9e52605ecfe3f5a7ba87280976315bccc94e9302bbe520d898
+    files:
+      - name: person-reidentification-retail-0076.xml
+        sha256: d8ae8edd22583d518cd7322aee3dd4743e1dbdb7ab2ff4d8af2f782d2e9dfc6c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP32/person-reidentification-retail-0076.xml
+      - name: person-reidentification-retail-0076.bin
+        sha256: acd718a8e6bd0c9e52605ecfe3f5a7ba87280976315bccc94e9302bbe520d898
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP32/person-reidentification-retail-0076.bin
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0076/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-reidentification-retail-0076-fp16"
     description: "Single embedding-based person reidentification model (most accurate person ReID model)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP16/person-reidentification-retail-0076.xml
-    model_hash: 4ce21984663dfbfece074e951883f9d6cebd320465d913fd0799b693a5dd4521
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP16/person-reidentification-retail-0076.bin
-    weights_hash: c8a127cb2b8ff5f26b1d248de5a07b79c916103ee39bec0825fb990e4b043fd6
+    files:
+      - name: person-reidentification-retail-0076-fp16.xml
+        sha256: 4ce21984663dfbfece074e951883f9d6cebd320465d913fd0799b693a5dd4521
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP16/person-reidentification-retail-0076.xml
+      - name: person-reidentification-retail-0076-fp16.bin
+        sha256: c8a127cb2b8ff5f26b1d248de5a07b79c916103ee39bec0825fb990e4b043fd6
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0076/FP16/person-reidentification-retail-0076.bin
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0076/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-reidentification-retail-0079"
     description: "Single embedding-based person reidentification model (the model is trade-off between performance and accuracy)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP32/person-reidentification-retail-0079.xml
-    model_hash: 82271346ae9487df85583eae591aeb588f1ca0ac48f7b8caf8b001b760aa8d05
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP32/person-reidentification-retail-0079.bin
-    weights_hash: e341d80b568d939dc121d2c4785d1f8bc90df477cd1754d0b286b2e24b7b33e4
+    files:
+      - name: person-reidentification-retail-0079.xml
+        sha256: 82271346ae9487df85583eae591aeb588f1ca0ac48f7b8caf8b001b760aa8d05
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP32/person-reidentification-retail-0079.xml
+      - name: person-reidentification-retail-0079.bin
+        sha256: e341d80b568d939dc121d2c4785d1f8bc90df477cd1754d0b286b2e24b7b33e4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP32/person-reidentification-retail-0079.bin
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0079/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-reidentification-retail-0079-fp16"
     description: "Single embedding-based person reidentification model (the model is trade-off between performance and accuracy)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP16/person-reidentification-retail-0079.xml
-    model_hash: b8f53174f7f7a02a01540042f4778a414ae1218e48bf5881d128b01f8dae88bd
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP16/person-reidentification-retail-0079.bin
-    weights_hash: 95c426b1d7e8f06f417172f5b1058bd906c769c8c10b3846f8b3adc826390d93
+    files:
+      - name: person-reidentification-retail-0079-fp16.xml
+        sha256: b8f53174f7f7a02a01540042f4778a414ae1218e48bf5881d128b01f8dae88bd
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP16/person-reidentification-retail-0079.xml
+      - name: person-reidentification-retail-0079-fp16.bin
+        sha256: 95c426b1d7e8f06f417172f5b1058bd906c769c8c10b3846f8b3adc826390d93
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-reidentification-retail-0079/FP16/person-reidentification-retail-0079.bin
     output: "Retail/object_reidentification/pedestrian/rmnet_based/0079/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-vehicle-bike-detection-crossroad-0078"
     description: "Multiclass (person, vehicle, non-vehicle) detector based on SSD detection architecture, RMNet backbone and learnable image downscale block"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
-    model_hash: f2e59c8b24fae359f577caaa58cf4485c5620aedf6b46aba9d83de8d1e4c78d2
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
-    weights_hash: d9969d9fbef7f69f1fe683344746953dd7638b6d9d323dc8aa8a58671dc46ca7
+    files:
+      - name: person-vehicle-bike-detection-crossroad-0078.xml
+        sha256: f2e59c8b24fae359f577caaa58cf4485c5620aedf6b46aba9d83de8d1e4c78d2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
+      - name: person-vehicle-bike-detection-crossroad-0078.bin
+        sha256: d9969d9fbef7f69f1fe683344746953dd7638b6d9d323dc8aa8a58671dc46ca7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
     output: "Security/object_detection/crossroad/0078/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-vehicle-bike-detection-crossroad-0078-fp16"
     description: "Multiclass (person, vehicle, non-vehicle) detector based on SSD detection architecture, RMNet backbone and learnable image downscale block"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
-    model_hash: 6dee99dc7fd212f5fa3b7eaac2eff1567f546435c640a849d016654be4e295b7
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
-    weights_hash: e1f9566a108510b68330080eb85e9a82becd64614c1570afaa5d4bcd1df00eaf
+    files:
+      - name: person-vehicle-bike-detection-crossroad-0078-fp16.xml
+        sha256: 6dee99dc7fd212f5fa3b7eaac2eff1567f546435c640a849d016654be4e295b7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
+      - name: person-vehicle-bike-detection-crossroad-0078-fp16.bin
+        sha256: e1f9566a108510b68330080eb85e9a82becd64614c1570afaa5d4bcd1df00eaf
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
     output: "Security/object_detection/crossroad/0078/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "road-segmentation-adas-0001"
     description: "Multiclass (BG, road, curbs, marks) segmentation based on ENET, using depthwise convolutions and without ELU operations and without concatenation"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
-    model_hash: cf3eea4fe64e6dfff7b758beaaf86e72ea7ff8c3c271d9da7879a7de8746499b
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
-    weights_hash: e4ec8fa66deb6904b5b6faa109fa699098cc1f947bf5216c6e31595ec397c569
+    files:
+      - name: road-segmentation-adas-0001.xml
+        sha256: cf3eea4fe64e6dfff7b758beaaf86e72ea7ff8c3c271d9da7879a7de8746499b
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
+      - name: road-segmentation-adas-0001.bin
+        sha256: e4ec8fa66deb6904b5b6faa109fa699098cc1f947bf5216c6e31595ec397c569
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
     output: "Transportation/segmentation/curbs/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "road-segmentation-adas-0001-fp16"
     description: "Multiclass (BG, road, curbs, marks) segmentation based on ENET, using depthwise convolutions and without ELU operations and without concatenation"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
-    model_hash: ad294f6070976ff45130e93dc382058f4b17d487cdd302e89780f7c3b30280dc
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
-    weights_hash: 292b8c8789d66f102ffb9b87104b39488bfa55293ef97e7d6a50439762cdd884
+    files:
+      - name: road-segmentation-adas-0001-fp16.xml
+        sha256: ad294f6070976ff45130e93dc382058f4b17d487cdd302e89780f7c3b30280dc
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
+      - name: road-segmentation-adas-0001-fp16.bin
+        sha256: 292b8c8789d66f102ffb9b87104b39488bfa55293ef97e7d6a50439762cdd884
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
     output: "Transportation/segmentation/curbs/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "road-segmentation-adas-0001-int8"
     description: "Multiclass (BG, road, curbs, marks) segmentation based on ENET, using depthwise convolutions and without ELU operations and without concatenation"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/INT8/road-segmentation-adas-0001.xml
-    model_hash: 891a58c1b62d343ebb05038010c527ab05b0122bc03c4e7be39be19b30048ae0
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/INT8/road-segmentation-adas-0001.bin
-    weights_hash: f300192b35c71717aebefdc24a1b8ba117e21c6c5eb13dc667f3f5c7bb3a722e
+    files:
+      - name: road-segmentation-adas-0001-int8.xml
+        sha256: 891a58c1b62d343ebb05038010c527ab05b0122bc03c4e7be39be19b30048ae0
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/INT8/road-segmentation-adas-0001.xml
+      - name: road-segmentation-adas-0001-int8.bin
+        sha256: f300192b35c71717aebefdc24a1b8ba117e21c6c5eb13dc667f3f5c7bb3a722e
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/road-segmentation-adas-0001/INT8/road-segmentation-adas-0001.bin
     output: "Transportation/segmentation/curbs/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "semantic-segmentation-adas-0001"
     description: "Multiclass (road, sidewalk, building, wall, fence, pole, traffic light, traffic sign, vegetation, terrain, sky, person, rider, car, truck, bus, train, motorcycle, bicycle, ego-vehicle) segmentation based on ICNet"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
-    model_hash: 4e86d8cab9778dcb85eac3856cfa7b13516ccdc922a47e00a764e159972cca92
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
-    weights_hash: 5a616b105fa42f574e4d23cfc227c10b8bdcc0ba0e66864d7aa4b8a269b7cc76
+    files:
+      - name: semantic-segmentation-adas-0001.xml
+        sha256: 4e86d8cab9778dcb85eac3856cfa7b13516ccdc922a47e00a764e159972cca92
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
+      - name: semantic-segmentation-adas-0001.bin
+        sha256: 5a616b105fa42f574e4d23cfc227c10b8bdcc0ba0e66864d7aa4b8a269b7cc76
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
     output: "Transportation/segmentation/semantic_segmentation/icnet_icv/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "semantic-segmentation-adas-0001-fp16"
     description: "Multiclass (road, sidewalk, building, wall, fence, pole, traffic light, traffic sign, vegetation, terrain, sky, person, rider, car, truck, bus, train, motorcycle, bicycle, ego-vehicle) segmentation based on ICNet"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
-    model_hash: 10696961209fbdf6106196b4aa8574aa2311031eae568a5e0f1583ab9c6f1d1d
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
-    weights_hash: 8c39dcb0d3569003264165eda163833eef2d0803121147ab06f46697e4f8b4c4
+    files:
+      - name: semantic-segmentation-adas-0001-fp16.xml
+        sha256: 10696961209fbdf6106196b4aa8574aa2311031eae568a5e0f1583ab9c6f1d1d
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
+      - name: semantic-segmentation-adas-0001-fp16.bin
+        sha256: 8c39dcb0d3569003264165eda163833eef2d0803121147ab06f46697e4f8b4c4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
     output: "Transportation/segmentation/semantic_segmentation/icnet_icv/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "single-image-super-resolution-1033"
     description: "Super resolution model based on SRResNet architecture (see https://arxiv.org/pdf/1609.04802.pdf)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
-    model_hash: 7314cb08b98e6287cb7ed25fa06d969bd7aa4dd605e940953b912e3bf1eeeae2
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
-    weights_hash: eab6008bc5c2773199078402d4ad68072e0d4a7bfc5c6b7bcfe7d8230ea5eb5b
+    files:
+      - name: single-image-super-resolution-1033.xml
+        sha256: 7314cb08b98e6287cb7ed25fa06d969bd7aa4dd605e940953b912e3bf1eeeae2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
+      - name: single-image-super-resolution-1033.bin
+        sha256: eab6008bc5c2773199078402d4ad68072e0d4a7bfc5c6b7bcfe7d8230ea5eb5b
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
     output: "Security/super_resolution/srresnet/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "single-image-super-resolution-1033-fp16"
     description: "Super resolution model based on SRResNet architecture (see https://arxiv.org/pdf/1609.04802.pdf)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
-    model_hash: 09548920b37974d6bcbd5ed6d03825da363062dddba86fcc72ab2a56e4bbc0f5
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
-    weights_hash: 4288e8ad4e9a8a6829b186aeb7e4112db1c7e971f935c3271c5ce47c7379cfbe
+    files:
+      - name: single-image-super-resolution-1033-fp16.xml
+        sha256: 09548920b37974d6bcbd5ed6d03825da363062dddba86fcc72ab2a56e4bbc0f5
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
+      - name: single-image-super-resolution-1033-fp16.bin
+        sha256: 4288e8ad4e9a8a6829b186aeb7e4112db1c7e971f935c3271c5ce47c7379cfbe
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
     output: "Security/super_resolution/srresnet/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "text-detection-0002"
     description: "Detects oriented text."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP32/text-detection-0002.xml
-    model_hash: 0c9bbaa480bbbf6be0bea431494b9478dd61c84c31b3a454784a012b7031a872
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP32/text-detection-0002.bin
-    weights_hash: fd2cdb0d70d816361c156fbc42a3363535009e1a7140494a4fb1acc7acbe4555
+    files:
+      - name: text-detection-0002.xml
+        sha256: 0c9bbaa480bbbf6be0bea431494b9478dd61c84c31b3a454784a012b7031a872
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP32/text-detection-0002.xml
+      - name: text-detection-0002.bin
+        sha256: fd2cdb0d70d816361c156fbc42a3363535009e1a7140494a4fb1acc7acbe4555
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP32/text-detection-0002.bin
     output: "Retail/object_detection/text/pixel_link_mobilenet_v2/0001/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "text-detection-0002-fp16"
     description: "Detects oriented text."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP16/text-detection-0002.xml
-    model_hash: 6193001bbef96a6f40fd3f0cc1726669baff9f1a5a6bcaa9d0eb9cda5f9513b4
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP16/text-detection-0002.bin
-    weights_hash: 18508f0fc72bb142d50e00326dfbba63a54143f3cae4f54f8833b2e4d9891b0d
+    files:
+      - name: text-detection-0002-fp16.xml
+        sha256: 6193001bbef96a6f40fd3f0cc1726669baff9f1a5a6bcaa9d0eb9cda5f9513b4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP16/text-detection-0002.xml
+      - name: text-detection-0002-fp16.bin
+        sha256: 18508f0fc72bb142d50e00326dfbba63a54143f3cae4f54f8833b2e4d9891b0d
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-detection-0002/FP16/text-detection-0002.bin
     output: "Retail/object_detection/text/pixel_link_mobilenet_v2/0001/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-attributes-recognition-barrier-0039"
     description: "Vehicle attributes recognition with modified ResNet10 backbone"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
-    model_hash: 7dc03429bbba0f588d37dfcbe1fe82c149cf624f3e19967c9f88c087f76f8f4c
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
-    weights_hash: 8195ea60216d9aefdab41e3129900aa847f4f0d3d003ce93aa15ecba0ca18e91
+    files:
+      - name: vehicle-attributes-recognition-barrier-0039.xml
+        sha256: 7dc03429bbba0f588d37dfcbe1fe82c149cf624f3e19967c9f88c087f76f8f4c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
+      - name: vehicle-attributes-recognition-barrier-0039.bin
+        sha256: 8195ea60216d9aefdab41e3129900aa847f4f0d3d003ce93aa15ecba0ca18e91
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
     output: "Security/object_attributes/vehicle/resnet10_update_1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-attributes-recognition-barrier-0039-fp16"
     description: "Vehicle attributes recognition with modified ResNet10 backbone"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
-    model_hash: 4987bda5dfc22429f9bc41f48ae9f8ac075224152551e8d90694657494707955
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
-    weights_hash: be8b61e337a23ffa57d1742f92d2317560303652f330fef0cbe918161bfcaf50
+    files:
+      - name: vehicle-attributes-recognition-barrier-0039-fp16.xml
+        sha256: 4987bda5dfc22429f9bc41f48ae9f8ac075224152551e8d90694657494707955
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
+      - name: vehicle-attributes-recognition-barrier-0039-fp16.bin
+        sha256: be8b61e337a23ffa57d1742f92d2317560303652f330fef0cbe918161bfcaf50
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
     output: "Security/object_attributes/vehicle/resnet10_update_1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-attributes-recognition-barrier-0039-int8"
     description: "Vehicle attributes recognition with modified ResNet10 backbone"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/INT8/vehicle-attributes-recognition-barrier-0039.xml
-    model_hash: 6b78a13e44ad3c7e6247061aec582e311d1d0b336a288bef1aceaa3d5147f0b1
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/INT8/vehicle-attributes-recognition-barrier-0039.bin
-    weights_hash: 4ca9587b866ecc92418b87424ec5becb05f73a9781cd2eab6abeff7a54067590
+    files:
+      - name: vehicle-attributes-recognition-barrier-0039-int8.xml
+        sha256: 6b78a13e44ad3c7e6247061aec582e311d1d0b336a288bef1aceaa3d5147f0b1
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/INT8/vehicle-attributes-recognition-barrier-0039.xml
+      - name: vehicle-attributes-recognition-barrier-0039-int8.bin
+        sha256: 4ca9587b866ecc92418b87424ec5becb05f73a9781cd2eab6abeff7a54067590
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-attributes-recognition-barrier-0039/INT8/vehicle-attributes-recognition-barrier-0039.bin
     output: "Security/object_attributes/vehicle/resnet10_update_1/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-detection-adas-0002"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
-    model_hash: 79245ea24591f452b60498b9b5930870a4b00caca9f8a0b5e83c0a6d57b507dc
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
-    weights_hash: a3046a4d72eb8a382ae3056533f570e3e9b049d463a3b33bfe20bd1dc8f9c0e4
+    files:
+      - name: vehicle-detection-adas-0002.xml
+        sha256: 79245ea24591f452b60498b9b5930870a4b00caca9f8a0b5e83c0a6d57b507dc
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
+      - name: vehicle-detection-adas-0002.bin
+        sha256: a3046a4d72eb8a382ae3056533f570e3e9b049d463a3b33bfe20bd1dc8f9c0e4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-detection-adas-0002-fp16"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
-    model_hash: d31ba2739f3aa953a17b1f645b77045e6116e3f890bd044414125c2965f8b654
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
-    weights_hash: 257a2a9c27ca3d3f5b515f982c3af50683ade869be966e57f0f04f2d95073714
+    files:
+      - name: vehicle-detection-adas-0002-fp16.xml
+        sha256: d31ba2739f3aa953a17b1f645b77045e6116e3f890bd044414125c2965f8b654
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
+      - name: vehicle-detection-adas-0002-fp16.bin
+        sha256: 257a2a9c27ca3d3f5b515f982c3af50683ade869be966e57f0f04f2d95073714
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-detection-adas-0002-int8"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.xml
-    model_hash: 40f9090d64ec72236e6b95a6f00220e8e5779e05fc4079febb22ad72b9bcd44f
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.bin
-    weights_hash: d529c1303bf5ab92167a304591cbb82a58655a949f13c56d88dacc89c536be1d
+    files:
+      - name: vehicle-detection-adas-0002-int8.xml
+        sha256: 40f9090d64ec72236e6b95a6f00220e8e5779e05fc4079febb22ad72b9bcd44f
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.xml
+      - name: vehicle-detection-adas-0002-int8.bin
+        sha256: d529c1303bf5ab92167a304591cbb82a58655a949f13c56d88dacc89c536be1d
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.bin
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-license-plate-detection-barrier-0106"
     description: "Multiclass (vehicle, license plates) detector based on MobileNetV2+SSD"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
-    model_hash: 0d5fd522c226547b7aaae690d78f786ca5ff7a9ae0433f9a19d7d7cd225381a3
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
-    weights_hash: abf00b35146445fd6d11afb467d48558dbeba0cc11d87968171d20373d4cc613
+    files:
+      - name: vehicle-license-plate-detection-barrier-0106.xml
+        sha256: 0d5fd522c226547b7aaae690d78f786ca5ff7a9ae0433f9a19d7d7cd225381a3
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
+      - name: vehicle-license-plate-detection-barrier-0106.bin
+        sha256: abf00b35146445fd6d11afb467d48558dbeba0cc11d87968171d20373d4cc613
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
     output: "Security/object_detection/barrier/0106/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-license-plate-detection-barrier-0106-fp16"
     description: "Multiclass (vehicle, license plates) detector based on MobileNetV2+SSD"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
-    model_hash: 9ad78ae598376addd0e1fe859790cd07a96f76f1ac198a55aeb80243df8645aa
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
-    weights_hash: 8899c10509ad8dfd029c845bcc409976a56c46f73f3354044f243f0bba9c6b97
+    files:
+      - name: vehicle-license-plate-detection-barrier-0106-fp16.xml
+        sha256: 9ad78ae598376addd0e1fe859790cd07a96f76f1ac198a55aeb80243df8645aa
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
+      - name: vehicle-license-plate-detection-barrier-0106-fp16.bin
+        sha256: 8899c10509ad8dfd029c845bcc409976a56c46f73f3354044f243f0bba9c6b97
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
     output: "Security/object_detection/barrier/0106/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "face-detection-adas-binary-0001"
     description: "Face Detection (MobileNet with reduced channels and binary convolution + SSD with weights sharing)"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-binary-0001/INT1/face-detection-adas-binary-0001.xml
-    model_hash: fde8c465a5e3f3425fb567d31b9591ff8be589930c8488639f8feddf7f0301f2
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-binary-0001/INT1/face-detection-adas-binary-0001.bin
-    weights_hash: 0e0742b61fb924e937a8974da8a2e15cc6afc15630afa3f220676ee7a3a99700
+    files:
+      - name: face-detection-adas-binary-0001.xml
+        sha256: fde8c465a5e3f3425fb567d31b9591ff8be589930c8488639f8feddf7f0301f2
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-binary-0001/INT1/face-detection-adas-binary-0001.xml
+      - name: face-detection-adas-binary-0001.bin
+        sha256: 0e0742b61fb924e937a8974da8a2e15cc6afc15630afa3f220676ee7a3a99700
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/face-detection-adas-binary-0001/INT1/face-detection-adas-binary-0001.bin
     output: "Transportation/object_detection/face/pruned_mobilenet_reduced_ssd_shared_weights_binary/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "single-image-super-resolution-1032"
     description: "Super resolution model"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
-    model_hash: cee9c808e3cf9f9c640a01cd445c4bdb518de9202d90fb2d78281456ebecb7a4
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
-    weights_hash: 4840a2f6d1793052b5b0cd5f5da4d69315831b044951c413a267ccf923ef7ebd
+    files:
+      - name: single-image-super-resolution-1032.xml
+        sha256: cee9c808e3cf9f9c640a01cd445c4bdb518de9202d90fb2d78281456ebecb7a4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
+      - name: single-image-super-resolution-1032.bin
+        sha256: 4840a2f6d1793052b5b0cd5f5da4d69315831b044951c413a267ccf923ef7ebd
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
     output: "Security/super_resolution/srresnet/dldt/1032/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "single-image-super-resolution-1032-fp16"
     description: "Super resolution model"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
-    model_hash: a6e670402d9f2b34ca4721bb89196a5e018daaee0e47de61ac5aedbadaa49529
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
-    weights_hash: 3a1b4aeab87229c5f91f16c0d6672f6cc185238674f5a967d7098dccc970e5ce
+    files:
+      - name: single-image-super-resolution-1032-fp16.xml
+        sha256: a6e670402d9f2b34ca4721bb89196a5e018daaee0e47de61ac5aedbadaa49529
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
+      - name: single-image-super-resolution-1032-fp16.bin
+        sha256: 3a1b4aeab87229c5f91f16c0d6672f6cc185238674f5a967d7098dccc970e5ce
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
     output: "Security/super_resolution/srresnet/dldt/1032/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "action-recognition-0001-encoder"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Encoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
-    model_hash: 88338f18f82dfb2d9843735a9d7352e2fe04ce1053280044aa7993be1770f167
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
-    weights_hash: 35e1454bdac521c7b7664db9b26aebda2bba6944e9da225e9884c0241021d92a
+    files:
+      - name: action-recognition-0001-encoder.xml
+        sha256: 88338f18f82dfb2d9843735a9d7352e2fe04ce1053280044aa7993be1770f167
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
+      - name: action-recognition-0001-encoder.bin
+        sha256: 35e1454bdac521c7b7664db9b26aebda2bba6944e9da225e9884c0241021d92a
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "action-recognition-0001-encoder-fp16"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Encoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
-    model_hash: 852ae9a90dce025e0a0d95af94de54c58686bf3032d74c8fd5e32337fe4055fb
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
-    weights_hash: f6347d5c4baf60581d0179a90702180798cb5f3d76079e919493d50f81406e14
+    files:
+      - name: action-recognition-0001-encoder-fp16.xml
+        sha256: 852ae9a90dce025e0a0d95af94de54c58686bf3032d74c8fd5e32337fe4055fb
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
+      - name: action-recognition-0001-encoder-fp16.bin
+        sha256: f6347d5c4baf60581d0179a90702180798cb5f3d76079e919493d50f81406e14
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "instance-segmentation-security-0049"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNet50 backbone, FPN block and light segmentation head."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP32/instance-segmentation-security-0049.xml
-    model_hash: b059a10f5aec72aada8f322fe02787fca26fab94580814496978854e37d16b06
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP32/instance-segmentation-security-0049.bin
-    weights_hash: 7565934ca333d2c7ae6978d47a22e12f94e96101b3743aa28fd98886362be807
+    files:
+      - name: instance-segmentation-security-0049.xml
+        sha256: b059a10f5aec72aada8f322fe02787fca26fab94580814496978854e37d16b06
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP32/instance-segmentation-security-0049.xml
+      - name: instance-segmentation-security-0049.bin
+        sha256: 7565934ca333d2c7ae6978d47a22e12f94e96101b3743aa28fd98886362be807
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP32/instance-segmentation-security-0049.bin
     output: "Security/instance_segmentation/common/0049/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "instance-segmentation-security-0049-fp16"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNet50 backbone, FPN block and light segmentation head."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP16/instance-segmentation-security-0049.xml
-    model_hash: 0723349aec16f7382b0e1778a2765ce87db236ab0de6220cd31775c3f1c05462
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP16/instance-segmentation-security-0049.bin
-    weights_hash: 60ebee3bd3da59971499398eaa466dffe0a8230cf7c880b014004a70fefd3473
+    files:
+      - name: instance-segmentation-security-0049-fp16.xml
+        sha256: 0723349aec16f7382b0e1778a2765ce87db236ab0de6220cd31775c3f1c05462
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP16/instance-segmentation-security-0049.xml
+      - name: instance-segmentation-security-0049-fp16.bin
+        sha256: 60ebee3bd3da59971499398eaa466dffe0a8230cf7c880b014004a70fefd3473
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0049/FP16/instance-segmentation-security-0049.bin
     output: "Security/instance_segmentation/common/0049/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "vehicle-detection-adas-binary-0001"
     description: "Vehicle detector based on SSD + MobileNet with reduced number of channels and depthwise head and binary layers."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.xml
-    model_hash: c98bf5984895b1309861597ec36181446877407cd985bb490e14461f41312670
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.bin
-    weights_hash: afdd8a2f175b2f19c07083ff23b2e28105f3d1c7dc06a4b1a1d5c2c42b98294f
+    files:
+      - name: vehicle-detection-adas-binary-0001.xml
+        sha256: c98bf5984895b1309861597ec36181446877407cd985bb490e14461f41312670
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.xml
+      - name: vehicle-detection-adas-binary-0001.bin
+        sha256: afdd8a2f175b2f19c07083ff23b2e28105f3d1c7dc06a4b1a1d5c2c42b98294f
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.bin
     output: "Transportation/object_detection/vehicle/mobilenet-reduced-ssd-binary/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "driver-action-recognition-adas-0002-decoder"
     description: "Video Transformer Network for driver action recognition. Decoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
-    model_hash: 90f4d84e8d237647fd2b23f0245bbc63b55fca625dd10fd2778afb51aa99e8d7
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
-    weights_hash: c4c302f54a79364e672e91b7c202275545cff1468ad0a6b226c45baac0082e71
+    files:
+      - name: driver-action-recognition-adas-0002-decoder.xml
+        sha256: 90f4d84e8d237647fd2b23f0245bbc63b55fca625dd10fd2778afb51aa99e8d7
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
+      - name: driver-action-recognition-adas-0002-decoder.bin
+        sha256: c4c302f54a79364e672e91b7c202275545cff1468ad0a6b226c45baac0082e71
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "driver-action-recognition-adas-0002-decoder-fp16"
     description: "Video Transformer Network for driver action recognition. Decoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
-    model_hash: d85192c526c537280d35cf369af98ffe205612088a143f7fcb92eb4c94b38006
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
-    weights_hash: d2d0396bddaf5c7b47c8198806c773ad48516f9c3c8d1abe724187fda8ad0b66
+    files:
+      - name: driver-action-recognition-adas-0002-decoder-fp16.xml
+        sha256: d85192c526c537280d35cf369af98ffe205612088a143f7fcb92eb4c94b38006
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
+      - name: driver-action-recognition-adas-0002-decoder-fp16.bin
+        sha256: d2d0396bddaf5c7b47c8198806c773ad48516f9c3c8d1abe724187fda8ad0b66
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "pedestrian-detection-adas-binary-0001"
     description: "Pedestrian detector based on ssd + mobilenet with reduced channels number binary layers."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.xml
-    model_hash: e64e7ce32c87e1c698b50abb8f2cf1d96c7651d45fc20bac09c417e046afa7f4
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.bin
-    weights_hash: 7c2761ca3859ef55a80d9ed924225df7ba363fcb151e4ec2f7d1061b70bdb374
+    files:
+      - name: pedestrian-detection-adas-binary-0001.xml
+        sha256: e64e7ce32c87e1c698b50abb8f2cf1d96c7651d45fc20bac09c417e046afa7f4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.xml
+      - name: pedestrian-detection-adas-binary-0001.bin
+        sha256: 7c2761ca3859ef55a80d9ed924225df7ba363fcb151e4ec2f7d1061b70bdb374
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.bin
     output: "Transportation/object_detection/pedestrian/mobilenet-reduced-ssd-binary/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-action-recognition-teacher-0002"
     description: "Second generation of action detection (SSD-based) model to use in Smart Classroom for classification teacher's actions."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
-    model_hash: fa3d9d2d8da10f4c63291a6b89589453849b94edd079fe92a219f15c179cc8a9
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
-    weights_hash: 231e01a33e8ceec66af07a54991c4611ec74a5e5f3070ac9482f4ab242b10d46
+    files:
+      - name: person-detection-action-recognition-teacher-0002.xml
+        sha256: fa3d9d2d8da10f4c63291a6b89589453849b94edd079fe92a219f15c179cc8a9
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
+      - name: person-detection-action-recognition-teacher-0002.bin
+        sha256: 231e01a33e8ceec66af07a54991c4611ec74a5e5f3070ac9482f4ab242b10d46
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
     output:  "Retail/action_detection/teacher/rmnet_ssd/0005_cut/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-action-recognition-teacher-0002-fp16"
     description: "Second generation of action detection (SSD-based) model to use in Smart Classroom for classification teacher's actions."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
-    model_hash: ad5b89b88ab04c05cb3b9fc5b968a027434719030b76f4538b6c944078338ac4
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
-    weights_hash: 22a0d3c984a66ab48ba4857b428dc4433224ff2dbdb0dd57ccb83153ef4d3275
+    files:
+      - name: person-detection-action-recognition-teacher-0002-fp16.xml
+        sha256: ad5b89b88ab04c05cb3b9fc5b968a027434719030b76f4538b6c944078338ac4
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
+      - name: person-detection-action-recognition-teacher-0002-fp16.bin
+        sha256: 22a0d3c984a66ab48ba4857b428dc4433224ff2dbdb0dd57ccb83153ef4d3275
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
     output:  "Retail/action_detection/teacher/rmnet_ssd/0005_cut/dldt"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "instance-segmentation-security-0033"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNeXt152 backbone and FPN block."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP32/instance-segmentation-security-0033.xml
-    model_hash: 2dc0e866c37247702076b8a225870b58bc48b6adaef972308dce0c78a3372e70
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP32/instance-segmentation-security-0033.bin
-    weights_hash: 1f496c48b4fc8ebc38f0ffb7ba82d638ff1ad2209ac9f504f7228e85a4d41f11
+    files:
+      - name: instance-segmentation-security-0033.xml
+        sha256: 2dc0e866c37247702076b8a225870b58bc48b6adaef972308dce0c78a3372e70
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP32/instance-segmentation-security-0033.xml
+      - name: instance-segmentation-security-0033.bin
+        sha256: 1f496c48b4fc8ebc38f0ffb7ba82d638ff1ad2209ac9f504f7228e85a4d41f11
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP32/instance-segmentation-security-0033.bin
     output: "Security/instance_segmentation/common/0033/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "instance-segmentation-security-0033-fp16"
     description: "General purpose instance segmentation model. Mask-RCNN with ResNeXt152 backbone and FPN block."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP16/instance-segmentation-security-0033.xml
-    model_hash: 68c967b026008cf6750c02846d25dec1f072fd43127a5b852998432b4ef034fb
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP16/instance-segmentation-security-0033.bin
-    weights_hash: 694b9bc747ffb441dc8749deda3016004fe94fd8d67598d3ded557d28de29887
+    files:
+      - name: instance-segmentation-security-0033-fp16.xml
+        sha256: 68c967b026008cf6750c02846d25dec1f072fd43127a5b852998432b4ef034fb
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP16/instance-segmentation-security-0033.xml
+      - name: instance-segmentation-security-0033-fp16.bin
+        sha256: 694b9bc747ffb441dc8749deda3016004fe94fd8d67598d3ded557d28de29887
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/instance-segmentation-security-0033/FP16/instance-segmentation-security-0033.bin
     output: "Security/instance_segmentation/common/0033/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "action-recognition-0001-decoder"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Decoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
-    model_hash: eeda01c569bb41af0714fb3714e85d5e532fc3819adb0ad9323b97feddf87b34
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
-    weights_hash: a840e506f821d927fda6f7dfa597adae29b0d68363727d0b31f56a7c4dfd80b5
+    files:
+      - name: action-recognition-0001-decoder.xml
+        sha256: eeda01c569bb41af0714fb3714e85d5e532fc3819adb0ad9323b97feddf87b34
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
+      - name: action-recognition-0001-decoder.bin
+        sha256: a840e506f821d927fda6f7dfa597adae29b0d68363727d0b31f56a7c4dfd80b5
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "action-recognition-0001-decoder-fp16"
     description: "General-purpose action recognition model for Kinetics-400 dataset based on Video Transformer Network approach. Decoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
-    model_hash: 220f09742e7ee77b44b1cab3491ac792a004ec6eb1551211b29e7c32c85ff0a0
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
-    weights_hash: 4ffa032a282559da0fd6a27dcb69d81dce7237574f1dde9e1c97478e109c96a6
+    files:
+      - name: action-recognition-0001-decoder-fp16.xml
+        sha256: 220f09742e7ee77b44b1cab3491ac792a004ec6eb1551211b29e7c32c85ff0a0
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
+      - name: action-recognition-0001-decoder-fp16.bin
+        sha256: 4ffa032a282559da0fd6a27dcb69d81dce7237574f1dde9e1c97478e109c96a6
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
     output: "Transportation/action_recognition/resnet34_vtn/kinetics/decoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "text-recognition-0012"
     description: "Recognizes alphanumeric text. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP32/text-recognition-0012.xml
-    model_hash: 71158750324de227342acec7b2edca95d5991be2242eaf3a0c54877c32dc9dff
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP32/text-recognition-0012.bin
-    weights_hash: d057d4536805ce4529876964e8277a21dbcfae4a65a7762417b4c884cb866347
+    files:
+      - name: text-recognition-0012.xml
+        sha256: 71158750324de227342acec7b2edca95d5991be2242eaf3a0c54877c32dc9dff
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP32/text-recognition-0012.xml
+      - name: text-recognition-0012.bin
+        sha256: d057d4536805ce4529876964e8277a21dbcfae4a65a7762417b4c884cb866347
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP32/text-recognition-0012.bin
     output: "Retail/text_recognition/bilstm_crnn_bilstm_decoder/0012/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "text-recognition-0012-fp16"
     description: "Recognizes alphanumeric text. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP16/text-recognition-0012.xml
-    model_hash: 322f6c6902714b81084bc71f560af2a6df69581181549e3d640ddef153c13b9e
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP16/text-recognition-0012.bin
-    weights_hash: 9f75d14d812695b71212f6fb92feffa42d8a75312d7c58c0fc6af3ff17a6c166
+    files:
+      - name: text-recognition-0012-fp16.xml
+        sha256: 322f6c6902714b81084bc71f560af2a6df69581181549e3d640ddef153c13b9e
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP16/text-recognition-0012.xml
+      - name: text-recognition-0012-fp16.bin
+        sha256: 9f75d14d812695b71212f6fb92feffa42d8a75312d7c58c0fc6af3ff17a6c166
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/text-recognition-0012/FP16/text-recognition-0012.bin
     output: "Retail/text_recognition/bilstm_crnn_bilstm_decoder/0012/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "driver-action-recognition-adas-0002-encoder"
     description: "Video Transformer Network for driver action recognition. Encoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
-    model_hash: b8625862f80388a63c3229824be44a75cb1baffdbd4fe00c560e7cdfc03f2b8d
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
-    weights_hash: f49782784647b4d84520d83b1260054ed6d6ce4c3da49e92357f64727a147805
+    files:
+      - name: driver-action-recognition-adas-0002-encoder.xml
+        sha256: b8625862f80388a63c3229824be44a75cb1baffdbd4fe00c560e7cdfc03f2b8d
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
+      - name: driver-action-recognition-adas-0002-encoder.bin
+        sha256: f49782784647b4d84520d83b1260054ed6d6ce4c3da49e92357f64727a147805
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "driver-action-recognition-adas-0002-encoder-fp16"
     description: "Video Transformer Network for driver action recognition. Encoder part"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
-    model_hash: a20c385b32b426db15eb0554a8428c8239aa3fbc7e63894f332d6ad4af65969c
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
-    weights_hash: cc6619627ded268452836220c8f23d228d674c94349778219ab032e611b6983f
+    files:
+      - name: driver-action-recognition-adas-0002-encoder-fp16.xml
+        sha256: a20c385b32b426db15eb0554a8428c8239aa3fbc7e63894f332d6ad4af65969c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
+      - name: driver-action-recognition-adas-0002-encoder-fp16.bin
+        sha256: cc6619627ded268452836220c8f23d228d674c94349778219ab032e611b6983f
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
     output: "Transportation/action_recognition/driver_monitoring/mobilenetv2/encoder/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "gaze-estimation-adas-0002"
     description: "Gaze estimation for ADAS"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
-    model_hash: b4860d52445836f5a1d4bce65e43054ffdbb0c9c9b75973abc93718f70b5baec
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
-    weights_hash: 9c48f7595d1dbb13dded4371e165401c9acc04c4018e8d3e05148c8a98f88727
+    files:
+      - name: gaze-estimation-adas-0002.xml
+        sha256: b4860d52445836f5a1d4bce65e43054ffdbb0c9c9b75973abc93718f70b5baec
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
+      - name: gaze-estimation-adas-0002.bin
+        sha256: 9c48f7595d1dbb13dded4371e165401c9acc04c4018e8d3e05148c8a98f88727
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
     output: "Transportation/object_attributes/gaze/custom-architecture/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "gaze-estimation-adas-0002-fp16"
     description: "Gaze estimation for ADAS"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
-    model_hash: 48724b449b8f379f646141411530342078cc738306e78fed3c969d83e8fd58e0
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
-    weights_hash: f10fae31d4bc925ea1b38f528a0adc7bde4b01badb427597bad0703e7adc947d
+    files:
+      - name: gaze-estimation-adas-0002-fp16.xml
+        sha256: 48724b449b8f379f646141411530342078cc738306e78fed3c969d83e8fd58e0
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
+      - name: gaze-estimation-adas-0002-fp16.bin
+        sha256: f10fae31d4bc925ea1b38f528a0adc7bde4b01badb427597bad0703e7adc947d
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
     output: "Transportation/object_attributes/gaze/custom-architecture/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "gaze-estimation-adas-0002-int8"
     description: "Gaze estimation for ADAS"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/INT8/gaze-estimation-adas-0002.xml
-    model_hash: 580c768b167d78039ccec566e6c5bde3a82d5aee785867423bc867c78ce57247
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/INT8/gaze-estimation-adas-0002.bin
-    weights_hash: 5e9651470495b1b4b31e6d4cdb44b721b0d82aeeea13e24c5cfd9ad0629b4d6c
+    files:
+      - name: gaze-estimation-adas-0002-int8.xml
+        sha256: 580c768b167d78039ccec566e6c5bde3a82d5aee785867423bc867c78ce57247
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/INT8/gaze-estimation-adas-0002.xml
+      - name: gaze-estimation-adas-0002-int8.bin
+        sha256: 5e9651470495b1b4b31e6d4cdb44b721b0d82aeeea13e24c5cfd9ad0629b4d6c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/gaze-estimation-adas-0002/INT8/gaze-estimation-adas-0002.bin
     output: "Transportation/object_attributes/gaze/custom-architecture/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "resnet50-binary-0001"
     description: "ResNet-50 Binary"
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/resnet50-binary-0001/INT1/resnet50-binary-0001.xml
-    model_hash: 1a7e41ab273f9e7b064e60e889ba2f13ce1b07cb4610096bd3abef33a93bf992
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/resnet50-binary-0001/INT1/resnet50-binary-0001.bin
-    weights_hash: e843a458ae786f860698919709fb0852ef8138d4461ce8c744f96fe29ef0d580
+    files:
+      - name: resnet50-binary-0001.xml
+        sha256: 1a7e41ab273f9e7b064e60e889ba2f13ce1b07cb4610096bd3abef33a93bf992
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/resnet50-binary-0001/INT1/resnet50-binary-0001.xml
+      - name: resnet50-binary-0001.bin
+        sha256: e843a458ae786f860698919709fb0852ef8138d4461ce8c744f96fe29ef0d580
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/resnet50-binary-0001/INT1/resnet50-binary-0001.bin
     output: "PublicCompressed/classification/resnet50_binary/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-raisinghand-recognition-0001"
     description: "Raising-hand action detection (SSD-based) model to use in Smart Classroom environment."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
-    model_hash: f15dacbaea3954b8c1b97ca48991a31347881504a9fabfc444c0e828c1a285b6
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
-    weights_hash: 0e0b22f2c3731cc6226e96710c558190b8b53777bb194152563249d305fb5498
+    files:
+      - name: person-detection-raisinghand-recognition-0001.xml
+        sha256: f15dacbaea3954b8c1b97ca48991a31347881504a9fabfc444c0e828c1a285b6
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
+      - name: person-detection-raisinghand-recognition-0001.bin
+        sha256: 0e0b22f2c3731cc6226e96710c558190b8b53777bb194152563249d305fb5498
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165_cut_2cl/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "person-detection-raisinghand-recognition-0001-fp16"
     description: "Raising-hand action detection (SSD-based) model to use in Smart Classroom environment."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
-    model_hash: 0f091550cdc61d709fbe0d6eb0f86b6bfaae771e66c5c579d7b0933b8f6db965
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
-    weights_hash: 8931e2a54277581c9a6a53c57b045d0d7473c819c7abd0d361a7e1a638a41566
+    files:
+      - name: person-detection-raisinghand-recognition-0001-fp16.xml
+        sha256: 0f091550cdc61d709fbe0d6eb0f86b6bfaae771e66c5c579d7b0933b8f6db965
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
+      - name: person-detection-raisinghand-recognition-0001-fp16.bin
+        sha256: 8931e2a54277581c9a6a53c57b045d0d7473c819c7abd0d361a7e1a638a41566
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
     output: "Retail/action_detection/pedestrian/rmnet_ssd/0165_cut_2cl/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "handwritten-score-recognition-0001"
     description: "Recognizes school marks (e.g '4' or '3.5'). Alphabet is '0123456789._'. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP32/handwritten-score-recognition-0001.xml
-    model_hash: 86d461c1fa55c1bccfdf3b5488847abc72d19ba3ee838a033d7b3886da6da443
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP32/handwritten-score-recognition-0001.bin
-    weights_hash: 5d2b8fc1233a184335728c8582f3458d44164f8de4a47e85d5865da69efe158c
+    files:
+      - name: handwritten-score-recognition-0001.xml
+        sha256: 86d461c1fa55c1bccfdf3b5488847abc72d19ba3ee838a033d7b3886da6da443
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP32/handwritten-score-recognition-0001.xml
+      - name: handwritten-score-recognition-0001.bin
+        sha256: 5d2b8fc1233a184335728c8582f3458d44164f8de4a47e85d5865da69efe158c
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP32/handwritten-score-recognition-0001.bin
     output: "Retail/handwritten-score-recognition/0001/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE
 
   - name: "handwritten-score-recognition-0001-fp16"
     description: "Recognizes school marks (e.g '4' or '3.5'). Alphabet is '0123456789._'. Architecture: VGG-like + BiLSTM as an encoder, BiLSTM as a decoder."
-    model: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP16/handwritten-score-recognition-0001.xml
-    model_hash: d36c5a3396aaaed02d1734ac2d03c8e656ab4e8432147d0473dfdd4dbb890745
-    weights: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP16/handwritten-score-recognition-0001.bin
-    weights_hash: 12ac804b9f1699c36fbc5d08b6e9878bbdb8441e782f6fe1948eecef5d0c6e14
+    files:
+      - name: handwritten-score-recognition-0001-fp16.xml
+        sha256: d36c5a3396aaaed02d1734ac2d03c8e656ab4e8432147d0473dfdd4dbb890745
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP16/handwritten-score-recognition-0001.xml
+      - name: handwritten-score-recognition-0001-fp16.bin
+        sha256: 12ac804b9f1699c36fbc5d08b6e9878bbdb8441e782f6fe1948eecef5d0c6e14
+        source: https://download.01.org/opencv/2019/open_model_zoo/R1/20190404_140900_models_bin/handwritten-score-recognition-0001/FP16/handwritten-score-recognition-0001.bin
     output: "Retail/handwritten-score-recognition/0001/dldt/"
     framework: dldt
     license: https://github.com/opencv/open_model_zoo/blob/master/LICENSE


### PR DESCRIPTION
This frees us from having to contort the meanings of "model" and "weights" to support various frameworks and makes it possible to support more than two files per model.

This change also makes the downloader keep the downloaded archive and all of its contents for models downloaded as archives. This is possible now, because the config now contains hashes for archives rather than their contents, and therefore the archives can be retrieved from a cache (when using one).

----

This is the second half of the series of changes started in #84. It completely decouples the downloader from framework specifics (in fact, the `framework` field in the config is now unused).