### PR TITLE
Added description for compressed models

### DIFF
--- a/intel_models/inceptionv3-int8-sparse-v1-tf-0001/description/inceptionv3-int8-sparse-v1-tf-0001.md
+++ b/intel_models/inceptionv3-int8-sparse-v1-tf-0001/description/inceptionv3-int8-sparse-v1-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/inceptionv3-int8-sparse-v1-tf-0001/description/inceptionv3-int8-sparse-v1-tf-0001.md
+++ b/intel_models/inceptionv3-int8-sparse-v1-tf-0001/description/inceptionv3-int8-sparse-v1-tf-0001.md
@@ -1,0 +1,45 @@
+# inceptionv3-int8-sparse-v1-tf-0001
+
+## Use Case and High-Level Description
+
+This is the Inception v3 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then pruned to **30.9%** of sparsity and quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. The sparsity is represented by zeros inside the weights of Convolutional and Fully-conneted layers. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1512.03385.pdf).
+
+The model input is a blob that consists of a single image of "1x299x299x3" in BGR order.
+
+The model output for `inceptionv3-int8-sparse-v1-tf-0001` is the usual object classifier output for the 1001 different classifications matching those in the ImageNet database (the first item represents the background).
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 11.469        |
+| MParams           | 23.819        |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 78.65% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,299,299,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/inceptionv3-int8-sparse-v2-tf-0001/description/inceptionv3-int8-sparse-v2-tf-0001.md
+++ b/intel_models/inceptionv3-int8-sparse-v2-tf-0001/description/inceptionv3-int8-sparse-v2-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/inceptionv3-int8-sparse-v2-tf-0001/description/inceptionv3-int8-sparse-v2-tf-0001.md
+++ b/intel_models/inceptionv3-int8-sparse-v2-tf-0001/description/inceptionv3-int8-sparse-v2-tf-0001.md
@@ -1,0 +1,45 @@
+# inceptionv3-int8-sparse-v2-tf-0001
+
+## Use Case and High-Level Description
+
+This is the Inception v3 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then pruned to **59.9%** of sparsity and quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. The sparsity is represented by zeros inside the weights of Convolutional and Fully-conneted layers. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1512.03385.pdf).
+
+The model input is a blob that consists of a single image of "1x299x299x3" in BGR order.
+
+The model output for `inceptionv3-int8-sparse-v2-tf-0001` is the usual object classifier output for the 1001 different classifications matching those in the ImageNet database (the first item represents the background).
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 11.469        |
+| MParams           | 23.819        |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 78.26% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,299,299,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/inceptionv3-int8-tf-0001/description/inceptionv3-int8-tf-0001.md
+++ b/intel_models/inceptionv3-int8-tf-0001/description/inceptionv3-int8-tf-0001.md
@@ -1,0 +1,45 @@
+# inceptionv3-int8-tf-0001
+
+## Use Case and High-Level Description
+
+This is the Inception v3 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1512.03385.pdf).
+
+The model input is a blob that consists of a single image of "1x299x299x3" in BGR order.
+
+The model output for `inceptionv3-int8-tf-0001` is the usual object classifier output for the 1001 different classifications matching those in the ImageNet database (the first item represents the background).
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 11.469        |
+| MParams           | 23.819        |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 78.07% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,299,299,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/inceptionv3-int8-tf-0001/description/inceptionv3-int8-tf-0001.md
+++ b/intel_models/inceptionv3-int8-tf-0001/description/inceptionv3-int8-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/index.md
+++ b/intel_models/index.md
@@ -172,6 +172,15 @@ Deep Learning compressed models
 | Model Name                                                                                                                                     | Complexity (GFLOPs)  | Size (Mp)  |
 |------------------------------------------------------------------------------------------------------------------------------------------------|--------------------- |----------- |
 | [resnet50-binary-0001](./resnet50-binary-0001/description/resnet50-binary-0001.md)                                                             | 1.002                | 7.446      |
+| [resnet-50-int8-tf-0001](./resnet-50-int8-tf-0001/description/resnet-50-int8-tf-0001.md)                                                       | 6.996                | 25.53      |
+| [resnet-50-int8-sparse-v1-tf-0001](./resnet-50-int8-sparse-v1-tf-0001/description/resnet-50-int8-sparse-v1-tf-0001.md)                         | 6.996                | 25.53      |
+| [resnet-50-int8-sparse-v2-tf-0001](./resnet-50-int8-sparse-v2-tf-0001/description/resnet-50-int8-sparse-v2-tf-0001.md)                         | 6.996                | 25.53      |
+| [inceptionv3-int8-tf-0001](./inceptionv3-int8-tf-0001/description/inceptionv3-int8-tf-0001.md)                                                 | 11.469               | 23.819     |
+| [inceptionv3-int8-sparse-v1-tf-0001](./inceptionv3-int8-sparse-v1-tf-0001/description/inceptionv3-int8-sparse-v1-tf-0001.md)                   | 11.469               | 23.819     |
+| [inceptionv3-int8-sparse-v2-tf-0001](./inceptionv3-int8-sparse-v2-tf-0001/description/inceptionv3-int8-sparse-v2-tf-0001.md)                   | 11.469               | 23.819     |
+| [mobilenetv2-int8-tf-0001](./mobilenetv2-int8-tf-0001/description/mobilenetv2-int8-tf-0001.md)                                                 | 0.615                | 3.489      |
+| [mobilenetv2-int8-sparse-v1-tf-0001](./mobilenetv2-int8-sparse-v1-tf-0001/description/mobilenetv2-int8-sparse-v1-tf-0001.md)                   | 0.615                | 3.489      |
+| [mobilenetv2-int8-sparse-v2-tf-0001](./mobilenetv2-int8-sparse-v2-tf-0001/description/mobilenetv2-int8-sparse-v2-tf-0001.md)                   | 0.615                | 3.489      |
 
 ## Legal Information
 [*] Other names and brands may be claimed as the property of others.

--- a/intel_models/mobilenetv2-int8-sparse-v1-tf-0001/description/mobilenetv2-int8-sparse-v1-tf-0001.md
+++ b/intel_models/mobilenetv2-int8-sparse-v1-tf-0001/description/mobilenetv2-int8-sparse-v1-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/mobilenetv2-int8-sparse-v1-tf-0001/description/mobilenetv2-int8-sparse-v1-tf-0001.md
+++ b/intel_models/mobilenetv2-int8-sparse-v1-tf-0001/description/mobilenetv2-int8-sparse-v1-tf-0001.md
@@ -1,0 +1,45 @@
+# mobilenetv2-int8-sparse-v1-tf-0001
+
+## Use Case and High-Level Description
+
+This is the MobileNet v2 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then pruned to **30.8%** of sparsity and quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. The sparsity is represented by zeros inside the weights of Convolutional and Fully-conneted layers. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1801.04381.pdf).
+
+The model input is a blob that consists of a single image of "1x224x224x3" in BGR order.
+
+The model output for `mobilenetv2-int8-sparse-v1-tf-0001` is the usual object classifier output for the 1001 different classifications matching those in the ImageNet database (the first item represents the background).
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 0.615         |
+| MParams           | 3.489         |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 71.42% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,224,224,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/mobilenetv2-int8-sparse-v2-tf-0001/description/mobilenetv2-int8-sparse-v2-tf-0001.md
+++ b/intel_models/mobilenetv2-int8-sparse-v2-tf-0001/description/mobilenetv2-int8-sparse-v2-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/mobilenetv2-int8-sparse-v2-tf-0001/description/mobilenetv2-int8-sparse-v2-tf-0001.md
+++ b/intel_models/mobilenetv2-int8-sparse-v2-tf-0001/description/mobilenetv2-int8-sparse-v2-tf-0001.md
@@ -1,0 +1,45 @@
+# mobilenetv2-int8-sparse-v2-tf-0001
+
+## Use Case and High-Level Description
+
+This is the MobileNet v2 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then pruned to **59.3%** of sparsity and quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. The sparsity is represented by zeros inside the weights of Convolutional and Fully-conneted layers. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1801.04381.pdf).
+
+The model input is a blob that consists of a single image of "1x224x224x3" in BGR order.
+
+The model output for `mobilenetv2-int8-sparse-v2-tf-0001` is the usual object classifier output for the 1001 different classifications matching those in the ImageNet database (the first item represents the background).
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 0.615         |
+| MParams           | 3.489         |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 70.85% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,224,224,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/mobilenetv2-int8-tf-0001/description/mobilenetv2-int8-tf-0001.md
+++ b/intel_models/mobilenetv2-int8-tf-0001/description/mobilenetv2-int8-tf-0001.md
@@ -1,0 +1,45 @@
+# mobilenetv2-int8-tf-0001
+
+## Use Case and High-Level Description
+
+This is the MobileNet v2 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1801.04381.pdf).
+
+The model input is a blob that consists of a single image of "1x224x224x3" in BGR order.
+
+The model output for `mobilenetv2-int8-tf-0001` is the usual object classifier output for the 1001 different classifications matching those in the ImageNet database (the first item represents the background).
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 0.615         |
+| MParams           | 3.489         |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 70.8% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,224,224,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/mobilenetv2-int8-tf-0001/description/mobilenetv2-int8-tf-0001.md
+++ b/intel_models/mobilenetv2-int8-tf-0001/description/mobilenetv2-int8-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1001`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/resnet-50-int8-sparse-v1-tf-0001/description/resnet-50-int8-sparse-v1-tf-0001.md
+++ b/intel_models/resnet-50-int8-sparse-v1-tf-0001/description/resnet-50-int8-sparse-v1-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/resnet-50-int8-sparse-v1-tf-0001/description/resnet-50-int8-sparse-v1-tf-0001.md
+++ b/intel_models/resnet-50-int8-sparse-v1-tf-0001/description/resnet-50-int8-sparse-v1-tf-0001.md
@@ -1,0 +1,45 @@
+# resnet-50-int8-sparse-v1-tf-0001
+
+## Use Case and High-Level Description
+
+This is the Resnet-50 v1 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then pruned to **28.4%** of sparsity and quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. The sparsity is represented by zeros inside the weights of Convolutional and Fully-conneted layers. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1512.03385.pdf).
+
+The model input is a blob that consists of a single image of "1x224x224x3" in BGR order.
+
+The model output for `resnet-50-int8-sparse-v1-tf-0001` is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 6.996         |
+| MParams           | 25.53         |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 76.1% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,224,224,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/resnet-50-int8-sparse-v2-tf-0001/description/resnet-50-int8-sparse-v2-tf-0001.md
+++ b/intel_models/resnet-50-int8-sparse-v2-tf-0001/description/resnet-50-int8-sparse-v2-tf-0001.md
@@ -1,0 +1,45 @@
+# resnet-50-int8-sparse-v2-tf-0001
+
+## Use Case and High-Level Description
+
+This is the Resnet-50 v1 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then pruned to **60.4%** of sparsity and quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. The sparsity is represented by zeros inside the weights of Convolutional and Fully-conneted layers. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1512.03385.pdf).
+
+The model input is a blob that consists of a single image of "1x224x224x3" in BGR order.
+
+The model output for `resnet-50-int8-sparse-v2-tf-0001` is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 6.996         |
+| MParams           | 25.53         |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 75.9% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,224,224,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+

--- a/intel_models/resnet-50-int8-sparse-v2-tf-0001/description/resnet-50-int8-sparse-v2-tf-0001.md
+++ b/intel_models/resnet-50-int8-sparse-v2-tf-0001/description/resnet-50-int8-sparse-v2-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/resnet-50-int8-tf-0001/description/resnet-50-int8-tf-0001.md
+++ b/intel_models/resnet-50-int8-tf-0001/description/resnet-50-int8-tf-0001.md
@@ -41,5 +41,5 @@ Channel order is `BGR`
 Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
 
 - `B` - batch size
-- `C` - Predicted probabilities for each class in  [0, 1] range
+- `C` - predicted probabilities for each class in  [0, 1] range
 

--- a/intel_models/resnet-50-int8-tf-0001/description/resnet-50-int8-tf-0001.md
+++ b/intel_models/resnet-50-int8-tf-0001/description/resnet-50-int8-tf-0001.md
@@ -1,0 +1,45 @@
+# resnet-50-int8-tf-0001
+
+## Use Case and High-Level Description
+
+This is the Resnet-50 v1 model that is designed to perform image classification. The model has been pretrained on the ImageNet image database and then quantized to INT8 fixed-point precision using so-called Quantization-aware training approach implemented in TensorFlow framework. For details about the original floating point model, check out the [paper](https://arxiv.org/pdf/1512.03385.pdf).
+
+The model input is a blob that consists of a single image of "1x224x224x3" in BGR order.
+
+The model output for `resnet-50-int8-tf-0001` is the usual object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 6.996         |
+| MParams           | 25.53         |
+| Source framework  | TensorFlow    |
+
+## Accuracy
+
+The quality metrics calculated on ImageNet validation dataset is 74.6% accuracy top-1.
+
+## Performance
+
+## Input
+
+Image, shape - `1,224,224,3`, format is `B,H,W,C` where:
+
+- `B` - batch size
+- `H` - height
+- `W` - width
+- `C` - channel
+
+Channel order is `BGR`
+
+## Output
+
+Object classifier according to ImageNet classes, shape -`1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+


### PR DESCRIPTION
Added description for:

- ResNet-50 v1 INT8 quantized from TF
- ResNet-50 v1 INT8 quantized + sparse < 50% from TF
- ResNet-50 v1 INT8 quantized + sparse > 50% from TF
- Inception v3 INT8 quantized from TF
- Inception v3 INT8 quantized + sparse < 50%  from TF
- Inception v3 INT8 quantized + sparse > 50%  from TF
- MobileNet v2 INT8 quantized from TF
- MobileNet v2 INT8 quantized + sparse < 50%  from TF
- MobileNet v2 INT8 quantized + sparse > 50%  from TF