### PR TITLE
Remove "dilation" from the model downloader config file

### DIFF
--- a/model_downloader/license.txt
+++ b/model_downloader/license.txt
@@ -436,35 +436,6 @@ License terms:
     SOFTWARE.
     
 ================================================================================================== 
-
-* dilation - Multi-Scale Context Aggregation by Dilated Convolutions https://arxiv.org/pdf/1511.07122.pdf
-
-License terms:
-
-    MIT License
-    
-    Copyright (c) 2016 Fisher Yu
-
-    Permission is hereby granted, free of charge, to any person obtaining
-    a copy of this software and associated documentation files (the
-    "Software"), to deal in the Software without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Software, and to
-    permit persons to whom the Software is furnished to do so, subject to
-    the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-    
-================================================================================================== 
     
 * googlenet-v1 - GoogleNet v1 - Inception v1 - https://arxiv.org/pdf/1409.4842.pdf
     

--- a/model_downloader/list_topologies.yml
+++ b/model_downloader/list_topologies.yml
@@ -417,28 +417,6 @@ topologies:
     framework: caffe
     license: https://raw.githubusercontent.com/soeaver/caffe-model/master/LICENSE
 
-  - name: "dilation"
-    description: "Multi-Scale Context Aggregation by Dilated Convolutions (https://arxiv.org/pdf/1511.07122.pdf)"
-    files:
-      - name: dilation.prototxt
-        sha256: 7b1adfc35901b5626504b44fbf3567bcf81926b9482b031925012e8fbef8f219
-        source: https://raw.githubusercontent.com/fyu/dilation/0f105742e8c2202af12feb54374781ba55c3e112/models/dilation10_cityscapes_deploy.prototxt
-      - name: dilation.caffemodel
-        sha256: ec6cec2bfa0f1b199f11e73f0e030ae29326bc5648f3ddf9127feb3367b68b92
-        source: http://dl.yf.io/dilation/models/dilation10_cityscapes.caffemodel
-    output: "semantic_segmentation/dilation/cityscapes/caffe"
-    model_optimizer_args:
-      - --framework=caffe
-      - --data_type=FP32
-      - --input_shape=[1,3,1396,1396]
-      - --input=data
-      - --mean_values=data[72.39,82.91,73.16]
-      - --output=prob
-      - --input_model=$dl_dir/dilation.caffemodel
-      - --input_proto=$dl_dir/dilation.prototxt
-    framework: caffe
-    license: https://raw.githubusercontent.com/fyu/dilation/master/LICENSE
-
   - name: "googlenet-v1"
     description: "GoogleNet v1 (Inception v1) (https://arxiv.org/pdf/1409.4842.pdf)"
     files:


### PR DESCRIPTION
The server hosting the .caffemodel file for it appears to be defunct, so we can no longer support it.