### PR TITLE
 model_downloader: make model_optimizer_args more machine-readable

### DIFF
--- a/model_downloader/list_topologies.yml
+++ b/model_downloader/list_topologies.yml
@@ -412,7 +412,8 @@ topologies:
       - --mean_values=data[128.0,128.0,128.0]
       - --scale_values=data[128.0]
       - --output=prob
-      - --input_model=$dl_dir/inception-resnet-v2.prototxt
+      - --input_model=$dl_dir/inception-resnet-v2.caffemodel
+      - --input_proto=$dl_dir/inception-resnet-v2.prototxt
     framework: caffe
     license: https://github.com/soeaver/caffe-model/blob/master/LICENSE
 
@@ -1041,7 +1042,7 @@ topologies:
       - --input=image_tensor
       - --output=detection_scores,detection_boxes,num_detections
       - --tensorflow_use_custom_operations_config=$mo_dir/extensions/front/tf/faster_rcnn_support.json
-      - --tensorflow_object_detection_api_pipeline_config=$dl_dir/faster_rcnn_resnet101_coco_2018_01_28/frozen_inference_graph.pb
+      - --tensorflow_object_detection_api_pipeline_config=$dl_dir/faster_rcnn_resnet101_coco_2018_01_28/pipeline.config
       - --input_model=$dl_dir/faster_rcnn_resnet101_coco_2018_01_28/frozen_inference_graph.pb
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE

--- a/model_downloader/list_topologies.yml
+++ b/model_downloader/list_topologies.yml
@@ -29,7 +29,16 @@ topologies:
           $type: google_drive
           id: 0B7ubpZO7HnlCcHlfNmJkU2VPelE
     output: "classification/densenet/121/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-121.caffemodel> --input_proto <densenet-121.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.94,116.78,123.68]
+      - --scale_values=data[58.8235294117647]
+      - --output=fc6
+      - --input_model=$dl_dir/densenet-121.caffemodel
+      - --input_proto=$dl_dir/densenet-121.prototxt
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
@@ -46,7 +55,16 @@ topologies:
           $type: google_drive
           id: 0B7ubpZO7HnlCa0phRGJIRERoTXM
     output: "classification/densenet/161/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-161.caffemodel> --input_proto <densenet-161.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.94,116.78,123.68]
+      - --scale_values=data[58.8235294117647]
+      - --output=fc6
+      - --input_model=$dl_dir/densenet-161.caffemodel
+      - --input_proto=$dl_dir/densenet-161.prototxt
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
@@ -63,7 +81,16 @@ topologies:
           $type: google_drive
           id: 0B7ubpZO7HnlCRWVVdUJjVVAyQXc
     output: "classification/densenet/169/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-169.caffemodel> --input_proto <densenet-169.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.94,116.78,123.68]
+      - --scale_values=data[58.8235294117647]
+      - --output=fc6
+      - --input_model=$dl_dir/densenet-169.caffemodel
+      - --input_proto=$dl_dir/densenet-169.prototxt
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
@@ -80,7 +107,16 @@ topologies:
           $type: google_drive
           id: 0B7ubpZO7HnlCV3pud2oyR3lNMWs
     output: "classification/densenet/201/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output fc6 --input_model <densenet-201.caffemodel> --input_proto <densenet-201.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.94,116.78,123.68]
+      - --scale_values=data[58.8235294117647]
+      - --output=fc6
+      - --input_model=$dl_dir/densenet-201.caffemodel
+      - --input_proto=$dl_dir/densenet-201.prototxt
     framework: caffe
     license: https://github.com/liuzhuang13/DenseNet/blob/master/LICENSE
 
@@ -99,7 +135,15 @@ topologies:
         file: squeezenet1.0.prototxt
         pattern: 'dim: 10'
         replacement: 'dim: 1'
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <squeezenet1.0.caffemodel> --input_proto <squeezenet1.0.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,227,227]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/squeezenet1.0.caffemodel
+      - --input_proto=$dl_dir/squeezenet1.0.prototxt
     framework: caffe
     license: https://github.com/DeepScale/SqueezeNet/blob/master/LICENSE
 
@@ -118,7 +162,15 @@ topologies:
         file: squeezenet1.1.prototxt
         pattern: 'dim: 10'
         replacement: 'dim: 1'
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <squeezenet1.1.caffemodel> --input_proto <squeezenet1.1.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,227,227]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/squeezenet1.1.caffemodel
+      - --input_proto=$dl_dir/squeezenet1.1.prototxt
     framework: caffe
     license: https://github.com/DeepScale/SqueezeNet/blob/master/LICENSE
 
@@ -143,7 +195,14 @@ topologies:
         pattern: 'dim: 12'
         replacement: 'dim: 1280'
         count: 1
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,720,1280] --input data --output prob1 --input_model <mtcnn-p.caffemodel> --input_proto <mtcnn-p.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,720,1280]
+      - --input=data
+      - --output=prob1
+      - --input_model=$dl_dir/mtcnn-p.caffemodel
+      - --input_proto=$dl_dir/mtcnn-p.prototxt
     framework: caffe
     license: https://github.com/DuinoDu/mtcnn/blob/master/LICENSE
 
@@ -157,7 +216,14 @@ topologies:
         sha256: 39b20f7a57bb8176cc9466cea4dfd52da6a6f876de60c7ab222a309f2d0ca08c
         source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.caffemodel
     output: "object_detection/common/mtcnn/r/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,24,24] --input data --output prob1 --input_model <mtcnn-r.caffemodel> --input_proto <mtcnn-r.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,24,24]
+      - --input=data
+      - --output=prob1
+      - --input_model=$dl_dir/mtcnn-r.caffemodel
+      - --input_proto=$dl_dir/mtcnn-r.prototxt
     framework: caffe
     license: https://github.com/DuinoDu/mtcnn/blob/master/LICENSE
 
@@ -171,7 +237,14 @@ topologies:
         sha256: 9d6098829a4d6d318f37cec42142465637fafe4c673f2e93b69495bf7ca23d2d
         source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.caffemodel
     output: "object_detection/common/mtcnn/o/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,48,48] --input data --output prob1 --input_model <mtcnn-o.caffemodel> --input_proto <mtcnn-o.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,48,48]
+      - --input=data
+      - --output=prob1
+      - --input_model=$dl_dir/mtcnn-o.caffemodel
+      - --input_proto=$dl_dir/mtcnn-o.prototxt
     framework: caffe
     license: https://github.com/DuinoDu/mtcnn/blob/master/LICENSE
 
@@ -188,7 +261,16 @@ topologies:
           $type: google_drive
           id: 0B3gersZ2cHIxRm5PMWRoTkdHdHc
     output: "object_detection/common/mobilenet-ssd/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[127.5,127.5,127.5] --scale_values data[127.50223128904757] --output detection_out --input_model <mobilenet-ssd.caffemodel> --input_proto <mobilenet-ssd.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,300,300]
+      - --input=data
+      - --mean_values=data[127.5,127.5,127.5]
+      - --scale_values=data[127.50223128904757]
+      - --output=detection_out
+      - --input_model=$dl_dir/mobilenet-ssd.caffemodel
+      - --input_proto=$dl_dir/mobilenet-ssd.prototxt
     framework: caffe
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
@@ -207,7 +289,15 @@ topologies:
         file: vgg19.prototxt
         pattern: 'dim: 10'
         replacement: 'dim: 1'
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.939,116.779,123.68] --output prob --input_model <vgg19.caffemodel> --input_proto <vgg19.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.939,116.779,123.68]
+      - --output=prob
+      - --input_model=$dl_dir/vgg19.caffemodel
+      - --input_proto=$dl_dir/vgg19.prototxt
     framework: caffe
     license: https://github.com/keras-team/keras/blob/master/LICENSE
 
@@ -226,7 +316,15 @@ topologies:
         file: vgg16.prototxt
         pattern: 'dim: 10'
         replacement: 'dim: 1'
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.939,116.779,123.68] --output prob --input_model <vgg16.caffemodel> --input_proto <vgg16.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.939,116.779,123.68]
+      - --output=prob
+      - --input_model=$dl_dir/vgg16.caffemodel
+      - --input_proto=$dl_dir/vgg16.prototxt
     framework: caffe
     license: https://github.com/keras-team/keras/blob/master/LICENSE
 
@@ -248,7 +346,15 @@ topologies:
         file: models/VGGNet/VOC0712Plus/SSD_512x512/deploy.prototxt
         pattern: ' +save_output_param \{.*\n.*\n +\}\n'
         replacement: ''
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,512,512] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <VGG_VOC0712Plus_SSD_512x512_iter_240000.caffemodel> --input_proto <deploy.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,512,512]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=detection_out
+      - --input_model=$dl_dir/models/VGGNet/VOC0712Plus/SSD_512x512/VGG_VOC0712Plus_SSD_512x512_iter_240000.caffemodel
+      - --input_proto=$dl_dir/models/VGGNet/VOC0712Plus/SSD_512x512/deploy.prototxt
     framework: caffe
     license: https://github.com/weiliu89/caffe/blob/ssd/LICENSE
 
@@ -270,7 +376,15 @@ topologies:
         file: models/VGGNet/VOC0712Plus/SSD_300x300_ft/deploy.prototxt
         pattern: ' +save_output_param \{.*\n.*\n +\}\n'
         replacement: ''
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --mean_values data[104.0,117.0,123.0] --output detection_out --input_model <VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.caffemodel> --input_proto <deploy.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,300,300]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=detection_out
+      - --input_model=$dl_dir/models/VGGNet/VOC0712Plus/SSD_300x300_ft/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.caffemodel
+      - --input_proto=$dl_dir/models/VGGNet/VOC0712Plus/SSD_300x300_ft/deploy.prototxt
     framework: caffe
     license: https://github.com/weiliu89/caffe/blob/ssd/LICENSE
 
@@ -290,7 +404,15 @@ topologies:
           $type: google_drive
           id: 0B9mkjlmP0d7zNmY5eXZhLUhzQVE
     output: "classification/inception-resnet/v2/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,299,299] --input data --mean_values data[128.0,128.0,128.0] --scale_values data[128.0] --output prob --input_model <inception-resnet-v2.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,299,299]
+      - --input=data
+      - --mean_values=data[128.0,128.0,128.0]
+      - --scale_values=data[128.0]
+      - --output=prob
+      - --input_model=$dl_dir/inception-resnet-v2.prototxt
     framework: caffe
     license: https://github.com/soeaver/caffe-model/blob/master/LICENSE
 
@@ -304,7 +426,15 @@ topologies:
         sha256: ec6cec2bfa0f1b199f11e73f0e030ae29326bc5648f3ddf9127feb3367b68b92
         source: http://dl.yf.io/dilation/models/dilation10_cityscapes.caffemodel
     output: "semantic_segmentation/dilation/cityscapes/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,1396,1396] --input data --mean_values data[72.39,82.91,73.16] --output prob --input_model <dilation.caffemodel> --input_proto <dilation.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,1396,1396]
+      - --input=data
+      - --mean_values=data[72.39,82.91,73.16]
+      - --output=prob
+      - --input_model=$dl_dir/dilation.caffemodel
+      - --input_proto=$dl_dir/dilation.prototxt
     framework: caffe
     license: https://github.com/fyu/dilation/blob/master/LICENSE
 
@@ -323,7 +453,15 @@ topologies:
         file: googlenet-v1.prototxt
         pattern: 'dim: 10'
         replacement: 'dim: 1'
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <googlenet-v1.caffemodel> --input_proto <googlenet-v1.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/googlenet-v1.caffemodel
+      - --input_proto=$dl_dir/googlenet-v1.prototxt
     framework: caffe
     license: https://github.com/BVLC/caffe/blob/master/LICENSE
 
@@ -346,7 +484,15 @@ topologies:
         file: googlenet-v2.prototxt
         pattern: 'layers \{'
         replacement: 'layer {'
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <googlenet-v2.caffemodel> --input_proto <googlenet-v2.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/googlenet-v2.caffemodel
+      - --input_proto=$dl_dir/googlenet-v2.prototxt
     framework: caffe
     license: https://github.com/lim0606/caffe-googlenet-bn/blob/master/README.md
 
@@ -366,7 +512,16 @@ topologies:
           $type: google_drive
           id: 0B9mkjlmP0d7zeG1HREVMR2F3WmM
     output: "classification/googlenet/v4/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,299,299] --input data --mean_values data[128.0,128.0,128.0] --scale_values data[128.0] --output prob --input_model <googlenet-v4.caffemodel> --input_proto <googlenet-v4.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,299,299]
+      - --input=data
+      - --mean_values=data[128.0,128.0,128.0]
+      - --scale_values=data[128.0]
+      - --output=prob
+      - --input_model=$dl_dir/googlenet-v4.caffemodel
+      - --input_proto=$dl_dir/googlenet-v4.prototxt
     framework: caffe
     license: https://github.com/soeaver/caffe-model/blob/master/LICENSE
 
@@ -385,7 +540,15 @@ topologies:
         file: alexnet.prototxt
         pattern: 'dim: 10'
         replacement: 'dim: 1'
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,227,227] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <alexnet.caffemodel> --input_proto <alexnet.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,227,227]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/alexnet.caffemodel
+      - --input_proto=$dl_dir/alexnet.prototxt
     framework: caffe
     license: https://github.com/BVLC/caffe/blob/master/models/bvlc_alexnet/readme.md
 
@@ -400,7 +563,16 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: ssd_mobilenet_v2_coco.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --tensorflow_use_custom_operations_config ./extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <pipeline.config> --output detection_classes,detection_scores,detection_boxes,num_detections --input_model <frozen_inference_graph.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,300,300,3]
+      - --input=image_tensor
+      - --tensorflow_use_custom_operations_config=$mo_dir/extensions/front/tf/ssd_v2_support.json
+      - --tensorflow_object_detection_api_pipeline_config=$dl_dir/ssd_mobilenet_v2_coco_2018_03_29/pipeline.config
+      - --output=detection_classes,detection_scores,detection_boxes,num_detections
+      - --input_model=$dl_dir/ssd_mobilenet_v2_coco_2018_03_29/frozen_inference_graph.pb
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
@@ -416,7 +588,14 @@ topologies:
         sha256: 44ee2b08816cede2b7aaa047888df07dcab52f73399aa1c8bef05a17bfdd4888
         source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117895&authkey=AAFW2-FVoxeVRck
     output: "classification/resnet/v1/50/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-50.caffemodel> --input_proto <resnet-50.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=prob
+      - --input_model=$dl_dir/resnet-50.caffemodel
+      - --input_proto=$dl_dir/resnet-50.prototxt
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
 
@@ -432,7 +611,14 @@ topologies:
         sha256: 2847d93346d7928ec1f257f49f60ea53e9075c15265c494469610e67ffb7f2e2
         source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117896&authkey=AAFW2-FVoxeVRck
     output: "classification/resnet/v1/101/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-101.caffemodel> --input_proto <resnet-101.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=prob
+      - --input_model=$dl_dir/resnet-101.caffemodel
+      - --input_proto=$dl_dir/resnet-101.prototxt
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
 
@@ -448,7 +634,14 @@ topologies:
         sha256: 6253c4c4132c0b25c112b166629aa57dcaeec044a4c68ac9f003b6c801329d55
         source: https://onedrive.live.com/download?cid=4006CBB8476FF777&resid=4006CBB8476FF777%2117897&authkey=AAFW2-FVoxeVRck
     output: "classification/resnet/v1/152/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --output prob --input_model <resnet-152.caffemodel> --input_proto <resnet-152.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=prob
+      - --input_model=$dl_dir/resnet-152.caffemodel
+      - --input_proto=$dl_dir/resnet-152.prototxt
     framework: caffe
     license: https://github.com/KaimingHe/deep-residual-networks/blob/master/LICENSE
 
@@ -463,7 +656,16 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: googlenet-v3.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,299,299,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.50000414375013] --output InceptionV3/Predictions/Softmax --input_model <inception_v3_2016_08_28_frozen.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,299,299,3]
+      - --input=input
+      - --mean_values=input[127.5,127.5,127.5]
+      - --scale_values=input[127.50000414375013]
+      - --output=InceptionV3/Predictions/Softmax
+      - --input_model=$dl_dir/inception_v3_2016_08_28_frozen.pb
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
@@ -480,7 +682,15 @@ topologies:
           $type: google_drive
           id: 0BwHV3BlNKkWlTWRRbDZYbVB2WWc
     output: "classification/se-networks/se-inception/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-inception.caffemodel> --input_proto <se-inception.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/se-inception.caffemodel
+      - --input_proto=$dl_dir/se-inception.prototxt
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
@@ -497,7 +707,15 @@ topologies:
           $type: google_drive
           id: 0BwHV3BlNKkWlTEg4YmcwQ0FoZFU
     output: "classification/se-networks/se-resnet-101/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-101.caffemodel> --input_proto <se-resnet-101.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/se-resnet-101.caffemodel
+      - --input_proto=$dl_dir/se-resnet-101.prototxt
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
@@ -514,7 +732,15 @@ topologies:
           $type: google_drive
           id: 0BwHV3BlNKkWlcFE0Q2NTcWl3WUE
     output: "classification/se-networks/se-resnet-152/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-152.caffemodel> --input_proto <se-resnet-152.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/se-resnet-152.caffemodel
+      - --input_proto=$dl_dir/se-resnet-152.prototxt
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
@@ -531,7 +757,15 @@ topologies:
           $type: google_drive
           id: 0BwHV3BlNKkWlS2QwZHFzM3RjNzg
     output: "classification/se-networks/se-resnet-50/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnet-50.caffemodel> --input_proto <se-resnet-50.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/se-resnet-50.caffemodel
+      - --input_proto=$dl_dir/se-resnet-50.prototxt
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
@@ -548,7 +782,15 @@ topologies:
           $type: google_drive
           id: 0BwHV3BlNKkWlQ2Z0Q204V1RITjA
     output: "classification/se-networks/se-resnext-50/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnext-50.caffemodel> --input_proto <se-resnext-50.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/se-resnext-50.caffemodel
+      - --input_proto=$dl_dir/se-resnext-50.prototxt
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
@@ -565,7 +807,15 @@ topologies:
           $type: google_drive
           id: 0BwHV3BlNKkWleklsNzBiZlprblk
     output: "classification/se-networks/se-resnext-101/caffe"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[104.0,117.0,123.0] --output prob --input_model <se-resnext-101.caffemodel> --input_proto <se-resnext-101.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[104.0,117.0,123.0]
+      - --output=prob
+      - --input_model=$dl_dir/se-resnext-101.caffemodel
+      - --input_proto=$dl_dir/se-resnext-101.prototxt
     framework: caffe
     license: https://github.com/hujie-frank/SENet/blob/master/LICENSE
 
@@ -582,7 +832,16 @@ topologies:
           $type: google_drive
           id: 0B_geeR2lTMegb2F6dmlmOXhWaVk
     output: "face_recognition/sphereface/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,112,96] --input data --mean_values data[127.5,127.5,127.5] --scale_values data[128.0] --output fc5 --input_model <Sphereface.caffemodel> --input_proto <Sphereface.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,112,96]
+      - --input=data
+      - --mean_values=data[127.5,127.5,127.5]
+      - --scale_values=data[128.0]
+      - --output=fc5
+      - --input_model=$dl_dir/Sphereface.caffemodel
+      - --input_proto=$dl_dir/Sphereface.prototxt
     framework: caffe
     license: https://github.com/wy1iu/sphereface/blob/master/LICENSE
 
@@ -597,7 +856,15 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: license-plate-recognition-barrier-0007.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,24,94,3] --input input --scale_values input[254.99997577500233] --output d_predictions --input_model <graph.pb.frozen>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,24,94,3]
+      - --input=input
+      - --scale_values=input[254.99997577500233]
+      - --output=d_predictions
+      - --input_model=$dl_dir/license-plate-recognition-barrier-0007/graph.pb.frozen
     framework: tf
     license: https://github.com/opencv/training_toolbox_tensorflow/blob/develop/LICENSE
 
@@ -611,7 +878,13 @@ topologies:
         sha256: 10f68b73f3b68db89fab151be51fc90a0bc1e2a18a87ac642e88aa9e94d53f8f
         source: https://github.com/opencv/training_toolbox_caffe/raw/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/face-detection-retail-0044.caffemodel
     output: "Retail/object_detection/face/sqnet1.0modif-ssd/0044/caffe/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,300,300] --input data --input_model <face-detection-retail-0044.caffemodel> --input_proto <face-detection-retail-0044.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,300,300]
+      - --input=data
+      - --input_model=$dl_dir/face-detection-retail-0044.caffemodel
+      - --input_proto=$dl_dir/face-detection-retail-0044.prototxt
     framework: caffe
     license: https://github.com/opencv/training_toolbox_caffe/blob/develop/LICENSE
 
@@ -625,7 +898,16 @@ topologies:
         sha256: 8d6edcd3dbd1356f2f19dd220c362c2ba8f44233a9b6c12ca6d0351cb0c446b6
         source: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet.caffemodel
     output: "classification/mobilenet/v1/1.0/224/cf/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output prob --input_model <mobilenet-v1-1.0-224.caffemodel> --input_proto <mobilenet-v1-1.0-224.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.94,116.78,123.68]
+      - --scale_values=data[58.8235294117647]
+      - --output=prob
+      - --input_model=$dl_dir/mobilenet-v1-1.0-224.caffemodel
+      - --input_proto=$dl_dir/mobilenet-v1-1.0-224.prototxt
     framework: caffe
     license: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE
 
@@ -639,7 +921,16 @@ topologies:
         sha256: a3124ce7abd258c7f35a2c586576bee8116934fa2a8556e4e528041859dd753f
         source: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2.caffemodel
     output: "classification/mobilenet/v2/cf/"
-    model_optimizer_args: "--framework caffe --data_type FP32 --input_shape [1,3,224,224] --input data --mean_values data[103.94,116.78,123.68] --scale_values data[58.8235294117647] --output prob --input_model <mobilenet-v2.caffemodel> --input_proto <mobilenet-v2.prototxt>"
+    model_optimizer_args:
+      - --framework=caffe
+      - --data_type=FP32
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --mean_values=data[103.94,116.78,123.68]
+      - --scale_values=data[58.8235294117647]
+      - --output=prob
+      - --input_model=$dl_dir/mobilenet-v2.caffemodel
+      - --input_proto=$dl_dir/mobilenet-v2.prototxt
     framework: caffe
     license: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE
 
@@ -654,7 +945,16 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: faster_rcnn_inception_v2_coco.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <pipeline.config> --input_model <frozen_inference_graph.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,600,600,3]
+      - --input=image_tensor
+      - --output=detection_scores,detection_boxes,num_detections
+      - --tensorflow_use_custom_operations_config=$mo_dir/extensions/front/tf/faster_rcnn_support.json
+      - --tensorflow_object_detection_api_pipeline_config=$dl_dir/faster_rcnn_inception_v2_coco_2018_01_28/pipeline.config
+      - --input_model=$dl_dir/faster_rcnn_inception_v2_coco_2018_01_28/frozen_inference_graph.pb
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
@@ -669,7 +969,13 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: deeplabv3.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --input_shape [1,513,513,3] --input 1:mul_1 --output ArgMax --input_model <frozen_inference_graph.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --input_shape=[1,513,513,3]
+      - --input=1:mul_1
+      - --output=ArgMax
+      - --input_model=$dl_dir/deeplabv3_mnv2_pascal_train_aug/frozen_inference_graph.pb
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
@@ -680,7 +986,15 @@ topologies:
         sha256: 09b3a0cc57eb826dd6b6fa95a03e078ad435b7b5fb0186dad2abdb98a4fdf64a
         source: https://github.com/eragonruan/text-detection-ctpn/releases/download/untagged-48d74c6337a71b6b5f87/ctpn.pb
     output: "text_detection/ctpn/tf/"
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input Placeholder --mean_values Placeholder[102.9801,115.9465,122.7717] --output Reshape_2,rpn_bbox_pred/Reshape_1 --input_model <ctpn.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,300,300,3]
+      - --input=Placeholder
+      - --mean_values=Placeholder[102.9801,115.9465,122.7717]
+      - --output=Reshape_2,rpn_bbox_pred/Reshape_1
+      - --input_model=$dl_dir/ctpn.pb
     framework: tf
     license: https://github.com/eragonruan/text-detection-ctpn/blob/banjin-dev/LICENSE
 
@@ -695,7 +1009,16 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: ssd_mobilenet_v1_coco.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,300,300,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/ssd_v2_support.json --tensorflow_object_detection_api_pipeline_config <pipeline.config> --input_model <frozen_inference_graph.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,300,300,3]
+      - --input=image_tensor
+      - --output=detection_scores,detection_boxes,num_detections
+      - --tensorflow_use_custom_operations_config=$mo_dir/extensions/front/tf/ssd_v2_support.json
+      - --tensorflow_object_detection_api_pipeline_config=$dl_dir/ssd_mobilenet_v1_coco_2018_01_28/pipeline.config
+      - --input_model=$dl_dir/ssd_mobilenet_v1_coco_2018_01_28/frozen_inference_graph.pb
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
@@ -710,7 +1033,16 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: faster_rcnn_resnet101_coco.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,600,600,3] --input image_tensor --output detection_scores,detection_boxes,num_detections --tensorflow_use_custom_operations_config /opt/intel/cvsdk/deployment_tools/model_optimizer/extensions/front/tf/faster_rcnn_support.json --tensorflow_object_detection_api_pipeline_config <faster_rcnn_resnet101_coco.pb> --input_model <frozen_inference_graph.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,600,600,3]
+      - --input=image_tensor
+      - --output=detection_scores,detection_boxes,num_detections
+      - --tensorflow_use_custom_operations_config=$mo_dir/extensions/front/tf/faster_rcnn_support.json
+      - --tensorflow_object_detection_api_pipeline_config=$dl_dir/faster_rcnn_resnet101_coco_2018_01_28/frozen_inference_graph.pb
+      - --input_model=$dl_dir/faster_rcnn_resnet101_coco_2018_01_28/frozen_inference_graph.pb
     framework: tf
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 
@@ -725,7 +1057,16 @@ topologies:
       - $type: unpack_archive
         format: gztar
         file: mobilenet-v2-1.4-224.tar.gz
-    model_optimizer_args: "--framework tf --data_type FP32 --reverse_input_channels --input_shape [1,224,224,3] --input input --mean_values input[127.5,127.5,127.5] --scale_values input[127.00001206500114] --output MobilenetV2/Predictions/Reshape_1 --input_model <mobilenet_v2_1.4_224_frozen.pb>"
+    model_optimizer_args:
+      - --framework=tf
+      - --data_type=FP32
+      - --reverse_input_channels
+      - --input_shape=[1,224,224,3]
+      - --input=input
+      - --mean_values=input[127.5,127.5,127.5]
+      - --scale_values=input[127.00001206500114]
+      - --output=MobilenetV2/Predictions/Reshape_1
+      - --input_model=$dl_dir/mobilenet_v2_1.4_224_frozen.pb
     framework: "tf"
     license: https://github.com/tensorflow/models/blob/master/LICENSE
 


### PR DESCRIPTION
* Make it a list rather than a string. This makes it possible to use the arguments regardless of what the system shell is. It's also a lot more human-readable.

* Replace the angle bracket placeholder syntax with shell-like variable substitutions. This will enable using Python's `string.Template` to substitute specific paths.

-----

This is a prelude to adding a tool that will automatically run Model Optimizer for each model using these arguments.