### PR TITLE
model_downloader/common.py: Order all topologies for print_all

### DIFF
--- a/model_downloader/common.py
+++ b/model_downloader/common.py
@@ -265,8 +265,11 @@ def load_topologies(config):
 # requires the --print_all, --all, --name and --list arguments to be in `args`
 def load_topologies_from_args(parser, args):
     if args.print_all:
+        print_list = []
         for top in load_topologies(args.config):
-            print(top.name)
+            print_list.append(top.name)
+        for p in sorted(print_list):
+            print(p)
         sys.exit()
 
     filter_args_count = sum([args.all, args.name is not None, args.list is not None])


### PR DESCRIPTION
Current print_all printing all topologies in non-sorted manner.
Sorted all topologies for print_all printing.

Signed-off-by: Yeoh Ee Peng <ee.peng.yeoh@intel.com>