### PR TITLE
demos: print HDDL as available

### DIFF
--- a/demos/common/samples/common.hpp
+++ b/demos/common/samples/common.hpp
@@ -1114,14 +1114,11 @@ inline std::size_t getTensorBatch(const InferenceEngine::TensorDesc& desc) {
 inline void showAvailableDevices() {
     InferenceEngine::Core ie;
     std::vector<std::string> devices = ie.GetAvailableDevices();
-    if (!devices.empty()) {
-        std::cout << std::endl;
-        std::cout << "Available target devices:";
-        for (const auto& device : devices) {
-            std::cout << "  " << device;
-        }
-        std::cout << "  HDDL" << std::endl;
-    } else {
-        THROW_IE_EXCEPTION << "Not available any target device to infer on";
+
+    std::cout << std::endl;
+    std::cout << "Available target devices:";
+    for (const auto& device : devices) {
+        std::cout << "  " << device;
     }
+    std::cout << "  HDDL" << std::endl;
 }

--- a/demos/common/samples/common.hpp
+++ b/demos/common/samples/common.hpp
@@ -1120,6 +1120,7 @@ inline void showAvailableDevices() {
         for (const auto& device : devices) {
             std::cout << "  " << device;
         }
+        std::cout << "  HDDL" << std::endl;
     } else {
         THROW_IE_EXCEPTION << "Not available any target device to infer on";
     }


### PR DESCRIPTION
Currently Core::GetAvailableDevices() will not print HDDL as available in any case. To avoid regression in the list of demos' supported devices (shown in help messages) we will just print HDDL as available as it was in R1.