### PR TITLE
[Accuracy Checker]: fix namespace compatibility bug

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/metrics/detection.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/detection.py
@@ -24,7 +24,10 @@ import numpy as np
 from ..utils import finalize_metric_result
 from .overlap import Overlap, IOA
 from ..config import BoolField, NumberField, StringField
-from ..representation import DetectionAnnotation, DetectionPrediction
+from ..representation import (
+    DetectionAnnotation, DetectionPrediction,
+    ActionDetectionPrediction, ActionDetectionAnnotation
+)
 from .metric import Metric, FullDatasetEvaluationMetric
 
 class APIntegralType(enum.Enum):
@@ -130,8 +133,8 @@ class DetectionMAP(BaseDetectionMetricMixin, FullDatasetEvaluationMetric):
 
     __provider__ = 'map'
 
-    annotation_types = (DetectionAnnotation, )
-    prediction_types = (DetectionPrediction, )
+    annotation_types = (DetectionAnnotation, ActionDetectionAnnotation)
+    prediction_types = (DetectionPrediction, ActionDetectionPrediction)
 
     @classmethod
     def parameters(cls):
@@ -180,8 +183,8 @@ class MissRate(BaseDetectionMetricMixin, FullDatasetEvaluationMetric):
 
     __provider__ = 'miss_rate'
 
-    annotation_types = (DetectionAnnotation, )
-    prediction_types = (DetectionPrediction, )
+    annotation_types = (DetectionAnnotation, ActionDetectionAnnotation)
+    prediction_types = (DetectionPrediction, ActionDetectionPrediction)
 
     @classmethod
     def parameters(cls):
@@ -219,8 +222,8 @@ class Recall(BaseDetectionMetricMixin, FullDatasetEvaluationMetric):
 
     __provider__ = 'recall'
 
-    annotation_types = (DetectionAnnotation, )
-    prediction_types = (DetectionPrediction, )
+    annotation_types = (DetectionAnnotation, ActionDetectionAnnotation)
+    prediction_types = (DetectionPrediction, ActionDetectionPrediction)
 
     def evaluate(self, annotations, predictions):
         valid_labels = get_valid_labels(self.labels, self.dataset.metadata.get('background_label'))
@@ -246,8 +249,8 @@ class Recall(BaseDetectionMetricMixin, FullDatasetEvaluationMetric):
 class DetectionAccuracyMetric(BaseDetectionMetricMixin, FullDatasetEvaluationMetric):
     __provider__ = 'detection_accuracy'
 
-    annotation_types = (DetectionAnnotation, )
-    prediction_types = (DetectionPrediction, )
+    annotation_types = (DetectionAnnotation, ActionDetectionAnnotation)
+    prediction_types = (DetectionPrediction, ActionDetectionPrediction)
 
     @classmethod
     def parameters(cls):

--- a/tools/accuracy_checker/accuracy_checker/metrics/metric.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/metric.py
@@ -20,7 +20,8 @@ from ..utils import is_single_metric_source, get_supported_representations
 from ..presenters import BasePresenter
 from ..config import ConfigValidator, NumberField, StringField
 from ..dependency import ClassProvider
-from ..utils import zipped_transform, get_parameter_value_from_config
+from ..utils import zipped_transform, get_parameter_value_from_config, contains_any
+
 
 class Metric(ClassProvider):
     """
@@ -129,8 +130,15 @@ class Metric(ClassProvider):
 
     def _resolve_representation_containers(self, annotation, prediction):
         def get_resolve_subject(representation, source=None):
-            if not isinstance(representation, ContainerRepresentation):
-                return representation
+            def is_container(representation):
+                if isinstance(representation, ContainerRepresentation):
+                    return True
+                representation_parents = type(representation).__bases__
+                representation_parents_names = [parent.__name__ for parent in representation_parents]
+
+                return contains_any(representation_parents_names, (ContainerRepresentation.__name__, ))
+
+            if not is_container(representation):
 
             if not source:
                 return representation.values()

--- a/tools/accuracy_checker/accuracy_checker/metrics/metric.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/metric.py
@@ -20,7 +20,7 @@ from ..utils import is_single_metric_source, get_supported_representations
 from ..presenters import BasePresenter
 from ..config import ConfigValidator, NumberField, StringField
 from ..dependency import ClassProvider
-from ..utils import zipped_transform, get_parameter_value_from_config, contains_any
+from ..utils import zipped_transform, get_parameter_value_from_config
 
 
 class Metric(ClassProvider):
@@ -136,9 +136,10 @@ class Metric(ClassProvider):
                 representation_parents = type(representation).__bases__
                 representation_parents_names = [parent.__name__ for parent in representation_parents]
 
-                return contains_any(representation_parents_names, (ContainerRepresentation.__name__, ))
+                return ContainerRepresentation.__name__ in representation_parents_names
 
             if not is_container(representation):
+                return representation
 
             if not source:
                 return representation.values()

--- a/tools/accuracy_checker/accuracy_checker/metrics/metric.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/metric.py
@@ -131,9 +131,7 @@ class Metric(ClassProvider):
     def _resolve_representation_containers(self, annotation, prediction):
         def get_resolve_subject(representation, source=None):
             def is_container(representation):
-                if isinstance(representation, ContainerRepresentation):
-                    return True
-                representation_parents = type(representation).__bases__
+                representation_parents = type(representation).__mro__
                 representation_parents_names = [parent.__name__ for parent in representation_parents]
 
                 return ContainerRepresentation.__name__ in representation_parents_names


### PR DESCRIPTION
the problem is the same as in https://github.com/opencv/open_model_zoo/pull/169, but this condition checked very rarely in usage dldt tools with pregenerated annotation pickles (happed only on several datasets from private part)