### PR TITLE
info_dumper.py: expose each model's subdirectory

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -159,6 +159,9 @@ describing a single model. Each such object has the following keys:
   converter can produce IR files in. Current possible values are `FP16`, `FP32`, `INT1`, `INT8`;
   more might be added in the future.
 
+* `subdirectory`: the subdirectory of the output tree into which the downloaded or converted files
+  will be placed by the downloader or the converter, respectively.
+
 Shared options
 --------------
 

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -212,10 +212,10 @@ class PostprocUnpackArchive(Postproc):
 Postproc.types['unpack_archive'] = PostprocUnpackArchive
 
 class Topology:
-    def __init__(self, name, subdir, files, postprocessing, mo_args, framework,
+    def __init__(self, name, subdirectory, files, postprocessing, mo_args, framework,
             description, license_url, precisions):
         self.name = name
-        self.subdir = subdir
+        self.subdirectory = subdirectory
         self.files = files
         self.postprocessing = postprocessing
         self.mo_args = mo_args
@@ -230,7 +230,7 @@ class Topology:
         if not name: raise DeserializationError('"name": must not be empty')
 
         with deserialization_context('In topology "{}"'.format(name)):
-            subdir = validate_relative_path('"output"', top['output'])
+            subdirectory = validate_relative_path('"output"', top['output'])
 
             files = []
             file_names = set()
@@ -278,7 +278,7 @@ class Topology:
 
             license_url = validate_string('"license"', top['license'])
 
-            return cls(name, subdir, files, postprocessing, mo_args, framework,
+            return cls(name, subdirectory, files, postprocessing, mo_args, framework,
                 description, license_url, precisions)
 
 def load_topologies(config):

--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -81,13 +81,13 @@ def main():
             continue
 
         expanded_mo_args = [
-            string.Template(arg).substitute(dl_dir=args.download_dir / top.subdir, mo_dir=mo_path.parent)
+            string.Template(arg).substitute(dl_dir=args.download_dir / top.subdirectory, mo_dir=mo_path.parent)
             for arg in top.mo_args]
 
         assert len(top.precisions) == 1 # only one precision per model is supported at the moment
 
         mo_cmd = [str(args.python), '--', str(mo_path),
-            '--output_dir={}'.format(output_dir / top.subdir / next(iter(top.precisions))),
+            '--output_dir={}'.format(output_dir / top.subdirectory / next(iter(top.precisions))),
             '--model_name={}'.format(top.name),
             *expanded_mo_args]
 

--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -213,7 +213,7 @@ print('###############|| Downloading topologies ||###############')
 print('')
 with requests.Session() as session:
     for top in topologies:
-        output = args.output_dir / top.subdir
+        output = args.output_dir / top.subdirectory
         output.mkdir(parents=True, exist_ok=True)
 
         for top_file in top.files:
@@ -232,7 +232,7 @@ print('')
 for top in topologies:
     if top.name in failed_topologies: continue
 
-    output = args.output_dir / top.subdir
+    output = args.output_dir / top.subdirectory
 
     for postproc in top.postprocessing:
         postproc.apply(output)

--- a/tools/downloader/info_dumper.py
+++ b/tools/downloader/info_dumper.py
@@ -30,6 +30,7 @@ def to_info(topology):
         'framework': topology.framework,
         'license_url': topology.license_url,
         'precisions': sorted(topology.precisions),
+        'subdirectory': str(topology.subdirectory),
     }
 
 def main():


### PR DESCRIPTION
I expanded the name of this variable from "subdir", because I thought the abbreviated name was a bit too informal to expose.