### PR TITLE
downloader/common.py: Order all topologies for print_all

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -231,11 +231,16 @@ configuration file and exit:
 
 ```
 $ ./TOOL.py --print_all
+Sphereface
+action-recognition-0001-decoder
+action-recognition-0001-encoder
+age-gender-recognition-retail-0013
+alexnet
+brain-tumor-segmentation-0001
+ctpn
+deeplabv3
 densenet-121
-densenet-161
-densenet-169
-densenet-201
-squeezenet1.0
+densenet-121-tf
 [...]
 ```
 

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -321,8 +321,9 @@ def load_topologies(config):
 # requires the --print_all, --all, --name and --list arguments to be in `args`
 def load_topologies_from_args(parser, args):
     if args.print_all:
-        for top in load_topologies(args.config):
-            print(top.name)
+        print_list = [top.name for top in load_topologies(args.config)]
+        for p in sorted(print_list):
+            print(p)
         sys.exit()
 
     filter_args_count = sum([args.all, args.name is not None, args.list is not None])


### PR DESCRIPTION
Current print_all printing all topologies in non-sorted manner.
Order all topologies for print_all to print sorted topologies.

Signed-off-by: Yeoh Ee Peng <ee.peng.yeoh@intel.com>