### PR TITLE
Fix sample to work with YOLOv2

### DIFF
--- a/demos/python_demos/object_detection_demo_yolov3_async/README.md
+++ b/demos/python_demos/object_detection_demo_yolov3_async/README.md
@@ -29,7 +29,7 @@ python3 object_detection_demo_yolov3_async.py -h
 The command yields the following usage message:
 ```
 usage: object_detection_demo_yolov3_async.py [-h] -m MODEL -i INPUT
-                                       [-l CPU_EXTENSION] [-d DEVICE] 
+                                       [-l CPU_EXTENSION] [-d DEVICE]
                                        [--labels LABELS] [-t PROB_THRESHOLD]
                                        [-iout IOU_THRESHOLD] [-ni NUMBER_ITER]
                                        [-pc] [-r]
@@ -88,3 +88,4 @@ In the default mode, the demo reports:
 * [Using Open Model Zoo demos](../../README.md)
 * [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
 * [Model Downloader](../../../tools/downloader/README.md)
+* [YOLOv3 COCO labels](https://github.com/opencv/opencv/blob/master/samples/data/dnn/object_detection_classes_yolov3.txt), [VOC labels](https://github.com/opencv/opencv/blob/master/samples/data/dnn/object_detection_classes_pascal_voc.txt)

--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -270,6 +270,7 @@ def main():
 
             start_time = time()
             for layer_name, out_blob in output.items():
+                out_blob = out_blob.reshape(net.layers[net.layers[layer_name].parents[0]].shape)
                 layer_params = YoloParams(net.layers[layer_name].params, out_blob.shape[2])
                 log.info("Layer {} parameters: ".format(layer_name))
                 layer_params.log_params()

--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -126,6 +126,8 @@ def parse_yolo_region(blob, resized_image_shape, original_im_shape, params, thre
             if scale < threshold:
                 continue
             box_index = entry_index(params.side, params.coords, params.classes, n * side_square + i, 0)
+            # Network produces location predictions in absolute coordinates of feature maps.
+            # Scale it to relative coordinates.
             x = (col + predictions[box_index + 0 * side_square]) / params.side
             y = (row + predictions[box_index + 1 * side_square]) / params.side
             # Value for exp is very big number in some cases so following construction is using here
@@ -134,6 +136,7 @@ def parse_yolo_region(blob, resized_image_shape, original_im_shape, params, thre
                 h_exp = exp(predictions[box_index + 3 * side_square])
             except OverflowError:
                 continue
+            # Depends on topology we need to normalize sizes by feature maps (up to YOLOv3) or by input shape (YOLOv3)
             w = w_exp * params.anchors[2 * n] / (resized_image_w if params.isYoloV3 else params.side)
             h = h_exp * params.anchors[2 * n + 1] / (resized_image_h if params.isYoloV3 else params.side)
             for j in range(params.classes):

--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -58,7 +58,7 @@ def build_argparser():
     return parser
 
 
-class YoloV3Params:
+class YoloParams:
     # ------------------------------------------- Extracting layer parameters ------------------------------------------
     # Magic numbers are copied from yolo samples
     def __init__(self, param, side):
@@ -79,6 +79,7 @@ class YoloV3Params:
             self.anchors = maskedAnchors
 
         self.side = side
+        self.isYoloV3 = 'mask' in param  # Weak way to determine but the only one.
 
 
     def log_params(self):
@@ -125,16 +126,16 @@ def parse_yolo_region(blob, resized_image_shape, original_im_shape, params, thre
             if scale < threshold:
                 continue
             box_index = entry_index(params.side, params.coords, params.classes, n * side_square + i, 0)
-            x = (col + predictions[box_index + 0 * side_square]) / params.side * resized_image_w
-            y = (row + predictions[box_index + 1 * side_square]) / params.side * resized_image_h
+            x = (col + predictions[box_index + 0 * side_square]) / params.side
+            y = (row + predictions[box_index + 1 * side_square]) / params.side
             # Value for exp is very big number in some cases so following construction is using here
             try:
                 w_exp = exp(predictions[box_index + 2 * side_square])
                 h_exp = exp(predictions[box_index + 3 * side_square])
             except OverflowError:
                 continue
-            w = w_exp * params.anchors[2 * n]
-            h = h_exp * params.anchors[2 * n + 1]
+            w = w_exp * params.anchors[2 * n] / (resized_image_w if params.isYoloV3 else params.side)
+            h = h_exp * params.anchors[2 * n + 1] / (resized_image_h if params.isYoloV3 else params.side)
             for j in range(params.classes):
                 class_index = entry_index(params.side, params.coords, params.classes, n * side_square + i,
                                           params.coords + 1 + j)
@@ -142,7 +143,7 @@ def parse_yolo_region(blob, resized_image_shape, original_im_shape, params, thre
                 if confidence < threshold:
                     continue
                 objects.append(scale_bbox(x=x, y=y, h=h, w=w, class_id=j, confidence=confidence,
-                                          h_scale=orig_im_h / resized_image_h, w_scale=orig_im_w / resized_image_w))
+                                          h_scale=orig_im_h, w_scale=orig_im_w))
     return objects
 
 
@@ -269,7 +270,7 @@ def main():
 
             start_time = time()
             for layer_name, out_blob in output.items():
-                layer_params = YoloV3Params(net.layers[layer_name].params, out_blob.shape[2])
+                layer_params = YoloParams(net.layers[layer_name].params, out_blob.shape[2])
                 log.info("Layer {} parameters: ".format(layer_name))
                 layer_params.log_params()
                 objects += parse_yolo_region(out_blob, in_frame.shape[2:],


### PR DESCRIPTION
YOLOv2 origin:
https://pjreddie.com/darknet/yolov2/

Classes names:
https://github.com/opencv/opencv/blob/master/samples/data/dnn/object_detection_classes_yolov3.txt

https://github.com/opencv/opencv/blob/master/samples/data/dnn/object_detection_classes_pascal_voc.txt

OpenVINO's HowTo:
http://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_tf_specific_Convert_YOLO_From_Tensorflow.html

**NOTE**: For YOLOv2 `--scale 255` is required:
```
python3 mo_tf.py --input_model yolov2.pb --batch 1 \
  --tensorflow_use_custom_operations_config extensions/front/tf/yolo_v2.json \
  --scale 255
```


