### PR TITLE
Documentation for public model

### DIFF
--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -25,7 +25,7 @@ The model output for `alexnet` is the usual object classifier output for the 100
 
 ## Input
 
-Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
+Image, shape - `1,3,227,227`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,10 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## Legal Information
 

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -27,21 +27,47 @@ See [https://github.com/BVLC/caffe/tree/master/models/bvlc_alexnet]
 
 ## Input
 
-Image, shape - `1,3,227,227`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`, shape - `1,3,227,227`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [104, 117, 123]
+
+### Converted model
+
+### Original model
+
+Image, name - `data`, shape - `1,3,227,227`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
 
 ## Legal Information
 

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -4,7 +4,7 @@
 
 The `alexnet` model is designed to perform image classification. Just like other common classification models, the `alexnet` model has been pretrained on the ImageNet image database. For details about this model, check out the [paper](http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
 
-The model input is a blob that consists of a single image of "1x3x227x227" in BGR order.
+The model input is a blob that consists of a single image of "1x3x227x227" in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
 
 The model output for `alexnet` is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -21,6 +21,8 @@ The model output for `alexnet` is the usual object classifier output for the 100
 
 ## Accuracy
 
+See [https://github.com/BVLC/caffe/tree/master/models/bvlc_alexnet]
+
 ## Performance
 
 ## Input
@@ -36,7 +38,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -4,7 +4,7 @@
 
 The `alexnet` model is designed to perform image classification. Just like other common classification models, the `alexnet` model has been pretrained on the ImageNet image database. For details about this model, check out the [paper](http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
 
-The model input is a blob that consists of a single image of "1x3x227x227" in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x227x227 in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
 
 The model output for `alexnet` is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,11 +17,11 @@ The model output for `alexnet` is the usual object classifier output for the 100
 | Type              | Classification|
 | GFLOPs            | 1.5           |
 | MParams           | 60.965        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/BVLC/caffe/tree/master/models/bvlc_alexnet]
+See [https://github.com/BVLC/caffe/tree/master/models/bvlc_alexnet].
 
 ## Performance
 

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -12,6 +12,13 @@ The model output for "alexnet" is the usual object classifier output for the 100
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 1.5           |
+| MParams           | 60.965        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -23,7 +23,7 @@ The model output for `alexnet` is the usual object classifier output for the 100
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -6,7 +6,7 @@ The `alexnet` model is designed to perform image classification. Just like other
 
 The model input is a blob that consists of a single image of "1x3x227x227" in BGR order.
 
-The model output for "alexnet" is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
+The model output for `alexnet` is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
 ## Example
 

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -1,0 +1,29 @@
+# alexnet
+
+## Use Case and High-Level Description
+
+The `alexnet` model is designed to perform image classification. Just like other common classification models, the `alexnet` model has been pretrained on the ImageNet image database. For details about this model, check out the [paper](http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
+
+The model input is a blob that consists of a single image of "1x3x227x227" in BGR order.
+
+The model output for "alexnet" is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,227,227`
+
+## Outputs
+
+Name: `prob`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_alexnet/readme.md]()

--- a/models/public/alexnet/alexnet.md
+++ b/models/public/alexnet/alexnet.md
@@ -25,7 +25,14 @@ The model output for "alexnet" is the usual object classifier output for the 100
 
 ## Inputs
 
-Name - `data`, shape - `1,3,227,227`
+Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -33,7 +33,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -44,7 +44,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
  
-## Outputs
+## Output
 
 Name: `fc6`
 

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -48,6 +48,6 @@ Channel order is `BGR`
 
 Name: `fc6`
 
-## License
+## Legal Information
 
 [https://raw.githubusercontent.com/liuzhuang13/DenseNet/master/LICENSE]()

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
 probability for each class in logits format
 
 ## Legal Information

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -1,0 +1,46 @@
+# densenet-121
+
+## Use Case and High-Level Description
+
+The `densenet-121` model is one of the [DenseNet](https://arxiv.org/pdf/1608.06993)
+group of models designed to perform image classification. Originally trained on
+Torch, the authors converted them into Caffe* format. All the DenseNet models have
+been pretrained on the ImageNet image database. For details about this family of
+models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+
+The model input is a blob that consists of a single image of 1x3x224x224 in BGR
+order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
+before passing the image blob into the network. In addition, values must be scaled
+by 0.017.
+
+The model output for `densenet-121` is the typical object classifier output for
+the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+See [https://github.com/shicai/DenseNet-Caffe]()
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+ 
+## Outputs
+
+Name: `fc6`
+
+## License
+
+[https://raw.githubusercontent.com/liuzhuang13/DenseNet/master/LICENSE]()

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -35,7 +35,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -43,10 +43,11 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`
- 
+
 ## Output
 
-Name: `fc6`
+Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+probability for each class in logits format
 
 ## Legal Information
 

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -20,6 +20,13 @@ the 1000 different classifications matching those in the ImageNet database.
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 5.724         |
+| MParams           | 7.971         |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 See [https://github.com/shicai/DenseNet-Caffe]()

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -4,9 +4,9 @@
 
 The `densenet-121` model is one of the [DenseNet](https://arxiv.org/pdf/1608.06993)
 group of models designed to perform image classification. Originally trained on
-Torch, the authors converted them into Caffe* format. All the DenseNet models have
+Torch, the authors converted them into Caffe\* format. All the DenseNet models have
 been pretrained on the ImageNet image database. For details about this family of
-models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+models, check out the [repository](https://github.com/shicai/DenseNet-Caffe).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
@@ -25,7 +25,7 @@ the 1000 different classifications matching those in the ImageNet database.
 | Type              | Classification|
 | GFLOPs            | 5.724         |
 | MParams           | 7.971         |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -10,7 +10,7 @@ models, check out the [repository](https://github.com/shicai/DenseNet-Caffe).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
-before passing the image blob into the network. In addition, values must be scaled
+before passing the image blob into the network. In addition, values must be divided
 by 0.017.
 
 The model output for `densenet-121` is the typical object classifier output for
@@ -35,7 +35,21 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`. 
+Mean values - [103.94,116.78,123.68], scale value - 58.8235294117647
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -46,7 +60,14 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
+probability for each class in logits format
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format
 
 ## Legal Information

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -12,7 +12,7 @@ about this family of models, check out the [repository](https://github.com/shica
 
 The model input is a blob that consists of a single image of "1x3x224x224" in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
-before passing the image blob into the network. In addition, values must be scaled
+before passing the image blob into the network. In addition, values must be divided
 by 0.017.
 
 The model output for `densenet-161` is the typical object classifier output for
@@ -37,7 +37,21 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`. 
+Mean values - [103.94,116.78,123.68], scale value - 58.8235294117647
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -48,7 +62,14 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
+probability for each class in logits format
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format
 
 ## Legal Information

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -8,9 +8,9 @@ the `densenet-121` model is the size and accuracy of the model. The `densenet-16
 is much larger at 100MB in size vs the `densenet-121` model's roughly 31MB size.
 Originally trained on Torch, the authors converted them into Caffe* format. All
 the DenseNet models have been pretrained on the ImageNet image database. For details
-about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe).
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR
+The model input is a blob that consists of a single image of 1x3x224x224 in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
 before passing the image blob into the network. In addition, values must be divided
 by 0.017.
@@ -27,11 +27,11 @@ the 1000 different classifications matching those in the ImageNet database.
 | Type              | Classification|
 | GFLOPs            | 15.561        |
 | MParams           | 28.666        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]()
+See [https://github.com/shicai/DenseNet-Caffe]().
 
 ## Performance
 

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -35,7 +35,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -46,7 +46,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
  
-## Outputs
+## Output
 
 Name: `fc6`
 

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -1,0 +1,48 @@
+# densenet-161
+
+## Use Case and High-Level Description
+
+The `densenet-161` model is one of the [DenseNet](https://arxiv.org/pdf/1608.06993)
+group of models designed to perform image classification. The main difference with
+the `densenet-121` model is the size and accuracy of the model. The `densenet-161`
+is much larger at 100MB in size vs the `densenet-121` model's roughly 31MB size.
+Originally trained on Torch, the authors converted them into Caffe* format. All
+the DenseNet models have been pretrained on the ImageNet image database. For details
+about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR
+order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
+before passing the image blob into the network. In addition, values must be scaled
+by 0.017.
+
+The model output for `densenet-161` is the typical object classifier output for
+the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+See [https://github.com/shicai/DenseNet-Caffe]()
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+ 
+## Outputs
+
+Name: `fc6`
+
+## License
+
+[https://raw.githubusercontent.com/liuzhuang13/DenseNet/master/LICENSE]()

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -48,7 +48,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
 probability for each class in logits format
 
 ## Legal Information

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -37,7 +37,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -45,10 +45,11 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`
- 
+
 ## Output
 
-Name: `fc6`
+Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+probability for each class in logits format
 
 ## Legal Information
 

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -50,6 +50,6 @@ Channel order is `BGR`
 
 Name: `fc6`
 
-## License
+## Legal Information
 
 [https://raw.githubusercontent.com/liuzhuang13/DenseNet/master/LICENSE]()

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -22,6 +22,13 @@ the 1000 different classifications matching those in the ImageNet database.
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 15.561        |
+| MParams           | 28.666        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 See [https://github.com/shicai/DenseNet-Caffe]()

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -1,0 +1,48 @@
+# densenet-169
+
+## Use Case and High-Level Description
+
+The `densenet-169` model is one of the [DenseNet](https://arxiv.org/pdf/1608.06993)
+group of models designed to perform image classification. The main difference with
+the `densenet-121` model is the size and accuracy of the model. The `densenet-169`
+is larger at just about 55MB in size vs the `densenet-121` model's roughly 31MB size.
+Originally trained on Torch, the authors converted them into Caffe* format. All
+the DenseNet models have been pretrained on the ImageNet image database. For details
+about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR
+order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
+before passing the image blob into the network. In addition, values must be scaled
+by 0.017.
+
+The model output for `densenet-169` is the typical object classifier output for
+the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+See [https://github.com/shicai/DenseNet-Caffe]()
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+ 
+## Outputs
+
+Name: `fc6`
+
+## License
+
+[https://raw.githubusercontent.com/liuzhuang13/DenseNet/master/LICENSE]()

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -8,9 +8,9 @@ the `densenet-121` model is the size and accuracy of the model. The `densenet-16
 is larger at just about 55MB in size vs the `densenet-121` model's roughly 31MB size.
 Originally trained on Torch, the authors converted them into Caffe* format. All
 the DenseNet models have been pretrained on the ImageNet image database. For details
-about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe).
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR
+The model input is a blob that consists of a single image of 1x3x224x224 in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
 before passing the image blob into the network. In addition, values must be divided
 by 0.017.
@@ -27,11 +27,11 @@ the 1000 different classifications matching those in the ImageNet database.
 | Type              | Classification|
 | GFLOPs            | 6.788         |
 | MParams           | 14.139        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]()
+See [https://github.com/shicai/DenseNet-Caffe]().
 
 ## Performance
 

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -35,7 +35,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -46,7 +46,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
  
-## Outputs
+## Output
 
 Name: `fc6`
 

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -12,7 +12,7 @@ about this family of models, check out the [repository](https://github.com/shica
 
 The model input is a blob that consists of a single image of "1x3x224x224" in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
-before passing the image blob into the network. In addition, values must be scaled
+before passing the image blob into the network. In addition, values must be divided
 by 0.017.
 
 The model output for `densenet-169` is the typical object classifier output for
@@ -37,7 +37,21 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [103.94,116.78,123.68], scale value - 58.8235294117647
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -48,7 +62,14 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
+probability for each class in logits format
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format
 
 ## License

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -48,7 +48,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
 probability for each class in logits format
 
 ## License

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -37,7 +37,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -45,10 +45,11 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`
- 
+
 ## Output
 
-Name: `fc6`
+Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+probability for each class in logits format
 
 ## License
 

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -22,6 +22,13 @@ the 1000 different classifications matching those in the ImageNet database.
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 6.788         |
+| MParams           | 14.139        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 See [https://github.com/shicai/DenseNet-Caffe]()

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -1,0 +1,48 @@
+# densenet-201
+
+## Use Case and High-Level Description
+
+The `densenet-201` model is also one of the [DenseNet](https://arxiv.org/pdf/1608.06993)
+group of models designed to perform image classification. The main difference with
+the `densenet-121` model is the size and accuracy of the model. The `densenet-201`
+is larger at over 77MB in size vs the `densenet-121` model's roughly 31MB size.
+Originally trained on Torch, the authors converted them into Caffe* format. All
+the DenseNet models have been pretrained on the ImageNet image database. For details
+about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR
+order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
+before passing the image blob into the network. In addition, values must be scaled
+by 0.017.
+
+The model output for `densenet-201` is the typical object classifier output for
+the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+See [https://github.com/shicai/DenseNet-Caffe]()
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+ 
+## Outputs
+
+Name: `fc6`
+
+## License
+
+[https://raw.githubusercontent.com/liuzhuang13/DenseNet/master/LICENSE]()

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -12,7 +12,7 @@ about this family of models, check out the [repository](https://github.com/shica
 
 The model input is a blob that consists of a single image of "1x3x224x224" in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
-before passing the image blob into the network. In addition, values must be scaled
+before passing the image blob into the network. In addition, values must be divided
 by 0.017.
 
 The model output for `densenet-201` is the typical object classifier output for
@@ -37,7 +37,21 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [103.94,116.78,123.68], scale value - 58.8235294117647
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -48,7 +62,14 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
+probability for each class in logits format
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format
 
 ## Legal Information

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -6,11 +6,11 @@ The `densenet-201` model is also one of the [DenseNet](https://arxiv.org/pdf/160
 group of models designed to perform image classification. The main difference with
 the `densenet-121` model is the size and accuracy of the model. The `densenet-201`
 is larger at over 77MB in size vs the `densenet-121` model's roughly 31MB size.
-Originally trained on Torch, the authors converted them into Caffe* format. All
+Originally trained on Torch, the authors converted them into Caffe\* format. All
 the DenseNet models have been pretrained on the ImageNet image database. For details
-about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe). 
+about this family of models, check out the [repository](https://github.com/shicai/DenseNet-Caffe).
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR
+The model input is a blob that consists of a single image of 1x3x224x224 in BGR
 order. The BGR mean values need to be subtracted as follows: [103.94, 116.78, 123.68]
 before passing the image blob into the network. In addition, values must be divided
 by 0.017.
@@ -27,11 +27,11 @@ the 1000 different classifications matching those in the ImageNet database.
 | Type              | Classification|
 | GFLOPs            | 8.673         |
 | MParams           | 20.001        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]()
+See [https://github.com/shicai/DenseNet-Caffe]().
 
 ## Performance
 

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -35,7 +35,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -46,7 +46,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
  
-## Outputs
+## Output
 
 Name: `fc6`
 

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -48,7 +48,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+Object classifier according to ImageNet classes, shape - `1,1000,1,1` contains predicted
 probability for each class in logits format
 
 ## Legal Information

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -37,7 +37,7 @@ See [https://github.com/shicai/DenseNet-Caffe]()
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -45,10 +45,11 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`
- 
+
 ## Output
 
-Name: `fc6`
+Object classifier according to ImageNet classes, shape -`1,1000,1,1` contains predicted
+probability for each class in logits format
 
 ## Legal Information
 

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -50,6 +50,6 @@ Channel order is `BGR`
 
 Name: `fc6`
 
-## License
+## Legal Information
 
 [https://raw.githubusercontent.com/liuzhuang13/DenseNet/master/LICENSE]()

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -22,6 +22,13 @@ the 1000 different classifications matching those in the ImageNet database.
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 8.673         |
+| MParams           | 20.001        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 See [https://github.com/shicai/DenseNet-Caffe]()

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -25,7 +25,7 @@ The model output for `googlenet-v1` is the typical object classifier output for 
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,10 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## Legal Information
 

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -1,0 +1,29 @@
+# googlenet-v1
+
+## Use Case and High-Level Description
+
+The `googlenet-v1` model is the first of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v1` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+
+The model output for `googlenet-v1` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`
+
+## Outputs
+
+Name: `prob`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/BVLC/caffe/master/LICENSE]()

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -12,6 +12,13 @@ The model output for `googlenet-v1` is the typical object classifier output for 
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 3.266         |
+| MParams           | 6.999         |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -23,7 +23,7 @@ The model output for `googlenet-v1` is the typical object classifier output for 
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v1` model is the first of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v1` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x224x224 in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output for `googlenet-v1` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,11 +17,11 @@ The model output for `googlenet-v1` is the typical object classifier output for 
 | Type              | Classification|
 | GFLOPs            | 3.266         |
 | MParams           | 6.999         |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet](https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet)
+See [https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet](https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet).
 
 ## Performance
 

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -25,7 +25,14 @@ The model output for `googlenet-v1` is the typical object classifier output for 
 
 ## Inputs
 
-Name - `data`, shape - `1,3,224,224`
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v1` model is the first of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v1` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output for `googlenet-v1` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -21,6 +21,8 @@ The model output for `googlenet-v1` is the typical object classifier output for 
 
 ## Accuracy
 
+See [https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet](https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet)
+
 ## Performance
 
 ## Input
@@ -36,7 +38,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/googlenet-v1/googlenet-v1.md
+++ b/models/public/googlenet-v1/googlenet-v1.md
@@ -27,7 +27,21 @@ See [https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet](https://gi
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0]
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -38,7 +52,16 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -12,6 +12,13 @@ The model output for `googlenet-v2` is the typical object classifier output for 
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 4.058         |
+| MParams           | 11.185        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -25,7 +25,7 @@ The model output for `googlenet-v2` is the typical object classifier output for 
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,10 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## Legal Information
 

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -1,0 +1,29 @@
+# googlenet-v2
+
+## Use Case and High-Level Description
+
+The `googlenet-v2` model is the second of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+
+The model output for `googlenet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`
+
+## Outputs
+
+Name: `prob`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/BVLC/caffe/master/LICENSE]()

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -25,7 +25,14 @@ The model output for `googlenet-v2` is the typical object classifier output for 
 
 ## Inputs
 
-Name - `data`, shape - `1,3,224,224`
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v2` model is the second of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR order. The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x224x224 in BGR order. The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output for `googlenet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,11 +17,11 @@ The model output for `googlenet-v2` is the typical object classifier output for 
 | Type              | Classification|
 | GFLOPs            | 4.058         |
 | MParams           | 11.185        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/lim0606/caffe-googlenet-bn](https://github.com/lim0606/caffe-googlenet-bn)
+See [https://github.com/lim0606/caffe-googlenet-bn](https://github.com/lim0606/caffe-googlenet-bn).
 
 ## Performance
 

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -27,7 +27,21 @@ See [https://github.com/lim0606/caffe-googlenet-bn](https://github.com/lim0606/c
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0]
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -38,7 +52,16 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -23,7 +23,7 @@ The model output for `googlenet-v2` is the typical object classifier output for 
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v2` model is the second of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order. The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output for `googlenet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -21,6 +21,8 @@ The model output for `googlenet-v2` is the typical object classifier output for 
 
 ## Accuracy
 
+See [https://github.com/lim0606/caffe-googlenet-bn](https://github.com/lim0606/caffe-googlenet-bn)
+
 ## Performance
 
 ## Input
@@ -36,7 +38,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/googlenet-v2/googlenet-v2.md
+++ b/models/public/googlenet-v2/googlenet-v2.md
@@ -45,4 +45,4 @@ Object classifier according to ImageNet classes, shape - `1,1000`, output data f
 
 ## Legal Information
 
-[https://raw.githubusercontent.com/BVLC/caffe/master/LICENSE]()
+[https://raw.githubusercontent.com/lim0606/caffe-googlenet-bn/master/README.md]()

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v4` model is the most recent of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v4` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x299x299" in BGR order.
+The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be scaled by 0.0078125.
 
 The model output for `googlenet-v4` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -21,6 +21,8 @@ The model output for `googlenet-v4` is the typical object classifier output for 
 
 ## Accuracy
 
+See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-model)
+
 ## Performance
 
 ## Input
@@ -36,11 +38,11 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## Legal Information
 
-[https://raw.githubusercontent.com/BVLC/caffe/master/LICENSE]()
+[https://raw.githubusercontent.com/soeaver/caffe-model/master/LICENSE]()

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -12,6 +12,13 @@ The model output for `googlenet-v4` is the typical object classifier output for 
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 24.584        |
+| MParams           | 42.648        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -23,7 +23,7 @@ The model output for `googlenet-v4` is the typical object classifier output for 
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v4` model is the most recent of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v4` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
+The model input is a blob that consists of a single image of 1x3x299x299 in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
 The model output for `googlenet-v4` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,11 +17,11 @@ The model output for `googlenet-v4` is the typical object classifier output for 
 | Type              | Classification|
 | GFLOPs            | 24.584        |
 | MParams           | 42.648        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-model)
+See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-model).
 
 ## Performance
 
@@ -65,7 +65,6 @@ Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range
-
 
 ## Legal Information
 

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -25,7 +25,14 @@ The model output for `googlenet-v4` is the typical object classifier output for 
 
 ## Inputs
 
-Name - `data`, shape - `1,3,224,224`
+Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v4` model is the most recent of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v4` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+The model input is a blob that consists of a single image of "1x3x299x299" in BGR order.
 
 The model output for `googlenet-v4` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -4,7 +4,7 @@
 
 The `googlenet-v4` model is the most recent of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v4` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be scaled by 0.0078125.
+The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
 The model output for `googlenet-v4` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -27,7 +27,21 @@ See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-mo
 
 ## Input
 
-Image, shape - `1,3,299,299`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`, shape - `1,3,299,299`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [128.0,128.0,128.0], scale value - 128.0
+
+### Converted model
+
+Image,  name - `data`, shape - `1,3,299,299`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -38,10 +52,20 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
 
 ## Legal Information
 

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -25,7 +25,7 @@ The model output for `googlenet-v4` is the typical object classifier output for 
 
 ## Input
 
-Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
+Image, shape - `1,3,299,299`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,10 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## Legal Information
 

--- a/models/public/googlenet-v4/googlenet-v4.md
+++ b/models/public/googlenet-v4/googlenet-v4.md
@@ -1,0 +1,29 @@
+# googlenet-v4
+
+## Use Case and High-Level Description
+
+The `googlenet-v4` model is the most recent of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification. Like the other Inception models, the `googlenet-v4` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+
+The model output for `googlenet-v4` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`
+
+## Outputs
+
+Name: `prob`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/BVLC/caffe/master/LICENSE]()

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -1,0 +1,29 @@
+# inception-resnet-v2
+
+## Use Case and High-Level Description
+
+The `inception-resnet-v2` model is one of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification.1 Like the other Inception models, the `inception-resnet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+
+The model output for `inception-resnet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`
+
+## Outputs
+
+Name: `prob`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/soeaver/caffe-model/master/LICENSE]()

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -25,7 +25,14 @@ The model output for `inception-resnet-v2` is the typical object classifier outp
 
 ## Inputs
 
-Name - `data`, shape - `1,3,224,224`
+Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -23,7 +23,7 @@ The model output for `inception-resnet-v2` is the typical object classifier outp
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -4,7 +4,7 @@
 
 The `inception-resnet-v2` model is one of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification.1 Like the other Inception models, the `inception-resnet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x299x299" in BGR order.
+The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be scaled by 0.0078125.
 
 The model output for `inception-resnet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -21,6 +21,8 @@ The model output for `inception-resnet-v2` is the typical object classifier outp
 
 ## Accuracy
 
+See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-model)
+
 ## Performance
 
 ## Input
@@ -36,7 +38,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -12,6 +12,13 @@ The model output for `inception-resnet-v2` is the typical object classifier outp
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 26.405        |
+| MParams           | 55.813        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -25,7 +25,7 @@ The model output for `inception-resnet-v2` is the typical object classifier outp
 
 ## Input
 
-Name - `data`, shape - `1,3,299,299`, image format is `B,C,H,W` where:
+Image, shape - `1,3,299,299`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,10 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape-`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## Legal Information
 

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -4,7 +4,7 @@
 
 The `inception-resnet-v2` model is one of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification.1 Like the other Inception models, the `inception-resnet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR order.
+The model input is a blob that consists of a single image of "1x3x299x299" in BGR order.
 
 The model output for `inception-resnet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -4,7 +4,7 @@
 
 The `inception-resnet-v2` model is one of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification.1 Like the other Inception models, the `inception-resnet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
+The model input is a blob that consists of a single image of 1x3x299x299 in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
 The model output for `inception-resnet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,11 +17,11 @@ The model output for `inception-resnet-v2` is the typical object classifier outp
 | Type              | Classification|
 | GFLOPs            | 26.405        |
 | MParams           | 55.813        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-model)
+See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-model).
 
 ## Performance
 

--- a/models/public/inception-resnet-v2/inception-resnet-v2.md
+++ b/models/public/inception-resnet-v2/inception-resnet-v2.md
@@ -4,7 +4,7 @@
 
 The `inception-resnet-v2` model is one of the [Inception](https://arxiv.org/pdf/1602.07261.pdf) family of models designed to perform image classification.1 Like the other Inception models, the `inception-resnet-v2` model has been pretrained on the ImageNet image database. For details about this family of models, check out the paper.
 
-The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be scaled by 0.0078125.
+The model input is a blob that consists of a single image of "1x3x299x299" in BGR order. The BGR mean values need to be subtracted as follows: [128.0,128.0,128.0] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
 The model output for `inception-resnet-v2` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -27,18 +27,41 @@ See [https://github.com/soeaver/caffe-model](https://github.com/soeaver/caffe-mo
 
 ## Input
 
-Image, shape - `1,3,299,299`, format is `B,C,H,W` where:
+### Original model
+
+Image,  name - `data`, shape - `1,3,299,299`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [128.0,128.0,128.0], scale value -128.0
+
+### Converted model
+
+Image,  name - `data`, shape - `1,3,299,299`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -23,7 +23,7 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `detection_out`
 

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -1,0 +1,29 @@
+# mobilenet-ssd
+
+## Use Case and High-Level Description
+
+The `mobilenet-ssd` model is a Single-Shot multibox Detection (SSD) network intended to perform object detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/chuanqi305/MobileNet-SSD).
+
+The model input is a blob that consists of a single image of "1x3x300x300" in BGR order, also like the `densenet-121` model. The BGR mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be scaled by 0.007843.
+
+The model output is a typical vector containing the tracked object data, as previously described.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,300,300`
+
+## Outputs
+
+Name: `detection_out`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/tensorflow/models/master/LICENSE]()

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -25,7 +25,7 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Input
 
-Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
+Image, shape - `1,3,300,300`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,16 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `detection_out`
+The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
+bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
+where:
+
+- `image_id` - ID of the image in the batch
+- `label` - predicted class ID
+- `conf` - confidence for the predicted class
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -21,6 +21,8 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Accuracy
 
+See [https://github.com/chuanqi305/MobileNet-SSD](https://github.com/chuanqi305/MobileNet-SSD)
+
 ## Performance
 
 ## Input

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -25,7 +25,14 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Inputs
 
-Name - `data`, shape - `1,3,300,300`
+Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -12,6 +12,13 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Detection     |
+| GFLOPs            | 2.316         |
+| MParams           | 5.783         |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -4,7 +4,7 @@
 
 The `mobilenet-ssd` model is a Single-Shot multibox Detection (SSD) network intended to perform object detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/chuanqi305/MobileNet-SSD).
 
-The model input is a blob that consists of a single image of "1x3x300x300" in BGR order, also like the `densenet-121` model. The BGR mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be scaled by 0.007843.
+The model input is a blob that consists of a single image of "1x3x300x300" in BGR order, also like the `densenet-121` model. The BGR mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.007843.
 
 The model output is a typical vector containing the tracked object data, as previously described.
 
@@ -27,7 +27,21 @@ See [https://github.com/chuanqi305/MobileNet-SSD](https://github.com/chuanqi305/
 
 ## Input
 
-Image, shape - `1,3,300,300`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `prob`,  shape - `1,3,300,300`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [127.5, 127.5, 127.5], scale value - 127.50223128904757.
+
+### Converted model
+
+Image, name - `prob`,  shape - `1,3,300,300`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -38,10 +52,21 @@ Channel order is `BGR`
 
 ## Output
 
-The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
-bounding boxes. For each detection, the description has the format:
-[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
-where:
+### Original model 
+
+The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
+
+- `image_id` - ID of the image in the batch
+- `label` - predicted class ID
+- `conf` - confidence for the predicted class
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+
+### Converted model
+
+The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -2,9 +2,9 @@
 
 ## Use Case and High-Level Description
 
-The `mobilenet-ssd` model is a Single-Shot multibox Detection (SSD) network intended to perform object detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/chuanqi305/MobileNet-SSD).
+The `mobilenet-ssd` model is a Single-Shot multibox Detection (SSD) network intended to perform object detection. This model is implemented using the Caffe\* framework. For details about this model, check out the [repository](https://github.com/chuanqi305/MobileNet-SSD).
 
-The model input is a blob that consists of a single image of "1x3x300x300" in BGR order, also like the `densenet-121` model. The BGR mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.007843.
+The model input is a blob that consists of a single image of 1x3x300x300 in BGR order, also like the `densenet-121` model. The BGR mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.007843.
 
 The model output is a typical vector containing the tracked object data, as previously described.
 
@@ -17,11 +17,11 @@ The model output is a typical vector containing the tracked object data, as prev
 | Type              | Detection     |
 | GFLOPs            | 2.316         |
 | MParams           | 5.783         |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [https://github.com/chuanqi305/MobileNet-SSD](https://github.com/chuanqi305/MobileNet-SSD)
+See [https://github.com/chuanqi305/MobileNet-SSD](https://github.com/chuanqi305/MobileNet-SSD).
 
 ## Performance
 
@@ -60,8 +60,8 @@ The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID
 - `conf` - confidence for the predicted class
-- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
-- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates are in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates are in normalized format, in range [0, 1])
 
 ### Converted model
 
@@ -71,8 +71,8 @@ The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID
 - `conf` - confidence for the predicted class
-- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
-- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates are in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates are in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -52,15 +52,15 @@ Expected color order: `RGB`.
 
 ### Original model
 
-1. Face detection, name - `prob1`, shape  - `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final refining face regions after`mtcnn-p` and `mtcnn-r`
-2. Face location, name - `conv6-2`, contains final clarifications for produced by `mtcnn-p` boxes and refined by `mtcnn-r`
-3. Control points, name - `conv6-3`, contains 5 facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region
+1. Face detection, name - `prob1`, shape  - `1,2,B`, contains scores across two classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final face regions refining after`mtcnn-p` and `mtcnn-r`.
+2. Face location, name - `conv6-2`, contains final clarifications for boxes produced by `mtcnn-p` and refined by `mtcnn-r`.
+3. Control points, name - `conv6-3`, contains five facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region.
 
 ### Converted model
 
-1. Face detection, name - `prob1`, shape  - `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final refining face regions after`mtcnn-p` and `mtcnn-r`
-2. Face location, name - `conv6-2`, contains final clarifications for produced by `mtcnn-p` boxes and refined by `mtcnn-r`
-3. Control points, name - `conv6-3`, contains 5 facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region
+1. Face detection, name - `prob1`, shape  - `1,2,B`, contains scores across two classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final face regions refining after`mtcnn-p` and `mtcnn-r`.
+2. Face location, name - `conv6-2`, contains final clarifications for boxes produced by `mtcnn-p` and refined by `mtcnn-r`.
+3. Control points, name - `conv6-3`, contains five facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region.
 
 ## Legal Information
 

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -1,0 +1,29 @@
+# mtcnn-o
+
+## Use Case and High-Level Description
+
+The `mtcnn-o` model is the third of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "o" designation indicates that this model is the "output" network intended to take the data returned from the "refine" `mtcnn-r` network, and transform it into the final output data.  For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
+
+The model input is a blob with a vector containing the refined face data, as returned by the `mtcnn-r` model.
+
+The model output is a blob with a vector containing the output face data.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,48,48`
+
+## Outputs
+
+Name: `prob1`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/DuinoDu/mtcnn/master/LICENSE]()

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -23,11 +23,11 @@ The model output is a blob with a vector containing the output face data.
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,48,48`
 
-## Outputs
+## Output
 
 Name: `prob1`
 

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -32,7 +32,7 @@ Image, shape - `1,3,48,48` in `B,C,W,H` format, where
 - `W` - width
 - `H` - height
 
-Expected color order: `BGR`
+Expected color order: `RGB`
 
 ## Output
 

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -12,6 +12,13 @@ The model output is a blob with a vector containing the output face data.
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Detection     |
+| GFLOPs            | 0.026         |
+| MParams           | 0.389         |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -25,11 +25,22 @@ The model output is a blob with a vector containing the output face data.
 
 ## Input
 
-Name - `data`, shape - `1,3,48,48`
+Image, shape - `1,3,48,48` in `B,C,W,H` format, where
+
+- `B` - input batch size
+- `C` - number of image channels
+- `W` - width
+- `H` - height
+
+Expected color order: `RGB`
+
+## 
 
 ## Output
 
-Name: `prob1`
+1. Name: `prob1` with shape `1,2,B` contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final refining face regions after`mtcnn-p` and `mtcnn-r`
+2. Name: `conv6-2` contains final clarifications for produced by `mtcnn-p` boxes and refined by `mtcnn-r`
+3. Name: `conv6-3` contains 5 facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region
 
 ## Legal Information
 

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -4,7 +4,7 @@
 
 The `mtcnn-o` model is the third of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "o" designation indicates that this model is the "output" network intended to take the data returned from the "refine" `mtcnn-r` network, and transform it into the final output data.  For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
-The model input is a blob with a vector containing the refined face data, as returned by the `mtcnn-r` model, with mean values [127.5,127.5,127.5] and scale value 0.0078125.
+The model input is a blob with a vector containing the refined face data, as returned by the `mtcnn-r` model. The mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
 The model output is a blob with a vector containing the output face data.
 
@@ -25,20 +25,42 @@ The model output is a blob with a vector containing the output face data.
 
 ## Input
 
-Image, shape - `1,3,48,48` in `B,C,W,H` format, where
+### Original model
+
+Image, name - `data`, shape - `1,3,48,48` in `B,C,W,H` format, where
 
 - `B` - input batch size
 - `C` - number of image channels
 - `W` - width
 - `H` - height
 
-Expected color order: `RGB`
+Expected color order: `RGB`.
+Mean values - [127.5, 127.5, 127.5], scale value - 128
+
+### Converted model
+
+Image, name - `data`, shape - `1,3,48,48` in `B,C,W,H` format, where
+
+- `B` - input batch size
+- `C` - number of image channels
+- `W` - width
+- `H` - height
+
+Expected color order: `RGB`.
 
 ## Output
 
-1. Name: `prob1` with shape `1,2,B` contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final refining face regions after`mtcnn-p` and `mtcnn-r`
-2. Name: `conv6-2` contains final clarifications for produced by `mtcnn-p` boxes and refined by `mtcnn-r`
-3. Name: `conv6-3` contains 5 facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region
+### Original model
+
+1. Face detection, name - `prob1`, shape  - `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final refining face regions after`mtcnn-p` and `mtcnn-r`
+2. Face location, name - `conv6-2`, contains final clarifications for produced by `mtcnn-p` boxes and refined by `mtcnn-r`
+3. Control points, name - `conv6-3`, contains 5 facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region
+
+### Converted model
+
+1. Face detection, name - `prob1`, shape  - `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for final refining face regions after`mtcnn-p` and `mtcnn-r`
+2. Face location, name - `conv6-2`, contains final clarifications for produced by `mtcnn-p` boxes and refined by `mtcnn-r`
+3. Control points, name - `conv6-3`, contains 5 facial landmarks: `left eye`, `right eye`, `nose`, `left mouth corner`, `right mouth corner` coordinates for each face region
 
 ## Legal Information
 

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `mtcnn-o` model is the third of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "o" designation indicates that this model is the "output" network intended to take the data returned from the "refine" `mtcnn-r` network, and transform it into the final output data.  For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
+The `mtcnn-o` model is the third of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe\* framework. The "o" designation indicates that this model is the "output" network intended to take the data returned from the "refine" `mtcnn-r` network, and transform it into the final output data.  For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
 The model input is a blob with a vector containing the refined face data, as returned by the `mtcnn-r` model. The mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
@@ -17,7 +17,7 @@ The model output is a blob with a vector containing the output face data.
 | Type              | Detection     |
 | GFLOPs            | 0.026         |
 | MParams           | 0.389         |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*       |
 
 ## Accuracy
 

--- a/models/public/mtcnn-o/mtcnn-o.md
+++ b/models/public/mtcnn-o/mtcnn-o.md
@@ -4,7 +4,7 @@
 
 The `mtcnn-o` model is the third of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "o" designation indicates that this model is the "output" network intended to take the data returned from the "refine" `mtcnn-r` network, and transform it into the final output data.  For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
-The model input is a blob with a vector containing the refined face data, as returned by the `mtcnn-r` model.
+The model input is a blob with a vector containing the refined face data, as returned by the `mtcnn-r` model, with mean values [127.5,127.5,127.5] and scale value 0.0078125.
 
 The model output is a blob with a vector containing the output face data.
 
@@ -32,9 +32,7 @@ Image, shape - `1,3,48,48` in `B,C,W,H` format, where
 - `W` - width
 - `H` - height
 
-Expected color order: `RGB`
-
-## 
+Expected color order: `BGR`
 
 ## Output
 

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -25,16 +25,19 @@ The model output is a blob with a vector containing the first pass of face data.
 
 ## Input
 
-Name - `data`, shape - `1,3,720,1280`, image format is `B,C,H,W` where:
+Image, shape - `1,3,720,1280`, format is `B,C,H,W`, where:
 
 - `B` - batch size
 - `C` - channel
-- `H` - height
 - `W` - width
+- `H` - height
+
+ Expected color order: `RGB`
 
 ## Output
 
-Name: `prob1`
+1. Name: `prob1` with shape `1,2,W,H` contains scores across 2 classes (0 - no face, 1 - face) for each pixel that it contains face or not.
+2. Name: `conv4-2` contains regions with detected faces.
 
 ## Legal Information
 

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -52,14 +52,13 @@ Expected color order: `RGB`.
 
 ### Original model
 
-1. Face detection, name - `prob1`, shape `1,2,W,H`, contains scores across 2 classes (0 - no face, 1 - face) for each pixel that it contains face or not.
+1. Face detection, name - `prob1`, shape - `1,2,W,H`, contains scores across two classes (0 - no face, 1 - face) for each pixel whether it contains face or not.
 2. Face location, name - `conv4-2`, contains regions with detected faces.
 
 ### Converted model
 
-1. Face detection, name - `prob1`, shape `1,2,W,H`, contains scores across 2 classes (0 - no face, 1 - face) for each pixel that it contains face or not.
+1. Face detection, name - `prob1`, shape - `1,2,W,H`, contains scores across two classes (0 - no face, 1 - face) for each pixel whether it contains face or not.
 2. Face location, name - `conv4-2`, contains regions with detected faces.
-
 
 ## Legal Information
 

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -32,7 +32,7 @@ Image, shape - `1,3,720,1280`, format is `B,C,W,H`, where:
 - `W` - width
 - `H` - height
 
-Expected color order: `BGR`
+Expected color order: `RGB`
 
 ## Output
 

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -1,0 +1,34 @@
+# mtcnn-p
+
+## Use Case and High-Level Description
+
+The `mtcnn-p` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "p" designation indicates that this model is the "proposal" network intended to find the initial set of faces. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
+
+The model input is an image containing the data to be analyzed.
+
+The model output is a blob with a vector containing the first pass of face data. If there are no faces detected, no further processing is needed. Otherwise, you will typically use this output as input to the `mtcnn-r` model.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,720,1280`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+## Outputs
+
+Name: `prob1`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/DuinoDu/mtcnn/master/LICENSE]()

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `mtcnn-p` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "p" designation indicates that this model is the "proposal" network intended to find the initial set of faces. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
+The `mtcnn-p` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe\* framework. The "p" designation indicates that this model is the "proposal" network intended to find the initial set of faces. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
 The model input is an image containing the data to be analyzed. The mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
@@ -17,7 +17,7 @@ The model output is a blob with a vector containing the first pass of face data.
 | Type              | Detection     |
 | GFLOPs            | 3.366         |
 | MParams           | 0.007         |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*       |
 
 ## Accuracy
 

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -12,6 +12,13 @@ The model output is a blob with a vector containing the first pass of face data.
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Detection     |
+| GFLOPs            | 3.366         |
+| MParams           | 0.007         |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -23,7 +23,7 @@ The model output is a blob with a vector containing the first pass of face data.
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,720,1280`, image format is `B,C,H,W` where:
 
@@ -32,7 +32,7 @@ Name - `data`, shape - `1,3,720,1280`, image format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-## Outputs
+## Output
 
 Name: `prob1`
 

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -4,7 +4,7 @@
 
 The `mtcnn-p` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "p" designation indicates that this model is the "proposal" network intended to find the initial set of faces. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
-The model input is an image containing the data to be analyzed, with mean values [127.5,127.5,127.5] and scale value 0.0078125.
+The model input is an image containing the data to be analyzed. The mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
 The model output is a blob with a vector containing the first pass of face data. If there are no faces detected, no further processing is needed. Otherwise, you will typically use this output as input to the `mtcnn-r` model.
 
@@ -25,6 +25,8 @@ The model output is a blob with a vector containing the first pass of face data.
 
 ## Input
 
+### Original model
+
 Image, shape - `1,3,720,1280`, format is `B,C,W,H`, where:
 
 - `B` - batch size
@@ -32,12 +34,32 @@ Image, shape - `1,3,720,1280`, format is `B,C,W,H`, where:
 - `W` - width
 - `H` - height
 
-Expected color order: `RGB`
+Expected color order: `RGB`.
+Mean values - [127.5, 127.5, 127.5], scale value - 128
+
+### Converted model
+
+Image, shape - `1,3,720,1280`, format is `B,C,W,H`, where:
+
+- `B` - batch size
+- `C` - channel
+- `W` - width
+- `H` - height
+
+Expected color order: `RGB`.
 
 ## Output
 
-1. Name: `prob1` with shape `1,2,W,H` contains scores across 2 classes (0 - no face, 1 - face) for each pixel that it contains face or not.
-2. Name: `conv4-2` contains regions with detected faces.
+### Original model
+
+1. Face detection, name - `prob1`, shape `1,2,W,H`, contains scores across 2 classes (0 - no face, 1 - face) for each pixel that it contains face or not.
+2. Face location, name - `conv4-2`, contains regions with detected faces.
+
+### Converted model
+
+1. Face detection, name - `prob1`, shape `1,2,W,H`, contains scores across 2 classes (0 - no face, 1 - face) for each pixel that it contains face or not.
+2. Face location, name - `conv4-2`, contains regions with detected faces.
+
 
 ## Legal Information
 

--- a/models/public/mtcnn-p/mtcnn-p.md
+++ b/models/public/mtcnn-p/mtcnn-p.md
@@ -4,7 +4,7 @@
 
 The `mtcnn-p` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "p" designation indicates that this model is the "proposal" network intended to find the initial set of faces. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
-The model input is an image containing the data to be analyzed.
+The model input is an image containing the data to be analyzed, with mean values [127.5,127.5,127.5] and scale value 0.0078125.
 
 The model output is a blob with a vector containing the first pass of face data. If there are no faces detected, no further processing is needed. Otherwise, you will typically use this output as input to the `mtcnn-r` model.
 
@@ -25,14 +25,14 @@ The model output is a blob with a vector containing the first pass of face data.
 
 ## Input
 
-Image, shape - `1,3,720,1280`, format is `B,C,H,W`, where:
+Image, shape - `1,3,720,1280`, format is `B,C,W,H`, where:
 
 - `B` - batch size
 - `C` - channel
 - `W` - width
 - `H` - height
 
- Expected color order: `RGB`
+Expected color order: `BGR`
 
 ## Output
 

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `mtcnn-r` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "r" designation indicates that this model is the "refine" network intended to refine the data returned as output from the "proposal" `mtcnn-p` network. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
+The `mtcnn-r` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe\* framework. The "r" designation indicates that this model is the "refine" network intended to refine the data returned as output from the "proposal" `mtcnn-p` network. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
 The model input is a blob with a vector containing the first pass of face data, as returned by the `mtcnn-p` model. The mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
@@ -17,7 +17,7 @@ The model output is a blob with a vector containing the refined face data. If th
 | Type              | Detection     |
 | GFLOPs            | 0.003         |
 | MParams           | 0.1           |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -52,13 +52,13 @@ Expected color order: `RGB`
 
 ### Original model
 
-1. Face detection, name - `prob1`, shape `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for refining face regions from `mtcnn-p`
-2. Face location, name - `conv5-2`, contains clarifications for produced by `mtcnn-p` boxes 
+1. Face detection, name - `prob1`, shape - `1,2,B`, contains scores across two classes (`0 `- no face, `1` - face) for each input in batch. This is necessary to refine face regions from `mtcnn-p`.
+2. Face location, name - `conv5-2`, contains clarifications for boxes produced by `mtcnn-p`.
 
 ### Converted model
 
-1. Face detection, name - `prob1`, shape `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for refining face regions from `mtcnn-p`
-2. Face location, name - `conv5-2`, contains clarifications for produced by `mtcnn-p` boxes 
+1. Face detection, name - `prob1`, shape - `1,2,B`, contains scores across two classes (`0 `- no face, `1` - face) for each input in batch. This is necessary to refine face regions from `mtcnn-p`.
+2. Face location, name - `conv5-2`, contains clarifications for boxes produced by `mtcnn-p`.
 
 ## Legal Information
 

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -1,0 +1,29 @@
+# mtcnn-r
+
+## Use Case and High-Level Description
+
+The `mtcnn-r` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "r" designation indicates that this model is the "refine" network intended to refine the data returned as output from the "proposal" `mtcnn-p` network. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
+
+The model input is a blob with a vector containing the first pass of face data, as returned by the `mtcnn-p` model.
+
+The model output is a blob with a vector containing the refined face data. If there are no faces detected by the refine pass, no further processing is needed. Otherwise, you will typically use this output as input to the `mtcnn-o` model.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,24,24`
+
+## Outputs
+
+Name: `prob1`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/DuinoDu/mtcnn/master/LICENSE]()

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -32,7 +32,7 @@ Image, shape - `1,3,24,24` in `B,C,W,H` format, where
 * `W` - width
 * `H` - height
 
-Expected color order: `BGR`
+Expected color order: `RGB`
 
 ## Output
 

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -23,11 +23,11 @@ The model output is a blob with a vector containing the refined face data. If th
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,24,24`
 
-## Outputs
+## Output
 
 Name: `prob1`
 

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -12,6 +12,13 @@ The model output is a blob with a vector containing the refined face data. If th
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Detection     |
+| GFLOPs            | 0.003         |
+| MParams           | 0.1           |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -4,7 +4,7 @@
 
 The `mtcnn-r` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "r" designation indicates that this model is the "refine" network intended to refine the data returned as output from the "proposal" `mtcnn-p` network. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
-The model input is a blob with a vector containing the first pass of face data, as returned by the `mtcnn-p` model, with mean values [127.5,127.5,127.5] and scale value 0.0078125.
+The model input is a blob with a vector containing the first pass of face data, as returned by the `mtcnn-p` model. The mean values need to be subtracted as follows: [127.5, 127.5, 127.5] before passing the image blob into the network. In addition, values must be divided by 0.0078125.
 
 The model output is a blob with a vector containing the refined face data. If there are no faces detected by the refine pass, no further processing is needed. Otherwise, you will typically use this output as input to the `mtcnn-o` model.
 
@@ -25,7 +25,21 @@ The model output is a blob with a vector containing the refined face data. If th
 
 ## Input
 
-Image, shape - `1,3,24,24` in `B,C,W,H` format, where
+### Original model
+
+Image, name - `data`, shape - `1,3,24,24` in `B,C,W,H` format, where
+
+* `B` - input batch size
+* `C` - number of image channels
+* `W` - width
+* `H` - height
+
+Expected color order: `RGB`
+Mean values - [127.5, 127.5, 127.5], scale value - 128
+
+### Converted model
+
+Image, name - `data`, shape - `1,3,24,24` in `B,C,W,H` format, where
 
 * `B` - input batch size
 * `C` - number of image channels
@@ -36,8 +50,15 @@ Expected color order: `RGB`
 
 ## Output
 
-1. Name: `prob1` with shape `1,2,B` contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for refining face regions from `mtcnn-p`
-2. Name: `conv5-2` contains clarifications for produced by `mtcnn-p` boxes 
+### Original model
+
+1. Face detection, name - `prob1`, shape `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for refining face regions from `mtcnn-p`
+2. Face location, name - `conv5-2`, contains clarifications for produced by `mtcnn-p` boxes 
+
+### Converted model
+
+1. Face detection, name - `prob1`, shape `1,2,B`, contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for refining face regions from `mtcnn-p`
+2. Face location, name - `conv5-2`, contains clarifications for produced by `mtcnn-p` boxes 
 
 ## Legal Information
 

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -4,7 +4,7 @@
 
 The `mtcnn-r` model is one of the [mtcnn](https://arxiv.org/ftp/arxiv/papers/1604/1604.02878.pdf) group of models designed to perform face detection. Short for "Multi-task Cascaded Convolutional Neural Network", it is implemented using the Caffe framework. The "r" designation indicates that this model is the "refine" network intended to refine the data returned as output from the "proposal" `mtcnn-p` network. For details about this family of models, check out the [repository](https://github.com/DuinoDu/mtcnn).
 
-The model input is a blob with a vector containing the first pass of face data, as returned by the `mtcnn-p` model.
+The model input is a blob with a vector containing the first pass of face data, as returned by the `mtcnn-p` model, with mean values [127.5,127.5,127.5] and scale value 0.0078125.
 
 The model output is a blob with a vector containing the refined face data. If there are no faces detected by the refine pass, no further processing is needed. Otherwise, you will typically use this output as input to the `mtcnn-o` model.
 
@@ -31,6 +31,8 @@ Image, shape - `1,3,24,24` in `B,C,W,H` format, where
 * `C` - number of image channels
 * `W` - width
 * `H` - height
+
+Expected color order: `BGR`
 
 ## Output
 

--- a/models/public/mtcnn-r/mtcnn-r.md
+++ b/models/public/mtcnn-r/mtcnn-r.md
@@ -25,11 +25,17 @@ The model output is a blob with a vector containing the refined face data. If th
 
 ## Input
 
-Name - `data`, shape - `1,3,24,24`
+Image, shape - `1,3,24,24` in `B,C,W,H` format, where
+
+* `B` - input batch size
+* `C` - number of image channels
+* `W` - width
+* `H` - height
 
 ## Output
 
-Name: `prob1`
+1. Name: `prob1` with shape `1,2,B` contains scores across 2 classes (`0 `- no face, `1` - face) for each input in batch. This is necessary for refining face regions from `mtcnn-p`
+2. Name: `conv5-2` contains clarifications for produced by `mtcnn-p` boxes 
 
 ## Legal Information
 

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -12,6 +12,13 @@ The model output for `squeezenet1.0` is the typical object classifier output for
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 1.737         |
+| MParams           | 1.248         |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -25,18 +25,41 @@ The model output for `squeezenet1.0` is the typical object classifier output for
 
 ## Input
 
-Image, shape - `1,3,227,227`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`, shape - `1,3,227,227`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [104, 117, 123]
+
+### Converted model
+
+Image, name - `data`, shape - `1,3,227,227`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -25,7 +25,7 @@ The model output for `squeezenet1.0` is the typical object classifier output for
 
 ## Input
 
-Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
+Image, shape - `1,3,227,227`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -33,10 +33,13 @@ Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`
- 
+
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## License
 

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -4,7 +4,7 @@
 
 The `squeezenet1.0` model is one of the [SqueezeNet](https://arxiv.org/pdf/1602.07360) topology models, is designed to perform image classification. The SqueezeNet models have been pre-trained on the ImageNet image database. For details about this family of models, check out the [repository](https://github.com/DeepScale/SqueezeNet).
 
-The model input is a blob that consists of a single image of "1x3x227x227" in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x227x227 in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
 
 The model output for `squeezenet1.0` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,7 +17,7 @@ The model output for `squeezenet1.0` is the typical object classifier output for
 | Type              | Classification|
 | GFLOPs            | 1.737         |
 | MParams           | 1.248         |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -1,0 +1,36 @@
+# squeezenet1.0
+
+## Use Case and High-Level Description
+
+The `squeezenet1.0` model is one of the [SqueezeNet](https://arxiv.org/pdf/1602.07360) topology models, is designed to perform image classification. The SqueezeNet models have been pre-trained on the ImageNet image database. For details about this family of models, check out the [repository](https://github.com/DeepScale/SqueezeNet).
+
+The model input is a blob that consists of a single image of "1x3x227x227" in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
+
+The model output for `squeezenet1.0` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+ 
+## Outputs
+
+Name: `prob`
+
+## License
+
+[https://raw.githubusercontent.com/DeepScale/SqueezeNet/master/LICENSE]()

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -23,7 +23,7 @@ The model output for `squeezenet1.0` is the typical object classifier output for
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
  
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -41,6 +41,6 @@ Object classifier according to ImageNet classes, shape - `1,1000`, output data f
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range
 
-## License
+## Legal Information
 
 [https://raw.githubusercontent.com/DeepScale/SqueezeNet/master/LICENSE]()

--- a/models/public/squeezenet1.0/squeezenet1.0.md
+++ b/models/public/squeezenet1.0/squeezenet1.0.md
@@ -36,7 +36,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -25,18 +25,41 @@ The model output for `squeezenet1.1` is the typical object classifier output for
 
 ## Input
 
-Image, shape - `1,3,227,227`, image format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`, shape - `1,3,227,227`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [104, 117, 123]
+
+### Converted model
+
+Image, name - `data`, shape - `1,3,227,227`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -23,7 +23,7 @@ The model output for `squeezenet1.1` is the typical object classifier output for
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
  
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -4,7 +4,7 @@
 
 The `squeezenet1.1` updated version of the [SqueezeNet](https://arxiv.org/pdf/1602.07360) topology. It is designed to perform image classification.  It requires 2.4x less computation than [SqueezeNet v1.0](../squeezenet1.0/squeezenet1.0.md) without diminishing accuracy. The SqueezeNet models have been pre-trained on the ImageNet image database. For details about this family of models, check out the [repository](https://github.com/DeepScale/SqueezeNet).
 
-The model input is a blob that consists of a single image of "1x3x227x227" in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x227x227 in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
 
 The model output for `squeezenet1.1` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,7 +17,7 @@ The model output for `squeezenet1.1` is the typical object classifier output for
 | Type              | Classification|
 | GFLOPs            | 0.785         |
 | MParams           | 1.236         |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -25,7 +25,7 @@ The model output for `squeezenet1.1` is the typical object classifier output for
 
 ## Input
 
-Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
+Image, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -33,10 +33,13 @@ Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`
- 
+
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## License
 

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -12,6 +12,13 @@ The model output for `squeezenet1.1` is the typical object classifier output for
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 0.785         |
+| MParams           | 1.236         |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -41,6 +41,6 @@ Object classifier according to ImageNet classes, shape - `1,1000`, output data f
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range
 
-## License
+## Legal Information
 
 [https://raw.githubusercontent.com/DeepScale/SqueezeNet/master/LICENSE]()

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -36,7 +36,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/squeezenet1.1/squeezenet1.1.md
+++ b/models/public/squeezenet1.1/squeezenet1.1.md
@@ -1,0 +1,36 @@
+# squeezenet1.1
+
+## Use Case and High-Level Description
+
+The `squeezenet1.1` updated version of the [SqueezeNet](https://arxiv.org/pdf/1602.07360) topology. It is designed to perform image classification.  It requires 2.4x less computation than [SqueezeNet v1.0](../squeezenet1.0/squeezenet1.0.md) without diminishing accuracy. The SqueezeNet models have been pre-trained on the ImageNet image database. For details about this family of models, check out the [repository](https://github.com/DeepScale/SqueezeNet).
+
+The model input is a blob that consists of a single image of "1x3x227x227" in BGR order. The BGR mean values need to be subtracted as follows: [104, 117, 123] before passing the image blob into the network.
+
+The model output for `squeezenet1.1` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,227,227`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+ 
+## Outputs
+
+Name: `prob`
+
+## License
+
+[https://raw.githubusercontent.com/DeepScale/SqueezeNet/master/LICENSE]()

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -29,7 +29,14 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Inputs
 
-Name - `data`, shape - `1,3,300,300`
+Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -29,21 +29,46 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Input
 
-Image, shape - `1,3,300,300`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - ` data`, shape - `1,3,300,300`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0]
+
+### Converted model
+
+Image, name - ` data`, shape - `1,3,300,300`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
-bounding boxes. For each detection, the description has the format:
-[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
-where:
+### Original model
+
+The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
+
+- `image_id` - ID of the image in the batch
+- `label` - predicted class ID
+- `conf` - confidence for the predicted class
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+
+### Converted model
+
+The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -1,0 +1,33 @@
+# ssd300
+
+## Use Case and High-Level Description
+
+The "ssd300" model is a a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
+
+The model input is a blob that consists of a single image of "1x3x300x300" in BGR order.
+
+The model output is a typical vector containing the tracked object data, as previously described.
+
+## Example
+
+See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+
+## Specification
+
+## Accuracy
+
+See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,300,300`
+
+## Outputs
+
+Name: `detection_out`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/weiliu89/caffe/ssd/LICENSE]()

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -27,7 +27,7 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
 
@@ -38,7 +38,7 @@ Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `detection_out`
 

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -14,6 +14,13 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Detection     |
+| GFLOPs            | 62.815        |
+| MParams           | 26.285        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 See [here](https://github.com/weiliu89/caffe/tree/ssd) 

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -4,7 +4,7 @@
 
 The "ssd300" model is a a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
 
-The model input is a blob that consists of a single image of "1x3x300x300" in BGR order.
+The model input is a blob that consists of a single image of "1x3x300x300" in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output is a typical vector containing the tracked object data, as previously described.
 

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -29,7 +29,7 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Input
 
-Name - `data`, shape - `1,3,300,300`, image format is `B,C,H,W` where:
+Image, shape - `1,3,300,300`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -40,7 +40,16 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `detection_out`
+The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
+bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
+where:
+
+- `image_id` - ID of the image in the batch
+- `label` - predicted class ID
+- `conf` - confidence for the predicted class
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -2,15 +2,15 @@
 
 ## Use Case and High-Level Description
 
-The "ssd300" model is a a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
+The "ssd300" model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe\* framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
 
-The model input is a blob that consists of a single image of "1x3x300x300" in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x300x300 in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output is a typical vector containing the tracked object data, as previously described.
 
 ## Example
 
-See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+See [here](https://github.com/weiliu89/caffe/tree/ssd).
 
 ## Specification
 
@@ -19,11 +19,11 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 | Type              | Detection     |
 | GFLOPs            | 62.815        |
 | MParams           | 26.285        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*         |
 
 ## Accuracy
 
-See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+See [here](https://github.com/weiliu89/caffe/tree/ssd).
 
 ## Performance
 
@@ -62,8 +62,8 @@ The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID
 - `conf` - confidence for the predicted class
-- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
-- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates are in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates are in normalized format, in range [0, 1])
 
 ### Converted model
 
@@ -73,8 +73,8 @@ The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID
 - `conf` - confidence for the predicted class
-- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
-- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates are in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates are in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -4,7 +4,7 @@
 
 The `ssd512` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
 
-The model input is a blob that consists of a single image of "1x3x512x512" in BGR order.
+The model input is a blob that consists of a single image of "1x3x512x512" in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output is a typical vector containing the tracked object data, as previously described.
 

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -29,21 +29,46 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Input
 
-Image, shape - `1,3,512,512`, format is `B,C,H,W` where:
+### Original model
+
+Image, name - `data`, shape - `1,3,512,512`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0]
+
+### Converted model
+
+Image, name - `data`, shape - `1,3,512,512`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
-bounding boxes. For each detection, the description has the format:
-[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
-where:
+### Original model
+
+The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
+
+- `image_id` - ID of the image in the batch
+- `label` - predicted class ID
+- `conf` - confidence for the predicted class
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+
+### Converted model
+
+The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -1,0 +1,33 @@
+# ssd512
+
+## Use Case and High-Level Description
+
+The `ssd512` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
+
+The model input is a blob that consists of a single image of "1x3x512x512" in BGR order.
+
+The model output is a typical vector containing the tracked object data, as previously described.
+
+## Example
+
+See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+
+## Specification
+
+## Accuracy
+
+See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,512,512`
+
+## Outputs
+
+Name: `detection_out`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/weiliu89/caffe/ssd/LICENSE]()

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -2,15 +2,15 @@
 
 ## Use Case and High-Level Description
 
-The `ssd512` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
+The `ssd512` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1512.02325.pdf) network intended to perform face detection. This model is implemented using the Caffe\*framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
 
-The model input is a blob that consists of a single image of "1x3x512x512" in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x512x512 in BGR order. The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 
 The model output is a typical vector containing the tracked object data, as previously described.
 
 ## Example
 
-See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+See [here](https://github.com/weiliu89/caffe/tree/ssd).
 
 ## Specification
 
@@ -19,11 +19,11 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 | Type              | Detection     |
 | GFLOPs            | 180.611       |
 | MParams           | 27.189        |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*        |
 
 ## Accuracy
 
-See [here](https://github.com/weiliu89/caffe/tree/ssd) 
+See [here](https://github.com/weiliu89/caffe/tree/ssd).
 
 ## Performance
 
@@ -62,8 +62,8 @@ The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID
 - `conf` - confidence for the predicted class
-- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
-- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates are in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates are in normalized format, in range [0, 1])
 
 ### Converted model
 
@@ -73,8 +73,8 @@ The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID
 - `conf` - confidence for the predicted class
-- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
-- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates are in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates are in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -29,7 +29,7 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Input
 
-Name - `data`, shape - `1,3,512,512`, image format is `B,C,H,W` where:
+Image, shape - `1,3,512,512`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -40,7 +40,16 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `detection_out`
+The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
+bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
+where:
+
+- `image_id` - ID of the image in the batch
+- `label` - predicted class ID
+- `conf` - confidence for the predicted class
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -27,7 +27,7 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,512,512`, image format is `B,C,H,W` where:
 
@@ -38,7 +38,7 @@ Name - `data`, shape - `1,3,512,512`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `detection_out`
 

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -14,6 +14,13 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Detection     |
+| GFLOPs            | 180.611       |
+| MParams           | 27.189        |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 See [here](https://github.com/weiliu89/caffe/tree/ssd) 

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -29,7 +29,14 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd)
 
 ## Inputs
 
-Name - `data`, shape - `1,3,512,512`
+Name - `data`, shape - `1,3,512,512`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -40,7 +40,7 @@ Channel order is `RGB`
 
 ### Converted model
 
-Image, shape - `1,300,300,3`, format is `B,H,W,C` where:
+Image, name - `image_tensor`, shape - `1,300,300,3`, format is `B,H,W,C` where:
 
 - `B` - batch size
 - `H` - height
@@ -55,18 +55,16 @@ Channel order is `BGR`
 
 ### Original model 
 
-1. Name: `detection_classes` contains predicted bounding boxes classes in range [1, 91]. The model was trained on MS COCO dataset version with 90 categories of object.
-2. Name: `detection_scores` probability of detected bounding boxes
-3. Name: `detection_boxes` contains detection boxes coordinates in format `[y_min, x_min, y_max, x_max]` where (`x_min`, `y_min`)  is coordinates top left corner,  (`x_max`, `y_max`) is coordinates right bottom corner. Coordinates rescaled to input image size.
-4. Name: `num_detections` contains the number of predicted detection boxes
+1. Classifier, name - `detection_classes`, contains predicted bounding boxes classes in range [1, 91]. The model was trained on MS COCO dataset version with 90 categories of object.
+2. Probability, name - `detection_scores`, contains probability of detected bounding boxes
+3. Detection box, name - `detection_boxes`, contains detection boxes coordinates in format `[y_min, x_min, y_max, x_max]` where (`x_min`, `y_min`)  is coordinates top left corner,  (`x_max`, `y_max`) is coordinates right bottom corner. Coordinates rescaled to input image size.
+4. Detections number, name - `num_detections`, contains the number of predicted detection boxes
 
 
-### Model in IR format
+### Converted model
 
-The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
-bounding boxes. For each detection, the description has the format:
-[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
-where:
+The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `ssd_mobilenet_v2_coco` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1801.04381.pdf) network intended to perform object detection. The differnce bewteen this model and the `mobilenet-ssd` is that there the `mobilenet-ssd` can only detect face, the `ssd_mobilenet_v2_coco` model can detect objects as it has been trained from the Common Objects in COntext (COCO) image dataset. 
+The `ssd_mobilenet_v2_coco` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1801.04381.pdf) network intended to perform object detection. The difference bewteen this model and the `mobilenet-ssd` is that there the `mobilenet-ssd` can only detect face, the `ssd_mobilenet_v2_coco` model can detect objects as it has been trained from the Common Objects in COntext (COCO) image dataset. 
 
 The model input is a blob that consists of a single image of "1x3x300x300" in RGB order.
 
@@ -32,9 +32,9 @@ Note that original model expects image in `RGB` format, converted model - in `BG
 Image, shape - `1,300,300,3`, format is `B,H,W,C` where:
 
 - `B` - batch size
-- `C` - channel
 - `H` - height
 - `W` - width
+- `C` - channel
 
 Channel order is `RGB`
 
@@ -43,15 +43,15 @@ Channel order is `RGB`
 Image, shape - `1,300,300,3`, format is `B,H,W,C` where:
 
 - `B` - batch size
-- `C` - channel
 - `H` - height
 - `W` - width
+- `C` - channel
 
 Channel order is `BGR`
 
 ## Output
 
-**ATTENTION!** After Model Optimizer conversion original output format will be changed. Detailed explanation changes after Model Optimizer conversion you an find in [Model Optimizer development guide](http://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_tf_specific_Convert_Object_Detection_API_Models.html)
+**ATTENTION!** After Model Optimizer's conversion original output format will be changed. Detailed explanation of changes after Model Optimizer's conversion you can find in [Model Optimizer development guide](http://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_tf_specific_Convert_Object_Detection_API_Models.html)
 
 ### Original model 
 

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -36,7 +36,7 @@ Image, shape - `1,300,300,3`, format is `B,H,W,C` where:
 - `W` - width
 - `C` - channel
 
-Channel order is `RGB`
+Channel order is `RGB`.
 
 ### Converted model
 
@@ -47,23 +47,23 @@ Image, name - `image_tensor`, shape - `1,300,300,3`, format is `B,H,W,C` where:
 - `W` - width
 - `C` - channel
 
-Channel order is `BGR`
+Channel order is `BGR`.
 
 ## Output
 
-**ATTENTION!** After Model Optimizer's conversion original output format will be changed. Detailed explanation of changes after Model Optimizer's conversion you can find in [Model Optimizer development guide](http://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_tf_specific_Convert_Object_Detection_API_Models.html)
+> **NOTE** output format changes after Model Optimizer conversion. To find detailed explanation of changes, go to [Model Optimizer development guide](http://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_tf_specific_Convert_Object_Detection_API_Models.html)
 
 ### Original model 
 
-1. Classifier, name - `detection_classes`, contains predicted bounding boxes classes in range [1, 91]. The model was trained on MS COCO dataset version with 90 categories of object.
-2. Probability, name - `detection_scores`, contains probability of detected bounding boxes
-3. Detection box, name - `detection_boxes`, contains detection boxes coordinates in format `[y_min, x_min, y_max, x_max]` where (`x_min`, `y_min`)  is coordinates top left corner,  (`x_max`, `y_max`) is coordinates right bottom corner. Coordinates rescaled to input image size.
-4. Detections number, name - `num_detections`, contains the number of predicted detection boxes
+1. Classifier, name - `detection_classes`, contains predicted bounding boxes classes in range [1, 91]. The model was trained on Microsoft\* COCO dataset version with 90 categories of object.
+2. Probability, name - `detection_scores`, contains probability of detected bounding boxes.
+3. Detection box, name - `detection_boxes`, contains detection boxes coordinates in format `[y_min, x_min, y_max, x_max]`, where (`x_min`, `y_min`)  are coordinates top left corner, (`x_max`, `y_max`) are coordinates right bottom corner. Coordinates are rescaled to input image size.
+4. Detections number, name - `num_detections`, contains the number of predicted detection boxes.
 
 
 ### Converted model
 
-The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
+The array of summary detection information, name - `detection_out`,  shape - `1, 1, N, 7`, where N is the number of detected bounding boxes. For each detection, the description has the format:
 [`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
 
 - `image_id` - ID of the image in the batch

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -32,6 +32,8 @@ Name - `data`, shape - `1,300,300,3` image format is `B,H,W,C` where:
 - `H` - height
 - `W` - width
 
+Channel order is `BGR`
+
 ## Outputs
 
 1. Name: `detection_classes`

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -2,9 +2,9 @@
 
 ## Use Case and High-Level Description
 
-The `ssd_mobilenet_v2_coco` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1801.04381.pdf) network intended to perform object detection. The difference bewteen this model and the `mobilenet-ssd` is that there the `mobilenet-ssd` can only detect face, the `ssd_mobilenet_v2_coco` model can detect objects as it has been trained from the Common Objects in COntext (COCO) image dataset. 
+The `ssd_mobilenet_v2_coco` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1801.04381.pdf) network intended to perform object detection. The difference between this model and the `mobilenet-ssd` is that the while `mobilenet-ssd` detects faces only, the `ssd_mobilenet_v2_coco` model detects objects, as it has been trained from the Common Objects in Context (COCO) image dataset.
 
-The model input is a blob that consists of a single image of "1x3x300x300" in RGB order.
+The model input is a blob that consists of a single image of 1x3x300x300 in RGB order.
 
 The model output is a typical vector containing the tracked object data, as previously described. Note that the "class_id" data is now significant and should be used to determine the classification for any detected object.
 
@@ -17,7 +17,7 @@ The model output is a typical vector containing the tracked object data, as prev
 | Type              | Detection     |
 | GFLOPs            | 3.775         |
 | MParams           | 16.818        |
-| Source framework  | Tensorflow    |
+| Source framework  | Tensorflow\*    |
 
 ## Accuracy
 
@@ -69,8 +69,8 @@ The array of detection summary info, name - `detection_out`,  shape - `1, 1, N, 
 - `image_id` - ID of the image in the batch
 - `label` - predicted class ID
 - `conf` - confidence for the predicted class
-- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
-- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates are in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates are in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -25,7 +25,7 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Input
 
-Name - `data`, shape - `1,300,300,3` image format is `B,H,W,C` where:
+Image, shape - `1,300,300,3`, format is `B,H,W,C` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,10 +36,28 @@ Channel order is `BGR`
 
 ## Output
 
-1. Name: `detection_classes`
-2. Name: `detection_scores`
-3. Name: `detection_boxes`
-4. Name: `num_detections`
+**ATTENTION!** After Model Optimizer conversion original output format will be changed. Detailed explanation changes after Model Optimizer conversion you an find in [Model Optimizer development guide](http://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_tf_specific_Convert_Object_Detection_API_Models.html)
+
+### Original model 
+
+1. Name: `detection_classes` contains predicted bounding boxes classes in range [1, 91]. The model was trained on MS COCO dataset version with 90 categories of object.
+2. Name: `detection_scores` probability of detected bounding boxes
+3. Name: `detection_boxes` contains detection boxes coordinates in format `[y_min, x_min, y_max, x_max]` where (`x_min`, `y_min`)  is coordinates top left corner,  (`x_max`, `y_max`) is coordinates right bottom corner. Coordinates rescaled to input image size.
+4. Name: `num_detections` contains the number of predicted detection boxes
+
+
+### Model in IR format
+
+The net outputs a blob with shape: [1, 1, N, 7], where N is the number of detected
+bounding boxes. For each detection, the description has the format:
+[`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`],
+where:
+
+- `image_id` - ID of the image in the batch
+- `label` - predicted class ID
+- `conf` - confidence for the predicted class
+- (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
+- (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
 
 ## Legal Information
 

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -23,7 +23,7 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,300,300,3` image format is `B,H,W,C` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,300,300,3` image format is `B,H,W,C` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 1. Name: `detection_classes`
 2. Name: `detection_scores`

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -1,0 +1,37 @@
+# ssd_mobilenet_v2_coco
+
+## Use Case and High-Level Description
+
+The `ssd_mobilenet_v2_coco` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1801.04381.pdf) network intended to perform object detection. The differnce bewteen this model and the `mobilenet-ssd` is that there the `mobilenet-ssd` can only detect face, the `ssd_mobilenet_v2_coco` model can detect objects as it has been trained from the Common Objects in COntext (COCO) image dataset. 
+
+The model input is a blob that consists of a single image of "1x3x300x300" in BGR order.
+
+The model output is a typical vector containing the tracked object data, as previously described. Note that the "class_id" data is now significant and should be used to determine the classification for any detected object.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,300,300,3` image format is `B,H,W,C` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+## Outputs
+
+1. Name: `detection_classes`
+2. Name: `detection_scores`
+3. Name: `detection_boxes`
+4. Name: `num_detections`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/tensorflow/models/master/LICENSE]()

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -4,7 +4,7 @@
 
 The `ssd_mobilenet_v2_coco` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/pdf/1801.04381.pdf) network intended to perform object detection. The differnce bewteen this model and the `mobilenet-ssd` is that there the `mobilenet-ssd` can only detect face, the `ssd_mobilenet_v2_coco` model can detect objects as it has been trained from the Common Objects in COntext (COCO) image dataset. 
 
-The model input is a blob that consists of a single image of "1x3x300x300" in BGR order.
+The model input is a blob that consists of a single image of "1x3x300x300" in RGB order.
 
 The model output is a typical vector containing the tracked object data, as previously described. Note that the "class_id" data is now significant and should be used to determine the classification for any detected object.
 
@@ -24,6 +24,21 @@ The model output is a typical vector containing the tracked object data, as prev
 ## Performance
 
 ## Input
+
+Note that original model expects image in `RGB` format, converted model - in `BGR` format.
+
+### Original model
+
+Image, shape - `1,300,300,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+### Converted model
 
 Image, shape - `1,300,300,3`, format is `B,H,W,C` where:
 

--- a/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
+++ b/models/public/ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md
@@ -12,6 +12,13 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Detection     |
+| GFLOPs            | 3.775         |
+| MParams           | 16.818        |
+| Source framework  | Tensorflow    |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -25,7 +25,7 @@ The model output for `vgg16` is the typical object classifier output for the 100
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,11 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
 
 ## Legal Information
 

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `vgg16` model is one of the [vgg](https://arxiv.org/pdf/1409.1556.pdf) models designed to perform image classification in Caffe format.
+The `vgg16` model is one of the [vgg](https://arxiv.org/pdf/1409.1556.pdf) models designed to perform image classification in Caffe\*format.
 
 The model input is a blob that consists of a single image of "1x3x224x224" in BGR order. The BGR mean values need to be subtracted as follows: [103.939, 116.779, 123.68] before passing the image blob into the network.
 
@@ -17,7 +17,7 @@ The model output for `vgg16` is the typical object classifier output for the 100
 | Type              | Classification|
 | GFLOPs            | 30.974        |
 | MParams           | 138.358       |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*        |
 
 ## Accuracy
 

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -23,7 +23,7 @@ The model output for `vgg16` is the typical object classifier output for the 100
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -36,11 +36,10 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range
-
 
 ## Legal Information
 

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -25,7 +25,14 @@ The model output for `vgg16` is the typical object classifier output for the 100
 
 ## Inputs
 
-Name - `data`, shape - `1,3,224,224`
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -1,0 +1,29 @@
+# vgg16
+
+## Use Case and High-Level Description
+
+The `vgg16` model is one of the [vgg](https://arxiv.org/pdf/1409.1556.pdf) models designed to perform image classification in Caffe format.
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order. The BGR mean values need to be subtracted as follows: [103.939, 116.779, 123.68] before passing the image blob into the network.
+
+The model output for `vgg16` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`
+
+## Outputs
+
+Name: `prob`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/keras-team/keras/master/LICENSE]()

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -12,6 +12,13 @@ The model output for `vgg16` is the typical object classifier output for the 100
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 30.974        |
+| MParams           | 138.358       |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/vgg16/vgg16.md
+++ b/models/public/vgg16/vgg16.md
@@ -25,18 +25,41 @@ The model output for `vgg16` is the typical object classifier output for the 100
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original mode
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [103.939, 116.779, 123.68]
+
+### Converted model
+
+Image, name - `data`, shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -2,9 +2,9 @@
 
 ## Use Case and High-Level Description
 
-The `vgg19` model is one of the [vgg](https://arxiv.org/pdf/1409.1556.pdf) models designed to perform image classification in Caffe format.
+The `vgg19` model is one of the [vgg](https://arxiv.org/pdf/1409.1556.pdf) models designed to perform image classification in Caffe\* format.
 
-The model input is a blob that consists of a single image of "1x3x224x224" in BGR order. The BGR mean values need to be subtracted as follows: [103.939, 116.779, 123.68] before passing the image blob into the network.
+The model input is a blob that consists of a single image of 1x3x224x224 in BGR order. The BGR mean values need to be subtracted as follows: [103.939, 116.779, 123.68] before passing the image blob into the network.
 
 The model output for `vgg19` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
 
@@ -17,7 +17,7 @@ The model output for `vgg19` is the typical object classifier output for the 100
 | Type              | Classification|
 | GFLOPs            | 39.3          |
 | MParams           | 143.667       |
-| Source framework  | Caffe         |
+| Source framework  | Caffe\*        |
 
 ## Accuracy
 

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -25,7 +25,7 @@ The model output for `vgg19` is the typical object classifier output for the 100
 
 ## Input
 
-Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
@@ -36,7 +36,10 @@ Channel order is `BGR`
 
 ## Output
 
-Name: `prob`
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
 
 ## Legal Information
 

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -25,18 +25,41 @@ The model output for `vgg19` is the typical object classifier output for the 100
 
 ## Input
 
-Image, shape - `1,3,224,224`, format is `B,C,H,W` where:
+### Original mode
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 
 - `B` - batch size
 - `C` - channel
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`
+Channel order is `BGR`.
+Mean values - [103.939, 116.779, 123.68]
+
+### Converted model
+
+Image, name - `data`, shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
 
 ## Output
 
-Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -1,0 +1,29 @@
+# vgg19
+
+## Use Case and High-Level Description
+
+The `vgg19` model is one of the [vgg](https://arxiv.org/pdf/1409.1556.pdf) models designed to perform image classification in Caffe format.
+
+The model input is a blob that consists of a single image of "1x3x224x224" in BGR order. The BGR mean values need to be subtracted as follows: [103.939, 116.779, 123.68] before passing the image blob into the network.
+
+The model output for `vgg19` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+## Accuracy
+
+## Performance
+
+## Inputs
+
+Name - `data`, shape - `1,3,224,224`
+
+## Outputs
+
+Name: `prob`
+
+## Legal Information
+
+[https://raw.githubusercontent.com/keras-team/keras/master/LICENSE]()

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -12,6 +12,13 @@ The model output for `vgg19` is the typical object classifier output for the 100
 
 ## Specification
 
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 39.3          |
+| MParams           | 143.667       |
+| Source framework  | Caffe         |
+
 ## Accuracy
 
 ## Performance

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -23,7 +23,7 @@ The model output for `vgg19` is the typical object classifier output for the 100
 
 ## Performance
 
-## Inputs
+## Input
 
 Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
@@ -34,7 +34,7 @@ Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
 
 Channel order is `BGR`
 
-## Outputs
+## Output
 
 Name: `prob`
 

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -25,7 +25,14 @@ The model output for `vgg19` is the typical object classifier output for the 100
 
 ## Inputs
 
-Name - `data`, shape - `1,3,224,224`
+Name - `data`, shape - `1,3,224,224`, image format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
 
 ## Outputs
 

--- a/models/public/vgg19/vgg19.md
+++ b/models/public/vgg19/vgg19.md
@@ -36,7 +36,7 @@ Channel order is `BGR`
 
 ## Output
 
-Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+Object classifier according to ImageNet classes, shape - `1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
 - `C` - Predicted probabilities for each class in  [0, 1] range


### PR DESCRIPTION
Here presented draft version of public models documentation. Documentation represents markdown file, as documentation for intel models. All docs located in `models/public/<model name>` directories, and files are named after model name. Model name is taken from `list_topologies.yml`. Model descriptions are from [https://software.intel.com/en-us/articles/model-downloader-essentials](https://software.intel.com/en-us/articles/model-downloader-essentials)
Note: description for `dilataion` model exists, but it is removed from `list_topologies.yml` 