### PR TITLE
Add a model converter option to override the output directory

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -81,15 +81,21 @@ The basic usage is to run the script like this:
 ```
 
 This will convert all models into the Inference Engine IR format. Models that
-were originally in that format are ignored. The conversion results are placed
-side by side with the original models.
+were originally in that format are ignored.
 
 The current directory must be the root of a download tree created by the model
-downloader. To specify a different download tree path, use the `-d`/`--download_root`
+downloader. To specify a different download tree path, use the `-d`/`--download_dir`
 option:
 
 ```sh
-./converter.py --all --download_root my/download/directory
+./converter.py --all --download_dir my/download/directory
+```
+
+By default, the converted models are placed into the download tree. To place them
+into a different directory tree, use the `-o`/`--output_dir` option:
+
+```sh
+./converter.py --all --output_dir my/output/directory
 ```
 
 The `--all` option can be replaced with other filter options to convert only


### PR DESCRIPTION
Also, make a couple of related changes:

* Rename `--download_root` into `--download_dir` for consistency with the other options. This script hasn't been a part of a release yet, so we don't need to retain the old name.

* Place converted models into a subdirectory corresponding to the precision (always "FP32" at the moment). This makes the directory structure more consistent between models that are converted and ones that are initially in the IR format, and will enable us to support alternate conversions in the future.