### PR TITLE
downloader: flush stdout before retrieving something from the cache

### DIFF
--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -144,7 +144,7 @@ def try_retrieve_from_cache(cache, files):
     try:
         if all(cache.has(file[0]) for file in files):
             for hash, destination in files:
-                print('========= Retrieving {} from the cache'.format(destination))
+                print('========= Retrieving {} from the cache'.format(destination), flush=True)
                 cache.get(hash, destination)
             print()
             return True


### PR DESCRIPTION
The cache can be on a remote filesystem, so retrieving a big file from it could take a while. Flush stdout before doing it to make the log better reflect the current state of the download process when stdout is buffered (e.g. when it's redirected to a pipe).