### PR TITLE
security_barrier_camera_demo: fix -no-show segfault

### DIFF
--- a/demos/security_barrier_camera_demo/main.cpp
+++ b/demos/security_barrier_camera_demo/main.cpp
@@ -804,11 +804,11 @@ int main(int argc, char* argv[]) {
         worker->join();
         const auto t1 = std::chrono::steady_clock::now();
 
-        if (FLAGS_pc) {  // Show performace results
-            for (auto& net : std::array<std::vector<InferRequest>, 3>{context.detectorsInfers.getActualInferRequests(),
-                    context.attributesInfers.getActualInferRequests(), context.platesInfers.getActualInferRequests()}) {
-                for (InferRequest& ir : net) {
-                    ir.Wait(IInferRequest::WaitMode::RESULT_READY);
+        for (auto& net : std::array<std::vector<InferRequest>, 3>{context.detectorsInfers.getActualInferRequests(),
+                context.attributesInfers.getActualInferRequests(), context.platesInfers.getActualInferRequests()}) {
+            for (InferRequest& ir : net) {
+                ir.Wait(IInferRequest::WaitMode::RESULT_READY);
+                if (FLAGS_pc) {
                     printPerformanceCounts(ir, std::cout);
                 }
             }


### PR DESCRIPTION
Earlier
./intel64/Release/security_barrier_camera_demo -i openvino_2019.2.201/deployment_tools/demo/car_1.bmp -m vehicle-license-plate-detection-barrier-0106.xml -m_va vehicle-attributes-recognition-barrier-0039.xml -no_show
could result in Segmentation fault (core dumped).

The reason was exiting the demo while IE still runs async inference