### PR TITLE
Public model documentation

### DIFF
--- a/models/public/Sphereface/Sphereface.md
+++ b/models/public/Sphereface/Sphereface.md
@@ -46,7 +46,7 @@ Channel order is `BGR`.
 
 ## Output
 
-### Origial model
+### Original model
 
 Face embedings, name - `fc5`,  shape - `1,512`, output data format  - `B,C`, where:
 

--- a/models/public/Sphereface/Sphereface.md
+++ b/models/public/Sphereface/Sphereface.md
@@ -1,0 +1,69 @@
+# Sphereface
+
+## Use Case and High-Level Description
+
+[Deep face recognition under open-set protocol](https://arxiv.org/pdf/1704.08063.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Face recognition |
+| GFLOPs            | 3.504         |
+| MParams           | 22.671        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,112,96`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [127.5,127.5,127.5], scale value - 128
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,112,96`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+
+## Output
+
+### Origial model
+
+Face embedings, name - `fc5`,  shape - `1,512`, output data format  - `B,C`, where:
+
+- `B` - batch size
+- `C` - row-vector of 512 floating points values, face embeddings
+
+The net outputs on different images are comparable in cosine distance.
+
+### Converted model
+
+Face embedings, name - `fc5`,  shape - `1,512`, output data format  - `B,C`, where:
+
+- `B` - batch size
+- `C` - row-vector of 512 floating points values, face embeddings
+
+The net outputs on different images are comparable in cosine distance.
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/wy1iu/sphereface/master/LICENSE)

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -60,7 +60,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -62,7 +62,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -62,7 +62,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -62,7 +62,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000,1,1`, contains predicted
 probability for each class in logits format

--- a/models/public/mobilenet-v1-1.0-224-tf/mobilenet-v1-1.0-224-tf.md
+++ b/models/public/mobilenet-v1-1.0-224-tf/mobilenet-v1-1.0-224-tf.md
@@ -1,4 +1,4 @@
-# mobilenet-v1-1.0-224
+# mobilenet-v1-1.0-224-tf
 
 ## Use Case and High-Level Description
 

--- a/models/public/mobilenet-v1-1.0-224/mobilenet-v1-1.0-224.md
+++ b/models/public/mobilenet-v1-1.0-224/mobilenet-v1-1.0-224.md
@@ -1,0 +1,63 @@
+# mobilenet-v1-1.0-224
+
+## Use Case and High-Level Description
+
+`mobilenet-v1-1.0-224` is one of [MobileNet V1 architecture](https://arxiv.org/abs/1704.04861) with the width multiplier 1.0 and resolution 224. It is small, low-latency, low-power models parameterized to meet the resource constraints of a variety of use cases. They can be built upon for classification, detection, embeddings and segmentation similar to how other popular large scale models are used.
+
+## Example
+
+## Specification
+
+| Metric                          | Value                                     |
+|---------------------------------|-------------------------------------------|
+| Type                            | Classification                            |
+| GFlops                          | 1.148                                     |
+| MParams                         | 4.221                                     |
+| Source framework                | Caffe\*                              |
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `input` , shape - [1x3x224x224], format [BxCxHxW], where:
+
+    - B - batch size
+    - C - number of channels
+    - H - image height
+    - W - image width
+
+   Expected color order - BGR.
+   Mean values - [103.94,116.78,123.68], scale factor for each channel - 58.8235294117647
+
+### Converted model
+
+Image, name - `input` , shape - [1x3x224x224], format [BxCxHxW], where:
+
+    - B - batch size
+    - C - number of channels
+    - H - image height
+    - W - image width
+
+   Expected color order - BGR.
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE)

--- a/models/public/mobilenet-v1-1.0-224/mobilenet-v1-1.0-224.md
+++ b/models/public/mobilenet-v1-1.0-224/mobilenet-v1-1.0-224.md
@@ -21,7 +21,7 @@
 
 ### Original model
 
-Image, name - `input` , shape - [1x3x224x224], format [BxCxHxW], where:
+Image, name - `input` , shape - `1,3,224,224`, format `B,C,H,W`, where:
 
     - B - batch size
     - C - number of channels
@@ -33,7 +33,7 @@ Image, name - `input` , shape - [1x3x224x224], format [BxCxHxW], where:
 
 ### Converted model
 
-Image, name - `input` , shape - [1x3x224x224], format [BxCxHxW], where:
+Image, name - `input` , shape - `1,3,224,224`, format `B,C,H,W`, where:
 
     - B - batch size
     - C - number of channels
@@ -44,7 +44,7 @@ Image, name - `input` , shape - [1x3x224x224], format [BxCxHxW], where:
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/mobilenet-v2-1.4-224/mobilenet-v2-1.4-224.md
+++ b/models/public/mobilenet-v2-1.4-224/mobilenet-v2-1.4-224.md
@@ -21,7 +21,7 @@
 
 ### Original model
 
-Image, name - `input` , shape - [1x224x224x3], format [BxHxWxC],
+Image, name - `input` , shape - `1,224,224,3`, format `B,H,W,C`,
    where:
 
     - B - batch size
@@ -34,7 +34,7 @@ Image, name - `input` , shape - [1x224x224x3], format [BxHxWxC],
 
 ### Converted model
 
-Image, name - `input` , shape - [1x3x224x224], format [BxCxHxW], where:
+Image, name - `input` , shape - `1,3,224,224`, format `B,C,H,W`, where:
 
     - B - batch size
     - C - number of channels

--- a/models/public/mobilenet-v2/mobilenet-v2.md
+++ b/models/public/mobilenet-v2/mobilenet-v2.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/mobilenet-v2/mobilenet-v2.md
+++ b/models/public/mobilenet-v2/mobilenet-v2.md
@@ -1,0 +1,65 @@
+# mobilenet-v2
+
+## Use Case and High-Level Description
+
+[MobileNet V2](https://arxiv.org/pdf/1801.04381.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 0.876         |
+| MParams           | 3.489         |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [103.94,116.78,123.68], scale value - 58.8235294117647
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE)

--- a/models/public/resnet-101/resnet-101.md
+++ b/models/public/resnet-101/resnet-101.md
@@ -1,0 +1,64 @@
+# resnet-101
+
+## Use Case and High-Level Description
+
+[ResNet-101](https://arxiv.org/pdf/1512.03385.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 14.441        |
+| MParams           | 44.496        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`. 
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/KaimingHe/deep-residual-networks/master/LICENSE)

--- a/models/public/resnet-101/resnet-101.md
+++ b/models/public/resnet-101/resnet-101.md
@@ -45,7 +45,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/resnet-101/resnet-101.md
+++ b/models/public/resnet-101/resnet-101.md
@@ -31,6 +31,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`. 
+Mean values - [104, 117, 123].
 
 ### Converted model
 

--- a/models/public/resnet-152/resnet-152.md
+++ b/models/public/resnet-152/resnet-152.md
@@ -1,0 +1,66 @@
+# resnet-152
+
+## Use Case and High-Level Description
+
+[ResNet-152](https://arxiv.org/pdf/1512.03385.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 21.89         |
+| MParams           | 60.117        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+See [https://github.com/shicai/DenseNet-Caffe]()
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`. 
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/KaimingHe/deep-residual-networks/master/LICENSE)

--- a/models/public/resnet-152/resnet-152.md
+++ b/models/public/resnet-152/resnet-152.md
@@ -47,7 +47,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/resnet-152/resnet-152.md
+++ b/models/public/resnet-152/resnet-152.md
@@ -32,7 +32,8 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `BGR`. 
+Channel order is `BGR`.
+Mean values - [104, 117, 123].
 
 ### Converted model
 

--- a/models/public/resnet-50/resnet-50.md
+++ b/models/public/resnet-50/resnet-50.md
@@ -45,7 +45,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/resnet-50/resnet-50.md
+++ b/models/public/resnet-50/resnet-50.md
@@ -1,0 +1,64 @@
+# resnet-50
+
+## Use Case and High-Level Description
+
+[ResNet-50](https://arxiv.org/pdf/1512.03385.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 6.996         |
+| MParams           | 25.53         |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`. 
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/KaimingHe/deep-residual-networks/master/LICENSE)

--- a/models/public/resnet-50/resnet-50.md
+++ b/models/public/resnet-50/resnet-50.md
@@ -31,6 +31,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`. 
+Mean values - [104, 117, 123].
 
 ### Converted model
 

--- a/models/public/se-inception/se-inception.md
+++ b/models/public/se-inception/se-inception.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/se-inception/se-inception.md
+++ b/models/public/se-inception/se-inception.md
@@ -1,0 +1,65 @@
+# se-inception
+
+## Use Case and High-Level Description
+
+[BN-Inception with Squeeze-and-Excitation blocks](https://arxiv.org/pdf/1709.01507.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 4.091         |
+| MParams           | 11.922        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0].
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE)

--- a/models/public/se-resnet-101/se-resnet-101.md
+++ b/models/public/se-resnet-101/se-resnet-101.md
@@ -1,0 +1,65 @@
+# se-resnet-101
+
+## Use Case and High-Level Description
+
+[ResNet-101 with Squeeze-and-Excitation blocks](https://arxiv.org/pdf/1709.01507.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 15.239        |
+| MParams           | 49.274        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0].
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE)

--- a/models/public/se-resnet-101/se-resnet-101.md
+++ b/models/public/se-resnet-101/se-resnet-101.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/se-resnet-152/se-resnet-152.md
+++ b/models/public/se-resnet-152/se-resnet-152.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/se-resnet-152/se-resnet-152.md
+++ b/models/public/se-resnet-152/se-resnet-152.md
@@ -1,0 +1,65 @@
+# se-resnet-152
+
+## Use Case and High-Level Description
+
+[ResNet-152 with Squeeze-and-Excitation blocks](https://arxiv.org/pdf/1709.01507.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 22.709        |
+| MParams           | 66.746        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0].
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE)

--- a/models/public/se-resnet-50/se-resnet-50.md
+++ b/models/public/se-resnet-50/se-resnet-50.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/se-resnet-50/se-resnet-50.md
+++ b/models/public/se-resnet-50/se-resnet-50.md
@@ -1,0 +1,65 @@
+# se-resnet-50
+
+## Use Case and High-Level Description
+
+[ResNet-50 with Squeeze-and-Excitation blocks](https://arxiv.org/pdf/1709.01507.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 7.775         |
+| MParams           | 28.061        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0].
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE)

--- a/models/public/se-resnext-101/se-resnext-101.md
+++ b/models/public/se-resnext-101/se-resnext-101.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 

--- a/models/public/se-resnext-101/se-resnext-101.md
+++ b/models/public/se-resnext-101/se-resnext-101.md
@@ -1,0 +1,65 @@
+# se-resnext-101
+
+## Use Case and High-Level Description
+
+[ResNext-101 with Squeeze-and-Excitation blocks](https://arxiv.org/pdf/1709.01507.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 16.054        |
+| MParams           | 48.886        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0].
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE)

--- a/models/public/se-resnext-50/se-resnext-50.md
+++ b/models/public/se-resnext-50/se-resnext-50.md
@@ -1,0 +1,65 @@
+# se-resnext-50
+
+## Use Case and High-Level Description
+
+[ResNext-50 with Squeeze-and-Excitation blocks](https://arxiv.org/pdf/1709.01507.pdf)
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 8.533         |
+| MParams           | 27.526        |
+| Source framework  | Caffe\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`.
+Mean values - [104.0,117.0,123.0].
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `BGR`
+
+## Output
+
+### Origial model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE)

--- a/models/public/se-resnext-50/se-resnext-50.md
+++ b/models/public/se-resnext-50/se-resnext-50.md
@@ -46,7 +46,7 @@ Channel order is `BGR`
 
 ## Output
 
-### Origial model
+### Original model
 
 Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
 


### PR DESCRIPTION
Added documentation to rest public models. Descriptions are taken from `list_topologies.yml`.
Also, fixed naming for MobileNet V2 from TF