### PR TITLE
Add a requirements file for Accuracy Checker CI

### DIFF
--- a/ci/requirements-ac.txt
+++ b/ci/requirements-ac.txt
@@ -1,0 +1,12 @@
+joblib==0.13.2            # via scikit-learn
+nibabel==2.4.1
+numpy==1.16.0
+pillow==6.0.0
+py-cpuinfo==4.0.0
+pyyaml==5.1.1
+scikit-learn==0.21.2
+scipy==0.19.0
+shapely==1.6.4.post2
+six==1.12.0               # via nibabel
+tqdm==4.32.1
+yamlloader==0.5.5


### PR DESCRIPTION
I used pip-compile to create it, although I manually removed `opencv-python` from the resulting file, since I would prefer to use the OpenCV bindings included in OpenVINO.