### PR TITLE
Specified models for pedestrian_tracker_demo

### DIFF
--- a/demos/pedestrian_tracker_demo/models.lst
+++ b/demos/pedestrian_tracker_demo/models.lst
@@ -1,3 +1,3 @@
 # This file can be used with the --list option of the model downloader.
-person-detection-retail-????
-person-reidentification-retail-????
+person-detection-retail-0013
+person-reidentification-retail-0031


### PR DESCRIPTION
Specified list of supported models.
Models are not supported by this demo: person-detection-retail-0002, person-reidentification-retail-0076, person-reidentification-retail-0079.