### PR TITLE
changes in action_recognition_demo for unification with оther demos

### DIFF
--- a/demos/python_demos/action_recognition/README.md
+++ b/demos/python_demos/action_recognition/README.md
@@ -24,7 +24,7 @@ When two consequent steps occur in separate threads, they communicate via messag
 To ensure maximum performance, Inference Engine models are wrapped in `AsyncWrapper`
 that uses Inference Engine async API by scheduling infer requests in cyclical order
 (inference on every new input is started asynchronously, result of the longest working infer request is returned).
-You can change the value of `num_requests` in `demo.py` to find an optimal number of parallel working infer requests for your inference accelerators
+You can change the value of `num_requests` in `action_recognition.py` to find an optimal number of parallel working infer requests for your inference accelerators
 (Compute Sticks and GPUs benefit from higher number of infer requests).
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_Converting_Model_General.html).
@@ -34,29 +34,27 @@ Running
 Running the application with the `-h` option yields the following usage message:
 
 ```
-usage: demo.py [-h] --encoder ENCODER --decoder DECODER [-v VIDEO]
-               [-vl VIDEO_LIST] [-e CPU_EXTENSION]
-               [-d DEVICE] [--fps FPS] [-l LABELS]
+usage: action_recognition.py [-h] -m_en ENCODER -m_de DECODER -i VIDEO
+               [-l CPU_EXTENSION]
+               [-d DEVICE] [--fps FPS] [-lb LABELS]
 
 Options:
   -h, --help            show this help message and exit
-  --encoder ENCODER     Required. Path to encoder model
-  --decoder DECODER     Required. Path to decoder model
-  -v VIDEO, --video VIDEO
-                        Optional. Path to a video or file. 'cam' for capturing
-                        video
-  -vl VIDEO_LIST, --video_list VIDEO_LIST
-                        Optional. Path to a list with video files (text file,
-                        one video per line)
-  -e CPU_EXTENSION, --cpu_extension CPU_EXTENSION
+  -m_en  ENCODER, --m_encoder ENCODER
+                        Required. Path to encoder model
+  -m_de DECODER, --m_decoder DECODER
+                        Required. Path to decoder model
+  -i VIDEO, --input VIDEO
+                        Required. Path to a video or a .txt file with a list of video files (one video per line)
+  -l CPU_EXTENSION, --cpu_extension CPU_EXTENSION
                         Optional. For CPU custom layers, if any. Absolute path
                         to a shared library with the kernels implementation.
   -d DEVICE, --device DEVICE
-                        Optional. Specify a target device to infer on. CPU, GPU, FPGA, HDDL or MYRIAD is "
+                        Optional. Specify a target device to infer on. CPU, GPU, FPGA, HDDL or MYRIAD is
                         acceptable. The demo will look for a suitable plugin for the device specified.
                         Default value is CPU
   --fps FPS             Optional. FPS for renderer
-  -l LABELS, --labels LABELS
+  -lb LABELS, --labels LABELS
                         Optional. Path to file with label names
 
 ```
@@ -69,9 +67,10 @@ To run the demo, you can use public or pre-trained models. To download the pre-t
 
 **For example**, to run the demo for in-cabin driver monitoring scenario, please provide a path to the encoder and decoder models, an input video and a file with label names:
 ```bash
-python3 demo.py --encoder models/driver_action_recognition_tsd_0002_encoder.xml \
-    --decoder models/driver_action_recognition_tsd_0002_decoder.xml \
-    --labels driver_actions.txt
+python3 action_recognition.py -m_en models/driver_action_recognition_tsd_0002_encoder.xml \
+    -m_de models/driver_action_recognition_tsd_0002_decoder.xml \
+    -i <path_to_video>/inputVideo.mp4 \
+    -lb driver_actions.txt
 ```
 
 Demo Output


### PR DESCRIPTION
Was done:
1) Renamed demo.py to action_recognition.py, like other samples has the name of script equal with its folder
2) Change -e to -l - it is also standard of all samples.
3) As -l in this sample means labels, renamed it to -lb. Because -l is always for custom cpu lib.
4) Combined two option in one: --video_list and --video and renamed it to --input -i (like in other samples)
5) Renamed  -encoder and -decoder to  --m_encoder -m_en &  --m_decoder  -m_de  
6) Changed README file in accordance with the above changes and also added required parameter in "For example" section.