### PR TITLE
demos: replace links to the repository with relative links

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -5,25 +5,25 @@ The Open Model Zoo demo applications are console applications that demonstrate h
 
 The Open Model Zoo includes the following demos:
 
-- [Action Recognition Python* Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/action_recognition/README.md) - Demo application for Action Recognition algorithm, which classifies actions that are being performed on input video.
-- [Crossroad Camera C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/crossroad_camera_demo/README.md) - Person Detection followed by the Person Attributes Recognition and Person Reidentification Retail, supports images/video and camera inputs.
-- [Gaze Estimation C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/gaze_estimation_demo/README.md) - Face detection followed by gaze estimation, head pose estimation and facial landmarks regression.
-- [Human Pose Estimation C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/human_pose_estimation_demo/README.md) - Human pose estimation demo.
-- [Image Segmentation C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/segmentation_demo/README.md) - Inference of image segmentation networks like FCN8 (the demo supports only images as inputs).
-- [Instance Segmentation Python* Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/instance_segmentation_demo/README.md) - Inference of instance segmentation networks trained in `Detectron` or `maskrcnn-benchmark`.
-- [Interactive Face Detection C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md) - Face Detection coupled with Age/Gender, Head-Pose, Emotion, and Facial Landmarks detectors. Supports video and camera inputs.
-- [Mask R-CNN C++ Demo for TensorFlow* Object Detection API](https://github.com/opencv/open_model_zoo/tree/master/demos/mask_rcnn_demo/README.md) - Inference of instance segmentation networks created with TensorFlow\* Object Detection API.
-- [Multi-Channel Face Detection C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/multichannel_demo/README.md) - Simultaneous Multi Camera Face Detection demo.
-- [Object Detection C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/object_detection_demo/README.md) - Inference of object detection networks like Faster R-CNN (the demo supports only images as inputs).
-- [Object Detection for SSD C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/object_detection_demo_ssd_async/README.md) - Demo application for SSD-based Object Detection networks, new Async API performance showcase, and simple OpenCV interoperability (supports video and camera inputs).
-- [Object Detection for YOLO V3 C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/object_detection_demo_yolov3_async/README.md) - Demo application for YOLOV3-based Object Detection networks, new Async API performance showcase, and simple OpenCV interoperability (supports video and camera inputs).
-- [Pedestrian Tracker C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/pedestrian_tracker_demo/README.md) - Demo application for pedestrian tracking scenario.
-- [Security Barrier Camera C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/security_barrier_camera_demo/README.md) - Vehicle Detection followed by the Vehicle Attributes and License-Plate Recognition, supports images/video and camera inputs.
-- [Smart Classroom C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/smart_classroom_demo/README.md) - Face recognition and action detection demo for classroom environment.
-- [Super Resolution C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/super_resolution_demo/README.md) - Super Resolution demo (the demo supports only images as inputs). It enhances the resolution of the input image.
-- [Text Detection C++ Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/text_detection_demo/README.md) - Text Detection demo. It detects and recognizes multi-oriented scene text on an input image and puts a bounding box around detected area.
+- [Action Recognition Python* Demo](python_demos/action_recognition/README.md) - Demo application for Action Recognition algorithm, which classifies actions that are being performed on input video.
+- [Crossroad Camera C++ Demo](crossroad_camera_demo/README.md) - Person Detection followed by the Person Attributes Recognition and Person Reidentification Retail, supports images/video and camera inputs.
+- [Gaze Estimation C++ Demo](gaze_estimation_demo/README.md) - Face detection followed by gaze estimation, head pose estimation and facial landmarks regression.
+- [Human Pose Estimation C++ Demo](human_pose_estimation_demo/README.md) - Human pose estimation demo.
+- [Image Segmentation C++ Demo](segmentation_demo/README.md) - Inference of image segmentation networks like FCN8 (the demo supports only images as inputs).
+- [Instance Segmentation Python* Demo](python_demos/instance_segmentation_demo/README.md) - Inference of instance segmentation networks trained in `Detectron` or `maskrcnn-benchmark`.
+- [Interactive Face Detection C++ Demo](interactive_face_detection_demo/README.md) - Face Detection coupled with Age/Gender, Head-Pose, Emotion, and Facial Landmarks detectors. Supports video and camera inputs.
+- [Mask R-CNN C++ Demo for TensorFlow* Object Detection API](mask_rcnn_demo/README.md) - Inference of instance segmentation networks created with TensorFlow\* Object Detection API.
+- [Multi-Channel Face Detection C++ Demo](multichannel_demo/README.md) - Simultaneous Multi Camera Face Detection demo.
+- [Object Detection C++ Demo](object_detection_demo/README.md) - Inference of object detection networks like Faster R-CNN (the demo supports only images as inputs).
+- [Object Detection for SSD C++ Demo](object_detection_demo_ssd_async/README.md) - Demo application for SSD-based Object Detection networks, new Async API performance showcase, and simple OpenCV interoperability (supports video and camera inputs).
+- [Object Detection for YOLO V3 C++ Demo](object_detection_demo_yolov3_async/README.md) - Demo application for YOLOV3-based Object Detection networks, new Async API performance showcase, and simple OpenCV interoperability (supports video and camera inputs).
+- [Pedestrian Tracker C++ Demo](pedestrian_tracker_demo/README.md) - Demo application for pedestrian tracking scenario.
+- [Security Barrier Camera C++ Demo](security_barrier_camera_demo/README.md) - Vehicle Detection followed by the Vehicle Attributes and License-Plate Recognition, supports images/video and camera inputs.
+- [Smart Classroom C++ Demo](smart_classroom_demo/README.md) - Face recognition and action detection demo for classroom environment.
+- [Super Resolution C++ Demo](super_resolution_demo/README.md) - Super Resolution demo (the demo supports only images as inputs). It enhances the resolution of the input image.
+- [Text Detection C++ Demo](text_detection_demo/README.md) - Text Detection demo. It detects and recognizes multi-oriented scene text on an input image and puts a bounding box around detected area.
 
-\* Several C++ demos referenced above have simplified implementation in Python (`https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos`)*.
+\* Several C++ demos referenced above have simplified implementation in Python*, located in the `python_demos` directory.
 
 ## Media Files Available for Demos
 
@@ -33,44 +33,44 @@ To run the demo applications, you can use images and videos from the media files
 
 > **NOTE:** Inference Engine MYRIAD and FPGA plugins are available in [proprietary](https://software.intel.com/en-us/openvino-toolkit) distribution only.
 
-You can download the [pre-trained models](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) using the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
+You can download the [pre-trained models](../intel_models/index.md) using the OpenVINO [Model Downloader](../tools/downloader/README.md) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
 The table below shows the correlation between models, demos, and supported plugins. The plugins names are exactly as they are passed to the demos with `-d` option. The correlation between the plugins and supported devices see in the [Supported Devices](https://docs.openvinotoolkit.org/latest/_docs_IE_DG_supported_plugins_Supported_Devices.html) section.
 
 > **NOTE:** **MYRIAD** below stands for Intel® Movidius™ Neural Compute Stick, Intel® Neural Compute Stick 2, and Intel® Vision Accelerator Design with Intel® Movidius™ Vision Processing Units.
 
 | Model                                            | Demos supported on the model                                                                                 | CPU       | GPU       | MYRIAD/HDDL | HETERO:FPGA,CPU |
 |--------------------------------------------------|----------------------------------------------------------------------------------------------------------------|-----------|-----------|-------------|-----------------|
-| action-recognition-0001-decoder                  | [Action Recognition Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/action_recognition/README.md)            | Supported | Supported |             |                 |
-| action-recognition-0001-encoder                  | [Action Recognition Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/action_recognition/README.md)            | Supported | Supported |             |                 |
-| driver-action-recognition-adas-0002-decoder      | [Action Recognition Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/action_recognition/README.md)            | Supported | Supported |             |                 |
-| driver-action-recognition-adas-0002-encoder      | [Action Recognition Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/action_recognition/README.md)            | Supported | Supported |             | Supported       |
-| person-attributes-recognition-crossroad-0230     | [Crossroad Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/crossroad_camera_demo/README.md)                            | Supported | Supported |             | Supported       |
-| person-reidentification-retail-0031              | [Crossroad Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
-| person-reidentification-retail-0076              | [Crossroad Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
-| person-reidentification-retail-0079              | [Crossroad Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
-| person-vehicle-bike-detection-crossroad-0078     | [Crossroad Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
-| human-pose-estimation-adas-0001                  | [Human Pose Estimation Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/human_pose_estimation_demo/README.md)                  | Supported | Supported |             | Supported       |
-| semantic-segmentation-adas-0001                  | [Image Segmentation Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/segmentation_demo/README.md)                              | Supported | Supported |             | Supported       |
-| instance-segmentation-security-0033              | [Instance Segmentation Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/instance_segmentation_demo/README.md) | Supported | Supported |             | Supported       |
-| instance-segmentation-security-0049              | [Instance Segmentation Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/instance_segmentation_demo/README.md) | Supported | Supported |             | Supported       |
-| age-gender-recognition-retail-0013               | [Interactive Face Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
-| emotions-recognition-retail-0003                 | [Interactive Face Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
-| face-detection-adas-0001                         | [Interactive Face Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
-| face-detection-adas-binary-0001                  | [Interactive Face Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md)        | Supported | Supported |             |                 |
-| face-detection-retail-0004                       | [Interactive Face Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
-| facial-landmarks-35-adas-0002                    | [Interactive Face Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md)        | Supported | Supported |             | Supported       |
-| head-pose-estimation-adas-0001                   | [Interactive Face Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
-| license-plate-recognition-barrier-0001           | [Security Barrier Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/security_barrier_camera_demo/README.md)              | Supported | Supported | Supported   | Supported       |
-| vehicle-attributes-recognition-barrier-0039      | [Security Barrier Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/security_barrier_camera_demo/README.md)              | Supported | Supported | Supported   | Supported       |
-| vehicle-license-plate-detection-barrier-0106     | [Security Barrier Camera Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/security_barrier_camera_demo/README.md)              | Supported | Supported | Supported   | Supported       |
-| face-reidentification-retail-0095                | [Smart Classroom Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/smart_classroom_demo/README.md)                              | Supported | Supported | Supported   | Supported       |
-| landmarks-regression-retail-0009                 | [Smart Classroom Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/smart_classroom_demo/README.md)                              | Supported | Supported | Supported   | Supported       |
-| person-detection-action-recognition-0005         | [Smart Classroom Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/smart_classroom_demo/README.md)                              | Supported | Supported |             | Supported       |
-| person-detection-action-recognition-teacher-0002 | [Smart Classroom Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/smart_classroom_demo/README.md)                              | Supported | Supported |             | Supported       |
-| single-image-super-resolution-1032               | [Super Resolution Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/super_resolution_demo/README.md)                            | Supported | Supported |             | Supported       |
-| single-image-super-resolution-1033               | [Super Resolution Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/super_resolution_demo/README.md)                            | Supported | Supported |             | Supported       |
-| text-detection-0002                              | [Text Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/text_detection_demo/README.md)                                | Supported | Supported |             | Supported       |
-| text-recognition-0012                            | [Text Detection Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/text_detection_demo/README.md)                                | Supported | Supported |             |                 |
+| action-recognition-0001-decoder                  | [Action Recognition Demo](python_demos/action_recognition/README.md)            | Supported | Supported |             |                 |
+| action-recognition-0001-encoder                  | [Action Recognition Demo](python_demos/action_recognition/README.md)            | Supported | Supported |             |                 |
+| driver-action-recognition-adas-0002-decoder      | [Action Recognition Demo](python_demos/action_recognition/README.md)            | Supported | Supported |             |                 |
+| driver-action-recognition-adas-0002-encoder      | [Action Recognition Demo](python_demos/action_recognition/README.md)            | Supported | Supported |             | Supported       |
+| person-attributes-recognition-crossroad-0230     | [Crossroad Camera Demo](crossroad_camera_demo/README.md)                            | Supported | Supported |             | Supported       |
+| person-reidentification-retail-0031              | [Crossroad Camera Demo](crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
+| person-reidentification-retail-0076              | [Crossroad Camera Demo](crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
+| person-reidentification-retail-0079              | [Crossroad Camera Demo](crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
+| person-vehicle-bike-detection-crossroad-0078     | [Crossroad Camera Demo](crossroad_camera_demo/README.md)                            | Supported | Supported | Supported   | Supported       |
+| human-pose-estimation-adas-0001                  | [Human Pose Estimation Demo](human_pose_estimation_demo/README.md)                  | Supported | Supported |             | Supported       |
+| semantic-segmentation-adas-0001                  | [Image Segmentation Demo](segmentation_demo/README.md)                              | Supported | Supported |             | Supported       |
+| instance-segmentation-security-0033              | [Instance Segmentation Demo](python_demos/instance_segmentation_demo/README.md) | Supported | Supported |             | Supported       |
+| instance-segmentation-security-0049              | [Instance Segmentation Demo](python_demos/instance_segmentation_demo/README.md) | Supported | Supported |             | Supported       |
+| age-gender-recognition-retail-0013               | [Interactive Face Detection Demo](interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
+| emotions-recognition-retail-0003                 | [Interactive Face Detection Demo](interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
+| face-detection-adas-0001                         | [Interactive Face Detection Demo](interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
+| face-detection-adas-binary-0001                  | [Interactive Face Detection Demo](interactive_face_detection_demo/README.md)        | Supported | Supported |             |                 |
+| face-detection-retail-0004                       | [Interactive Face Detection Demo](interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
+| facial-landmarks-35-adas-0002                    | [Interactive Face Detection Demo](interactive_face_detection_demo/README.md)        | Supported | Supported |             | Supported       |
+| head-pose-estimation-adas-0001                   | [Interactive Face Detection Demo](interactive_face_detection_demo/README.md)        | Supported | Supported | Supported   | Supported       |
+| license-plate-recognition-barrier-0001           | [Security Barrier Camera Demo](security_barrier_camera_demo/README.md)              | Supported | Supported | Supported   | Supported       |
+| vehicle-attributes-recognition-barrier-0039      | [Security Barrier Camera Demo](security_barrier_camera_demo/README.md)              | Supported | Supported | Supported   | Supported       |
+| vehicle-license-plate-detection-barrier-0106     | [Security Barrier Camera Demo](security_barrier_camera_demo/README.md)              | Supported | Supported | Supported   | Supported       |
+| face-reidentification-retail-0095                | [Smart Classroom Demo](smart_classroom_demo/README.md)                              | Supported | Supported | Supported   | Supported       |
+| landmarks-regression-retail-0009                 | [Smart Classroom Demo](smart_classroom_demo/README.md)                              | Supported | Supported | Supported   | Supported       |
+| person-detection-action-recognition-0005         | [Smart Classroom Demo](smart_classroom_demo/README.md)                              | Supported | Supported |             | Supported       |
+| person-detection-action-recognition-teacher-0002 | [Smart Classroom Demo](smart_classroom_demo/README.md)                              | Supported | Supported |             | Supported       |
+| single-image-super-resolution-1032               | [Super Resolution Demo](super_resolution_demo/README.md)                            | Supported | Supported |             | Supported       |
+| single-image-super-resolution-1033               | [Super Resolution Demo](super_resolution_demo/README.md)                            | Supported | Supported |             | Supported       |
+| text-detection-0002                              | [Text Detection Demo](text_detection_demo/README.md)                                | Supported | Supported |             | Supported       |
+| text-recognition-0012                            | [Text Detection Demo](text_detection_demo/README.md)                                | Supported | Supported |             |                 |
 | face-person-detection-retail-0002                | any demo that supports SSD\*-based models, above                                                               | Supported | Supported | Supported   | Supported       |
 | pedestrian-and-vehicle-detector-adas-0001        | any demo that supports SSD\*-based models, above                                                               | Supported | Supported | Supported   | Supported       |
 | pedestrian-detection-adas-0002                   | any demo that supports SSD\*-based models, above                                                               | Supported | Supported | Supported   | Supported       |

--- a/demos/README.md
+++ b/demos/README.md
@@ -14,7 +14,7 @@ The Open Model Zoo includes the following demos:
 - [Interactive Face Detection C++ Demo](interactive_face_detection_demo/README.md) - Face Detection coupled with Age/Gender, Head-Pose, Emotion, and Facial Landmarks detectors. Supports video and camera inputs.
 - [Mask R-CNN C++ Demo for TensorFlow* Object Detection API](mask_rcnn_demo/README.md) - Inference of instance segmentation networks created with TensorFlow\* Object Detection API.
 - [Multi-Channel Face Detection C++ Demo](multichannel_demo/README.md) - Simultaneous Multi Camera Face Detection demo.
-- [Object Detection C++ Demo](object_detection_demo/README.md) - Inference of object detection networks like Faster R-CNN (the demo supports only images as inputs).
+- [Object Detection for Faster R-CNN C++ Demo](object_detection_demo_faster_rcnn/README.md) - Inference of object detection networks like Faster R-CNN (the demo supports only images as inputs).
 - [Object Detection for SSD C++ Demo](object_detection_demo_ssd_async/README.md) - Demo application for SSD-based Object Detection networks, new Async API performance showcase, and simple OpenCV interoperability (supports video and camera inputs).
 - [Object Detection for YOLO V3 C++ Demo](object_detection_demo_yolov3_async/README.md) - Demo application for YOLOV3-based Object Detection networks, new Async API performance showcase, and simple OpenCV interoperability (supports video and camera inputs).
 - [Pedestrian Tracker C++ Demo](pedestrian_tracker_demo/README.md) - Demo application for pedestrian tracking scenario.

--- a/demos/crossroad_camera_demo/README.md
+++ b/demos/crossroad_camera_demo/README.md
@@ -8,7 +8,7 @@ reports person attributes like gender, has hat, has long-sleeved clothes
 * `person-reidentification-retail-0079`, which is executed on top of the results from the first network and prints
 a vector of features for each detected person. This vector is used to conclude if it is already detected person or not.
 
-For more information about the pre-trained models, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained models, refer to the [model documentation](../../intel_models/index.md).
 
 Other demo objectives are:
 * Images/Video/Camera as inputs, via OpenCV*
@@ -66,7 +66,7 @@ Options:
 
 Running the application with an empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -87,6 +87,6 @@ If Person Attributes Recognition or Person Reidentification Retail are enabled, 
 
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/gaze_estimation_demo/README.md
+++ b/demos/gaze_estimation_demo/README.md
@@ -83,6 +83,6 @@ The following keys are supported:
 * Esc - to quit the demo
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/human_pose_estimation_demo/README.md
+++ b/demos/human_pose_estimation_demo/README.md
@@ -4,7 +4,7 @@ This demo showcases the work of multi-person 2D pose estimation algorithm. The t
 
 * `human-pose-estimation-0001`, which is a human pose estimation network, that produces two feature vectors. The algorithm uses these feature vectors to predict human poses.
 
-For more information about the pre-trained model, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained model, refer to the [model documentation](../../intel_models/index.md).
 
 The input frame height is scaled to model height, frame width is scaled to preserve initial aspect ratio and padded to multiple of 8.
 
@@ -42,7 +42,7 @@ Options:
 
 Running the application with an empty list of options yields an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -57,6 +57,6 @@ For example, to do inference on a CPU, run the following command:
 The demo uses OpenCV to display the resulting frame with estimated poses and text report of **FPS** - frames per second performance for the human pose estimation demo.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/interactive_face_detection_demo/README.md
+++ b/demos/interactive_face_detection_demo/README.md
@@ -10,7 +10,7 @@ This demo executes four parallel infer requests for the Age/Gender Recognition, 
 * `emotions-recognition-retail-0003`, which is executed on top of the results of the first model and reports an emotion for each detected face
 * `facial-landmarks-35-adas-0002`, which is executed on top of the results of the first model and reports normed coordinates of estimated facial landmarks
 
-For more information about the pre-trained models, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained models, refer to the [model documentation](../../intel_models/index.md).
 
 Other demo objectives are:
 
@@ -87,7 +87,7 @@ Options:
 
 Running the application with an empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -103,6 +103,6 @@ The demo uses OpenCV to display the resulting frame with detections (rendered as
 The demo reports total image throughput which includes frame decoding time, inference time, time to render bounding boxes and labels, and time to display the results.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/mask_rcnn_demo/README.md
+++ b/demos/mask_rcnn_demo/README.md
@@ -37,7 +37,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -51,6 +51,6 @@ You can use the following command to do inference on CPU on an image using a tra
 For each input image the application outputs a segmented image. For example, `out0.png` and `out1.png` are created for the network with batch size equal to 2.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/multichannel_demo/fd/README.md
+++ b/demos/multichannel_demo/fd/README.md
@@ -3,7 +3,7 @@
 This demo provides an inference pipeline for multi-channel face detection. The demo uses Face Detection network. You can use the following pre-trained model with the demo:
 * `face-detection-retail-0004`, which is a primary detection network for finding faces
 
-For more information about the pre-trained models, refer to https://github.com/opencv/open_model_zoo/blob/master/intel_models/index.md in the Open Model Zoo repository.
+For more information about the pre-trained models, refer to the [model documentation](../../../intel_models/index.md).
 
 Other demo objectives are:
 
@@ -50,7 +50,7 @@ Options:
 
 ```
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/2018/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -105,6 +105,6 @@ If your cameras are connected to PC with indexes gap (for example, `0,1,3`), use
 IP-cameras through RSTP URI interface are not supported.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/multichannel_demo/hpe/README.md
+++ b/demos/multichannel_demo/hpe/README.md
@@ -3,7 +3,7 @@
 This demo provides an inference pipeline for Multi-Channel Human Pose Estimation. The demo uses Human Pose Estimation network. You can use the following pre-trained model with the demos:
 * `human-pose-estimation-0001`
 
-For more information about the pre-trained models, refer to https://github.com/opencv/open_model_zoo/blob/master/intel_models/index.md in the Open Model Zoo repository.
+For more information about the pre-trained models, refer to the [model documentation](../../../intel_models/index.md).
 
 Other demo objectives are:
 
@@ -48,7 +48,7 @@ Options:
 
 Running the application with an empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/2018/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -104,6 +104,6 @@ If your cameras are connected to PC with indexes gap (for example, `0,1,3`), use
 IP-cameras through RSTP URI interface are not supported.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/object_detection_demo_faster_rcnn/README.md
+++ b/demos/object_detection_demo_faster_rcnn/README.md
@@ -54,7 +54,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -70,7 +70,7 @@ of the detected objects along with the respective confidence values and the coor
 rectangles to the standard output stream.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Using Open Model Zoo demos](../README.md)
+* [Model Downloader](../../tools/downloader/README.md)
 * [Converting a Model Using General Conversion Parameters](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_Converting_Model_General.html)
 * [Converting a Caffe Model](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_Convert_Model_From_Caffe.html)

--- a/demos/object_detection_demo_ssd_async/README.md
+++ b/demos/object_detection_demo_ssd_async/README.md
@@ -7,7 +7,7 @@ Specifically, this demo keeps two parallel infer requests and while the current 
 is being captured. This essentially hides the latency of capturing, so that the overall framerate is rather
 determined by the `MAXIMUM(detection time, input capturing time)` and not the `SUM(detection time, input capturing time)`.
 
-> **NOTE:** This topic describes usage of C++ implementation of the Object Detection SSD Demo Async API. For the Python* implementation, refer to [Object Detection SSD Python* Demo, Async API Performance Showcase](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/object_detection_demo_ssd_async/README.md).
+> **NOTE:** This topic describes usage of C++ implementation of the Object Detection SSD Demo Async API. For the Python* implementation, refer to [Object Detection SSD Python* Demo, Async API Performance Showcase](../python_demos/object_detection_demo_ssd_async/README.md).
 
 The technique can be generalized to any available parallel slack, for example, doing inference and simultaneously encoding the resulting
 (previous) frames or running further inference, like some emotion detection on top of the face detection results.
@@ -124,7 +124,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -145,6 +145,6 @@ In the default mode the demo reports
 
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/object_detection_demo_yolov3_async/README.md
+++ b/demos/object_detection_demo_yolov3_async/README.md
@@ -2,9 +2,9 @@
 
 This demo showcases Object Detection with YOLO* V3 and Async API.
 
-> **NOTE:** This topic describes usage of C++ implementation of the Object Detection YOLO* V3 Demo Async API . For the Python* implementation, refer to [Object Detection YOLO* V3 Python* Demo, Async API Performance Showcase](https://github.com/opencv/open_model_zoo/tree/master/demos/object_detection_demo_yolov3_async/README.md).
+> **NOTE:** This topic describes usage of C++ implementation of the Object Detection YOLO* V3 Demo Async API . For the Python* implementation, refer to [Object Detection YOLO* V3 Python* Demo, Async API Performance Showcase](../python_demos/object_detection_demo_yolov3_async/README.md).
 
-To learn more about Async API features, please refer to [Object Detection for SSD Demo, Async API Performance Showcase](https://github.com/opencv/open_model_zoo/tree/master/demos/object_detection_demo_ssd_async/README.md).
+To learn more about Async API features, please refer to [Object Detection for SSD Demo, Async API Performance Showcase](../object_detection_demo_ssd_async/README.md).
 
 Other demo objectives are:
 * Video as input support via OpenCV*
@@ -50,7 +50,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -70,6 +70,6 @@ In the default mode, the demo reports:
 * **Wallclock time**, which is combined application-level performance.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/pedestrian_tracker_demo/README.md
+++ b/demos/pedestrian_tracker_demo/README.md
@@ -6,7 +6,7 @@ You can use a set of the following pre-trained models with the demo:
 * _person-detection-retail-0013_, which is the primary detection network for finding pedestrians
 * _person-reidentification-retail-0031_, which is the network that is executed on top of the results from inference of the first network and makes reidentification of the pedestrians
 
-For more information about the pre-trained models, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained models, refer to the [model documentation](../../intel_models/index.md).
 
 ## How It Works
 
@@ -54,7 +54,7 @@ Options:
     -last                        Optional. The index of the last frame of video sequence to process. This has effect only if it is positive and the source video sequence is an image folder.
 ```
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -72,6 +72,6 @@ For example, to run the application with the OpenVINO&trade; toolkit pre-trained
 The demo uses OpenCV to display the resulting frame with detections rendered as bounding boxes, curves (for trajectories displaying), and text.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/python_demos/3d_segmentation_demo/README.md
+++ b/demos/python_demos/3d_segmentation_demo/README.md
@@ -52,7 +52,7 @@ Options:
 ```
 
 Running the application with the empty list of options yields the usage message and an error message.
-To run the demo, use public or pre-trained models that support 3D convolution, for example, UNet3D. You can download the pre-trained models using the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, use public or pre-trained models that support 3D convolution, for example, UNet3D. You can download the pre-trained models using the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -73,6 +73,6 @@ python3 3d_segmentation_demo.py -i <path_to_nifti_images> -m <path_to_model>/mul
 The demo outputs a multipage TIFF image and a NIFTI archive.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/python_demos/action_recognition/README.md
+++ b/demos/python_demos/action_recognition/README.md
@@ -6,7 +6,7 @@ The following pre-trained models are delivered with the product:
 * `driver-action-recognition-adas-0002-encoder` + `driver-action-recognition-adas-0002-decoder`, which are models for driver monitoring scenario. They recognize actions like safe driving, talking to the phone and others
 * `action-recognition-0001-encoder` + `action-recognition-0001-decoder`, which are general-purpose action recognition (400 actions) models for Kinetics-400 dataset.
 
-For more information about the pre-trained models, refer to https://github.com/opencv/open_model_zoo/blob/master/intel_models/index.md in the Open Model Zoo repository.
+For more information about the pre-trained models, refer to the [model documentation](../../../intel_models/index.md).
 
 How It Works
 ------------
@@ -65,7 +65,7 @@ Options:
 
 Running the application with an empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -81,6 +81,6 @@ Demo Output
 The application uses OpenCV to display the real-time results and current inference performance (in FPS).
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/python_demos/instance_segmentation_demo/README.md
+++ b/demos/python_demos/instance_segmentation_demo/README.md
@@ -69,7 +69,7 @@ Options:
 
 Running the application with an empty list of options yields the short version of the usage message and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (`*.xml` + `*.bin`) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -83,6 +83,6 @@ python3 instance_segmentation_demo/main.py -m <path_to_model>/maskrcnn_r50_fpn_2
 The application uses OpenCV to display resulting instance segmentation masks and current inference performance.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/python_demos/object_detection_demo_ssd_async/README.md
+++ b/demos/python_demos/object_detection_demo_ssd_async/README.md
@@ -142,7 +142,7 @@ You can use the following command to do inference on GPU with a pre-trained obje
     python3 object_detection_demo_ssd_async.py -i <path_to_video>/inputVideo.mp4 -m <path_to_model>/ssd.xml -d GPU
 ```
 
-To run the demo, you can use public or pre-trained models. You can download the pre-trained models with the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. You can download the pre-trained models with the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -158,6 +158,6 @@ In the default mode the demo reports
 
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/python_demos/object_detection_demo_yolov3_async/README.md
+++ b/demos/python_demos/object_detection_demo_yolov3_async/README.md
@@ -2,7 +2,7 @@
 
 This demo showcases Object Detection with YOLO* V3 and Async API.
 
-To learn more about Async API features, please refer to [Object Detection for SSD Demo, Async API Performance Showcase](https://github.com/opencv/open_model_zoo/tree/master/demos/object_detection_demo_ssd_async/README.md).
+To learn more about Async API features, please refer to [Object Detection for SSD Demo, Async API Performance Showcase](../../object_detection_demo_ssd_async/README.md).
 
 Other demo objectives are:
 * Video as input support via OpenCV*
@@ -73,7 +73,7 @@ You can use the following command to do inference on GPU with a pre-trained obje
     python3 object_detection_demo_yolov3_async.py -i <path_to_video>/inputVideo.mp4 -m <path_to_model>/yolo_v3.xml -d GPU
 ```
 
-To run the demo, you can use public or pre-trained models. You can download the pre-trained models with the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. You can download the pre-trained models with the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -88,6 +88,6 @@ In the default mode, the demo reports:
 * **Wallclock time**, which is combined application-level performance.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/python_demos/segmentation_demo/README.md
+++ b/demos/python_demos/segmentation_demo/README.md
@@ -49,7 +49,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. You can download the pre-trained models with the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. You can download the pre-trained models with the OpenVINO [Model Downloader](../../../tools/downloader/README.md) or from [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -65,6 +65,6 @@ The application outputs are a segmented image (`out.bmp`).
 
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../../tools/downloader/README.md)

--- a/demos/security_barrier_camera_demo/README.md
+++ b/demos/security_barrier_camera_demo/README.md
@@ -8,7 +8,7 @@ reports general vehicle attributes, for example, vehicle type (car/van/bus/track
 * `license-plate-recognition-barrier-0001`, which is executed on top of the results from the first network
 and reports a string per recognized license plate
 
-For more information about the pre-trained models, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained models, refer to the [model documentation](../../intel_models/index.md).
 
 Other demo objectives are:
 * Video/Camera as inputs, via OpenCV\*
@@ -81,7 +81,7 @@ Options:
 
 Running the application with an empty list of options yields an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -123,6 +123,6 @@ The demo uses OpenCV to display the resulting frame with detections rendered as 
 
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/segmentation_demo/README.md
+++ b/demos/segmentation_demo/README.md
@@ -3,7 +3,7 @@
 This topic demonstrates how to run the Image Segmentation demo application, which does inference using image
 segmentation networks like FCN8.
 
-> **NOTE:** This topic describes usage of C++ implementation of the Image Segmentation Demo. For the Python* implementation, refer to [Image Segmentation Python* Demo](https://github.com/opencv/open_model_zoo/tree/master/demos/python_demos/segmentation_demo/README.md).
+> **NOTE:** This topic describes usage of C++ implementation of the Image Segmentation Demo. For the Python* implementation, refer to [Image Segmentation Python* Demo](../python_demos/segmentation_demo/README.md).
 
 ## How It Works
 
@@ -37,7 +37,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -51,6 +51,6 @@ You can use the following command to do inference on CPU on an image using a tra
 The application outputs are a segmented image (`out.bmp`).
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/smart_classroom_demo/README.md
+++ b/demos/smart_classroom_demo/README.md
@@ -11,7 +11,7 @@ a vector of features for each detected face.
 * `person-detection-raisinghand-recognition-0001`, which is a detection network for finding students and simultaneously predicting their current actions (in contrast with the previous model, predicts only if a student raising hand or not).
 * `person-detection-action-recognition-teacher-0002`, which is a detection network for finding persons and simultaneously predicting their current actions.
 
-For more information about the pre-trained models, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained models, refer to the [model documentation](../../intel_models/index.md).
 
 ## How It Works
 
@@ -80,7 +80,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -120,6 +120,6 @@ Example of a valid command line to run the application for recognizing first rai
 The demo uses OpenCV to display the resulting frame with labeled actions and faces.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/super_resolution_demo/README.md
+++ b/demos/super_resolution_demo/README.md
@@ -7,7 +7,7 @@ You can use the following pre-trained model with the demo:
 * `single-image-super-resolution-1033`, which is the primary and only model that
   performs super resolution 4x upscale on a 200x200 image
 
-For more information about the pre-trained models, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained models, refer to the [model documentation](../../intel_models/index.md).
 
 ## How It Works
 
@@ -40,7 +40,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -56,6 +56,6 @@ The application outputs a reconstructed high-resolution image and saves it in
 the current working directory as `*.bmp` file with `sr` prefix.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)

--- a/demos/text_detection_demo/README.md
+++ b/demos/text_detection_demo/README.md
@@ -7,7 +7,7 @@ The demo shows an example of using neural networks to detect and recognize print
 * `text-recognition-0012`, which is a recognition network for recognizing text.
 * `handwritten-score-recognition-0001`, which is a recognition network for recognizing handwritten score marks like `<digit>` or `<digit>.<digit>`.
 
-For more information about the pre-trained models, refer to the [Open Model Zoo](https://github.com/opencv/open_model_zoo/tree/master/intel_models/index.md) repository on GitHub*.
+For more information about the pre-trained models, refer to the [model documentation](../../intel_models/index.md).
 
 ## How It Works
 
@@ -49,7 +49,7 @@ Options:
 
 Running the application with the empty list of options yields the usage message given above and an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../tools/downloader/README.md) or go to [https://download.01.org/opencv/](https://download.01.org/opencv/).
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
@@ -65,6 +65,6 @@ For example, use the following command line command to run the application:
 The demo uses OpenCV to display the resulting frame with detections rendered as bounding boxes and text.
 
 ## See Also
-* [Using Open Model Zoo demos](https://github.com/opencv/open_model_zoo/tree/master/demos/README.md)
+* [Using Open Model Zoo demos](../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
-* [Model Downloader](https://github.com/opencv/open_model_zoo/tree/master/model_downloader)
+* [Model Downloader](../../tools/downloader/README.md)


### PR DESCRIPTION
Since we've finally moved the demos to this repo, there's no longer a reason to use absolute links to refer to other stuff in this repo. Doing so is wrong anyway, since we can't guarantee that the master branch (or any other) will hold any given content in the future.

Also, fix one of those links, which was broken.