### PR TITLE
downloader.py: produce less output when not printing to a terminal

### DIFF
--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -83,7 +83,7 @@ class FileSourceHttp(FileSource):
     def deserialize(cls, source):
         return FileSourceHttp(validate_string('"url"', source['url']))
 
-    def start_download(self, session, total_size=None):
+    def start_download(self, session, chunk_size, total_size=None):
         response = session.get(self.url, stream=True, timeout=DOWNLOAD_TIMEOUT)
         response.raise_for_status()
 
@@ -92,7 +92,7 @@ class FileSourceHttp(FileSource):
         else:
             size = total_size
 
-        return response.iter_content(chunk_size=8192), size
+        return response.iter_content(chunk_size=chunk_size), size
 
 FileSource.types['http'] = FileSourceHttp
 
@@ -104,7 +104,7 @@ class FileSourceGoogleDrive(FileSource):
     def deserialize(cls, source):
         return FileSourceGoogleDrive(validate_string('"id"', source['id']))
 
-    def start_download(self, session, total_size):
+    def start_download(self, session, chunk_size, total_size):
         URL = 'https://docs.google.com/uc?export=download'
         response = session.get(URL, params={'id' : self.id}, stream=True, timeout=DOWNLOAD_TIMEOUT)
         response.raise_for_status()
@@ -115,7 +115,7 @@ class FileSourceGoogleDrive(FileSource):
                 response = session.get(URL, params=params, stream=True, timeout=DOWNLOAD_TIMEOUT)
                 response.raise_for_status()
 
-        return response.iter_content(chunk_size=32768), total_size
+        return response.iter_content(chunk_size=chunk_size), total_size
 
 FileSource.types['google_drive'] = FileSourceGoogleDrive
 


### PR DESCRIPTION
With our small chunk sizes, downloading large networks produces an obscene amount of output, which is hard to read in CI logs. Mitigate this by using a larger chunk size when standard output is not a terminal.

Also, don't attempt to overwrite the progress line when not printing to a terminal. It makes no sense, and it confuses programs that read the downloader's output into thinking that it's printing one giant line.