### PR TITLE
model_downloader: Don't attempt post-processing on topologies that failed to download

### DIFF
--- a/model_downloader/downloader.py
+++ b/model_downloader/downloader.py
@@ -228,6 +228,8 @@ print('')
 print('###############|| Post processing ||###############')
 print('')
 for top in topologies:
+    if top.name in failed_topologies: continue
+
     output = args.output_dir / top.subdir
 
     for postproc in top.postprocessing:


### PR DESCRIPTION
It just leads to additional errors and crashes the downloader before it can print the list of failed topologies.