### PR TITLE
Accuracy Checker: fix getting input data shape for scalar data

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/utils.py
+++ b/tools/accuracy_checker/accuracy_checker/utils.py
@@ -379,7 +379,8 @@ def set_image_metadata(annotation, images):
     if not isinstance(data, list):
         data = [data]
     for image in data:
-        image_sizes.append(image.shape)
+        data_shape = np.shape(image) if not np.isscalar(image) else 1
+        image_sizes.append(data_shape)
     annotation.set_image_size(image_sizes)
 
     return annotation, images

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
     requirements['opencv'] = 'opencv-python'
 
-tests_requirements = OrderedDict([("PyTest", 'pytest==4.0.0'), ("PyTest Mock", 'pytest-mock')])
+tests_requirements = OrderedDict([("PyTest", 'pytest==4.0.0'), ("PyTest Mock", 'pytest-mock==1.10.4')])
 
 
 class PyTest(test_command):

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
     requirements['opencv'] = 'opencv-python'
 
-tests_requirements = OrderedDict([("PyTest", 'pytest'), ("PyTest Mock", 'pytest-mock')])
+tests_requirements = OrderedDict([("PyTest", 'pytest==4.0.0'), ("PyTest Mock", 'pytest-mock')])
 
 
 class PyTest(test_command):


### PR DESCRIPTION
usually, input data for inference in accuracy checker is ndarray. But there is model NCF where input is one scalar value. This fix handles this issue.

P.S. priority is very small, the model is not in OMZ and even has not been added to public validation yet, due to another issue related to dataset conversion.