### PR TITLE
[MXNET] OctConv networks

### DIFF
--- a/models/public/octave-densenet-121-0.125/octave-densenet-121-0.125.md
+++ b/models/public/octave-densenet-121-0.125/octave-densenet-121-0.125.md
@@ -1,0 +1,69 @@
+# octave-densenet-121-0.125
+
+## Use Case and High-Level Description
+
+The `octave-densenet-121-0.125` model is a modification of `densenet-121` from the [this paper](https://arxiv.org/pdf/1608.06993) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+
+The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
+
+The model output for `octave-densenet-121-0.125` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 4.883         |
+| MParams           | 7.977         |
+| Source framework  | MXNET\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`. 
+Mean values - [124,117,104], scale value - 59.880239521
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+## Output
+
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)

--- a/models/public/octave-densenet-121-0.125/octave-densenet-121-0.125.md
+++ b/models/public/octave-densenet-121-0.125/octave-densenet-121-0.125.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `octave-densenet-121-0.125` model is a modification of `densenet-121` from the [this paper](https://arxiv.org/pdf/1608.06993) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+The `octave-densenet-121-0.125` model is a modification of `densenet-121` from [this paper](https://arxiv.org/pdf/1608.06993) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with `alpha=0.125`. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
 
@@ -17,7 +17,7 @@ The model output for `octave-densenet-121-0.125` is the typical object classifie
 | Type              | Classification|
 | GFLOPs            | 4.883         |
 | MParams           | 7.977         |
-| Source framework  | MXNET\*       |
+| Source framework  | MXNet\*       |
 
 ## Accuracy
 
@@ -46,7 +46,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `RGB`
+Channel order is `BGR`.
 
 ## Output
 

--- a/models/public/octave-resnet-101-0.125/octave-resnet-101-0.125.md
+++ b/models/public/octave-resnet-101-0.125/octave-resnet-101-0.125.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `octave-resnet-101-0.125` model is a modification of `resnet-101` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+The `octave-resnet-101-0.125` model is a modification of `resnet-101` from [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with `alpha=0.125`. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
 
@@ -17,7 +17,7 @@ The model output for `octave-resnet-101-0.125` is the typical object classifier 
 | Type              | Classification|
 | GFLOPs            | 13.387        |
 | MParams           | 44.543        |
-| Source framework  | MXNET\*       |
+| Source framework  | MXNet\*       |
 
 ## Accuracy
 
@@ -46,7 +46,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `RGB`
+Channel order is `BGR`.
 
 ## Output
 

--- a/models/public/octave-resnet-101-0.125/octave-resnet-101-0.125.md
+++ b/models/public/octave-resnet-101-0.125/octave-resnet-101-0.125.md
@@ -1,0 +1,69 @@
+# octave-resnet-101-0.125
+
+## Use Case and High-Level Description
+
+The `octave-resnet-101-0.125` model is a modification of `resnet-101` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+
+The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
+
+The model output for `octave-resnet-101-0.125` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 13.387        |
+| MParams           | 44.543        |
+| Source framework  | MXNET\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`. 
+Mean values - [124,117,104], scale value - 59.880239521
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+## Output
+
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)

--- a/models/public/octave-resnet-200-0.125/octave-resnet-200-0.125.md
+++ b/models/public/octave-resnet-200-0.125/octave-resnet-200-0.125.md
@@ -1,0 +1,69 @@
+# octave-resnet-200-0.125
+
+## Use Case and High-Level Description
+
+The `octave-resnet-200-0.125` model is a modification of `resnet-200` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+
+The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
+
+The model output for `octave-resnet-200-0.125` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 25.407        |
+| MParams           | 64.667        |
+| Source framework  | MXNET\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`. 
+Mean values - [124,117,104], scale value - 59.880239521
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+## Output
+
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)

--- a/models/public/octave-resnet-200-0.125/octave-resnet-200-0.125.md
+++ b/models/public/octave-resnet-200-0.125/octave-resnet-200-0.125.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `octave-resnet-200-0.125` model is a modification of `resnet-200` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+The `octave-resnet-200-0.125` model is a modification of `resnet-200` from [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with `alpha=0.125`. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
 
@@ -17,7 +17,7 @@ The model output for `octave-resnet-200-0.125` is the typical object classifier 
 | Type              | Classification|
 | GFLOPs            | 25.407        |
 | MParams           | 64.667        |
-| Source framework  | MXNET\*       |
+| Source framework  | MXNet\*       |
 
 ## Accuracy
 
@@ -46,7 +46,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `RGB`
+Channel order is `BGR`.
 
 ## Output
 

--- a/models/public/octave-resnet-26-0.25/octave-resnet-26-0.25.md
+++ b/models/public/octave-resnet-26-0.25/octave-resnet-26-0.25.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `octave-resnet-26-0.25` model is a modification of `resnet-26` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.25. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+The `octave-resnet-26-0.25` model is a modification of `resnet-26` from [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with `alpha=0.25`. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
 
@@ -17,7 +17,7 @@ The model output for `octave-resnet-26-0.25` is the typical object classifier ou
 | Type              | Classification|
 | GFLOPs            | 3.768         |
 | MParams           | 15.99         |
-| Source framework  | MXNET\*       |
+| Source framework  | MXNet\*       |
 
 ## Accuracy
 
@@ -46,7 +46,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `RGB`
+Channel order is `BGR`.
 
 ## Output
 

--- a/models/public/octave-resnet-26-0.25/octave-resnet-26-0.25.md
+++ b/models/public/octave-resnet-26-0.25/octave-resnet-26-0.25.md
@@ -1,0 +1,69 @@
+# octave-resnet-26-0.25
+
+## Use Case and High-Level Description
+
+The `octave-resnet-26-0.25` model is a modification of `resnet-26` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.25. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+
+The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
+
+The model output for `octave-resnet-26-0.25` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 3.768         |
+| MParams           | 15.99         |
+| Source framework  | MXNET\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`. 
+Mean values - [124,117,104], scale value - 59.880239521
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+## Output
+
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)

--- a/models/public/octave-resnet-50-0.125/octave-resnet-50-0.125.md
+++ b/models/public/octave-resnet-50-0.125/octave-resnet-50-0.125.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `octave-resnet-50-0.125` model is a modification of `resnet-50` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+The `octave-resnet-50-0.125` model is a modification of `resnet-50` from [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with `alpha=0.125`. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
 
@@ -17,7 +17,7 @@ The model output for `octave-resnet-50-0.125` is the typical object classifier o
 | Type              | Classification|
 | GFLOPs            | 7.221         |
 | MParams           | 25.551        |
-| Source framework  | MXNET\*       |
+| Source framework  | MXNet\*       |
 
 ## Accuracy
 
@@ -46,7 +46,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `RGB`
+Channel order is `BGR`
 
 ## Output
 

--- a/models/public/octave-resnet-50-0.125/octave-resnet-50-0.125.md
+++ b/models/public/octave-resnet-50-0.125/octave-resnet-50-0.125.md
@@ -1,0 +1,69 @@
+# octave-resnet-50-0.125
+
+## Use Case and High-Level Description
+
+The `octave-resnet-50-0.125` model is a modification of `resnet-50` from the [this paper](https://arxiv.org/pdf/1512.03385.pdf) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.125. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+
+The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
+
+The model output for `octave-resnet-50-0.125` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 7.221         |
+| MParams           | 25.551        |
+| Source framework  | MXNET\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`. 
+Mean values - [124,117,104], scale value - 59.880239521
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+## Output
+
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)

--- a/models/public/octave-resnext-101-0.25/octave-resnext-101-0.25.md
+++ b/models/public/octave-resnext-101-0.25/octave-resnext-101-0.25.md
@@ -1,0 +1,69 @@
+# octave-resnext-101-0.25
+
+## Use Case and High-Level Description
+
+The `octave-resnext-101-0.25` model is a modification of `resnext-101` from the [this paper](https://arxiv.org/abs/1611.05431) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.25. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+
+The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
+
+The model output for `octave-resnext-101-0.125` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 11.521        |
+| MParams           | 44.169        |
+| Source framework  | MXNET\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`. 
+Mean values - [124,117,104], scale value - 59.880239521
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+## Output
+
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)

--- a/models/public/octave-resnext-101-0.25/octave-resnext-101-0.25.md
+++ b/models/public/octave-resnext-101-0.25/octave-resnext-101-0.25.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `octave-resnext-101-0.25` model is a modification of `resnext-101` from the [this paper](https://arxiv.org/abs/1611.05431) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.25. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+The `octave-resnext-101-0.25` model is a modification of `resnext-101` from [this paper](https://arxiv.org/abs/1611.05431) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with `alpha=0.25`. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
 
@@ -17,7 +17,7 @@ The model output for `octave-resnext-101-0.125` is the typical object classifier
 | Type              | Classification|
 | GFLOPs            | 11.521        |
 | MParams           | 44.169        |
-| Source framework  | MXNET\*       |
+| Source framework  | MXNet\*       |
 
 ## Accuracy
 
@@ -46,7 +46,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `RGB`
+Channel order is `BGR`.
 
 ## Output
 

--- a/models/public/octave-resnext-50-0.25/octave-resnext-50-0.25.md
+++ b/models/public/octave-resnext-50-0.25/octave-resnext-50-0.25.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `octave-resnext-50-0.25` model is a modification of `resnext-50` from the [this paper](https://arxiv.org/abs/1611.05431) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.25. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+The `octave-resnext-50-0.25` model is a modification of `resnext-50` from [this paper](https://arxiv.org/abs/1611.05431) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with `alpha=0.25`. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
 
 The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
 
@@ -17,7 +17,7 @@ The model output for `octave-resnext-50-0.125` is the typical object classifier 
 | Type              | Classification|
 | GFLOPs            | 6.444         |
 | MParams           | 25.02         |
-| Source framework  | MXNET\*       |
+| Source framework  | MXNet\*       |
 
 ## Accuracy
 
@@ -46,7 +46,7 @@ Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
 - `H` - height
 - `W` - width
 
-Channel order is `RGB`
+Channel order is `BGR`.
 
 ## Output
 

--- a/models/public/octave-resnext-50-0.25/octave-resnext-50-0.25.md
+++ b/models/public/octave-resnext-50-0.25/octave-resnext-50-0.25.md
@@ -1,0 +1,69 @@
+# octave-resnext-50-0.25
+
+## Use Case and High-Level Description
+
+The `octave-resnext-50-0.25` model is a modification of `resnext-50` from the [this paper](https://arxiv.org/abs/1611.05431) with octave convolutions from [Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with Octave Convolution](https://arxiv.org/abs/1904.05049) with &alpha;=0.25. As origin, it's designed to perform image classification. For details about family of octave convolution models, check out the [repository](https://github.com/facebookresearch/OctConv).
+
+The model input is a blob that consists of a single image of 1x3x224x224 in RGB order. The RGB mean values need to be subtracted as follows: [124,117,104] before passing the image blob into the network. In addition, values must be divided by 0.0167.
+
+The model output for `octave-resnext-50-0.125` is the typical object classifier output for the 1000 different classifications matching those in the ImageNet database.
+
+## Example
+
+## Specification
+
+| Metric            | Value         |
+|-------------------|---------------|
+| Type              | Classification|
+| GFLOPs            | 6.444         |
+| MParams           | 25.02         |
+| Source framework  | MXNET\*       |
+
+## Accuracy
+
+## Performance
+
+## Input
+
+### Original model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`. 
+Mean values - [124,117,104], scale value - 59.880239521
+
+### Converted model
+
+Image, name - `data`,  shape - `1,3,224,224`, format is `B,C,H,W` where:
+
+- `B` - batch size
+- `C` - channel
+- `H` - height
+- `W` - width
+
+Channel order is `RGB`
+
+## Output
+
+### Original model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+### Converted model
+
+Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000`, output data format is `B,C` where:
+
+- `B` - batch size
+- `C` - Predicted probabilities for each class in  [0, 1] range
+
+## Legal Information
+
+[LICENSE](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)

--- a/tools/downloader/license.txt
+++ b/tools/downloader/license.txt
@@ -3713,3 +3713,37 @@ License terms:
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ==================================================================================================
+
+* octave-densenet-121-0.125 - octave convolution networks https://github.com/facebookresearch/OctConv
+* octave-resnet-26-0.25 - octave convolution networks https://github.com/facebookresearch/OctConv
+* octave-resnet-50-0.125  - octave convolution networks https://github.com/facebookresearch/OctConv
+* octave-resnet-101-0.125 - octave convolution networks https://github.com/facebookresearch/OctConv
+* octave-resnet-200-0.125 - octave convolution networks https://github.com/facebookresearch/OctConv
+* octave-resnext-50-0.25 - octave convolution networks https://github.com/facebookresearch/OctConv
+* octave-resnext-101-0.25 - octave convolution networks https://github.com/facebookresearch/OctConv
+
+License terms:
+
+    MIT License
+
+    Copyright (c) Facebook, Inc. and its affiliates.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+==================================================================================================

--- a/tools/downloader/list_topologies.yml
+++ b/tools/downloader/list_topologies.yml
@@ -3629,3 +3629,283 @@ topologies:
       - --output=prob
       - --input_model=$conv_dir/resnet-v1-50.onnx
     license: https://raw.githubusercontent.com/pytorch/vision/master/LICENSE
+
+  - name: "octave-densenet-121-0.125"
+    description: >-
+      The `octave-densenet-121-0.125` model is a modification of `densenet-121` from
+      the this paper <https://arxiv.org/pdf/1608.06993> with octave convolutions from
+      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
+      As origin, it's designed to perform image classification. For details about
+      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+
+      The model input is a blob that consists of a single image of 1x3x224x224 in
+      RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
+      before passing the image blob into the network. In addition, values must be
+      divided by 0.0167.
+
+      The model output for `octave-densenet-121-0.125` is the typical object classifier
+      output for the 1000 different classifications matching those in the ImageNet
+      database.
+    task_type: "classification"
+    files:
+      - name: a01_densenet-121_alpha-0.125.tar
+        sha256: 93fcdf376c2ee7e9278e2c4a9d8a0a30e35d92051ad4889fb5d5c1855ea31ca4
+        source: https://dl.fbaipublicfiles.com/octconv/ablation/a01_densenet-121_alpha-0.125.tar
+    postprocessing:
+      - $type: unpack_archive
+        format: tar
+        file: a01_densenet-121_alpha-0.125.tar
+    output: "classification/octave/densenet-121-0.125/"
+    model_optimizer_args:
+      - --framework=mxnet
+      - --data_type=FP32
+      - --mean_values=data[124,117,104]
+      - --scale_values=data[59.880239521]
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=softmax
+      - --input_model=$dl_dir/a01_densenet-121_alpha-0.125/checkpoint-0-0000.params
+      - --input_symbol=$dl_dir/a01_densenet-121_alpha-0.125/checkpoint-0-symbol.json
+    framework: mxnet
+    license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE
+
+  - name: "octave-resnet-26-0.25"
+    description: >-
+      The `octave-resnet-26-0.25` model is a modification of `resnet-26` from the
+      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
+      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.25.
+      As origin, it's designed to perform image classification. For details about
+      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+
+      The model input is a blob that consists of a single image of 1x3x224x224 in
+      RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
+      before passing the image blob into the network. In addition, values must be
+      divided by 0.0167.
+
+      The model output for `octave-resnet-26-0.25` is the typical object classifier
+      output for the 1000 different classifications matching those in the ImageNet
+      database.
+    task_type: "classification"
+    files:
+      - name: a02_resnet-26_alpha-0.250.tar
+        sha256: 29fba1f4f421f86bebcc5bd99c0d1936c20c63b3e5bb20b48665106469bd54b0
+        source: https://dl.fbaipublicfiles.com/octconv/ablation/a02_resnet-26_alpha-0.250.tar
+    postprocessing:
+      - $type: unpack_archive
+        format: tar
+        file: a02_resnet-26_alpha-0.250.tar
+    output: "classification/octave/resnet-26-0.25/"
+    model_optimizer_args:
+      - --framework=mxnet
+      - --data_type=FP32
+      - --mean_values=data[124,117,104]
+      - --scale_values=data[59.880239521]
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=softmax
+      - --input_model=$dl_dir/a02_resnet-26_alpha-0.250/checkpoint-0-0000.params
+      - --input_symbol=$dl_dir/a02_resnet-26_alpha-0.250/checkpoint-0-symbol.json
+    framework: mxnet
+    license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE
+
+  - name: "octave-resnet-50-0.125"
+    description: >-
+      The `octave-resnet-50-0.125` model is a modification of `resnet-50` from the
+      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
+      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
+      As origin, it's designed to perform image classification. For details about
+      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+
+      The model input is a blob that consists of a single image of 1x3x224x224 in
+      RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
+      before passing the image blob into the network. In addition, values must be
+      divided by 0.0167.
+
+      The model output for `octave-resnet-50-0.125` is the typical object classifier
+      output for the 1000 different classifications matching those in the ImageNet
+      database.
+    task_type: "classification"
+    files:
+      - name: a03_resnet-50_alpha-0.125.tar
+        sha256: 1ad2c754a5569d6c297c10601fd62feed4d5fe36354167697315e644f5c913d4
+        source: https://dl.fbaipublicfiles.com/octconv/ablation/a03_resnet-50_alpha-0.125.tar
+    postprocessing:
+      - $type: unpack_archive
+        format: tar
+        file: a03_resnet-50_alpha-0.125.tar
+    output: "classification/octave/resnet-50-0.125/"
+    model_optimizer_args:
+      - --framework=mxnet
+      - --data_type=FP32
+      - --mean_values=data[124,117,104]
+      - --scale_values=data[59.880239521]
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=softmax
+      - --input_model=$dl_dir/a03_resnet-50_alpha-0.125/checkpoint-0-0000.params
+      - --input_symbol=$dl_dir/a03_resnet-50_alpha-0.125/checkpoint-0-symbol.json
+    framework: mxnet
+    license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE
+
+  - name: "octave-resnet-101-0.125"
+    description: >-
+      The `octave-resnet-101-0.125` model is a modification of `resnet-101` from the
+      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
+      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
+      As origin, it's designed to perform image classification. For details about
+      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+
+      The model input is a blob that consists of a single image of 1x3x224x224 in
+      RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
+      before passing the image blob into the network. In addition, values must be
+      divided by 0.0167.
+
+      The model output for `octave-resnet-101-0.125` is the typical object classifier
+      output for the 1000 different classifications matching those in the ImageNet
+      database.
+    task_type: "classification"
+    files:
+      - name: a06_resnet-101_alpha-0.125.tar
+        sha256: 28fe5741d60232fa303292c632f8665cb10ed2f7c32617dae575bad14d4ac45a
+        source: https://dl.fbaipublicfiles.com/octconv/ablation/a06_resnet-101_alpha-0.125.tar
+    postprocessing:
+      - $type: unpack_archive
+        format: tar
+        file: a06_resnet-101_alpha-0.125.tar
+    output: "classification/octave/resnet-101-0.125/"
+    model_optimizer_args:
+      - --framework=mxnet
+      - --data_type=FP32
+      - --mean_values=data[124,117,104]
+      - --scale_values=data[59.880239521]
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=softmax
+      - --input_model=$dl_dir/a06_resnet-101_alpha-0.125/checkpoint-0-0000.params
+      - --input_symbol=$dl_dir/a06_resnet-101_alpha-0.125/checkpoint-0-symbol.json
+    framework: mxnet
+    license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE
+
+  - name: "octave-resnet-200-0.125"
+    description: >-
+      The `octave-resnet-200-0.125` model is a modification of `resnet-200` from the
+      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
+      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
+      As origin, it's designed to perform image classification. For details about
+      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+
+      The model input is a blob that consists of a single image of 1x3x224x224 in
+      RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
+      before passing the image blob into the network. In addition, values must be
+      divided by 0.0167.
+
+      The model output for `octave-resnet-200-0.125` is the typical object classifier
+      output for the 1000 different classifications matching those in the ImageNet
+      database.
+    task_type: "classification"
+    files:
+      - name: a08_resnet-200_alpha-0.125.tar
+        sha256: d9ce49aa73e3f0f31ac659ddf812ff8a79242a058e6b53a7140c756d83413e58
+        source: https://dl.fbaipublicfiles.com/octconv/ablation/a08_resnet-200_alpha-0.125.tar
+    postprocessing:
+      - $type: unpack_archive
+        format: tar
+        file: a08_resnet-200_alpha-0.125.tar
+    output: "classification/octave/resnet-200-0.125/"
+    model_optimizer_args:
+      - --framework=mxnet
+      - --data_type=FP32
+      - --mean_values=data[124,117,104]
+      - --scale_values=data[59.880239521]
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=softmax
+      - --input_model=$dl_dir/a08_resnet-200_alpha-0.125/checkpoint-0-0000.params
+      - --input_symbol=$dl_dir/a08_resnet-200_alpha-0.125/checkpoint-0-symbol.json
+    framework: mxnet
+    license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE
+
+  - name: "octave-resnext-50-0.25"
+    description: >-
+      The `octave-resnext-50-0.25` model is a modification of `resnext-50` from the
+      this paper <https://arxiv.org/abs/1611.05431> with octave convolutions from
+      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.25.
+      As origin, it's designed to perform image classification. For details about
+      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+
+      The model input is a blob that consists of a single image of 1x3x224x224 in
+      RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
+      before passing the image blob into the network. In addition, values must be
+      divided by 0.0167.
+
+      The model output for `octave-resnext-50-0.125` is the typical object classifier
+      output for the 1000 different classifications matching those in the ImageNet
+      database.
+    task_type: "classification"
+    files:
+      - name: a04_resnext-50_32x4d_alpha-0.250.tar
+        sha256: e4f4d8438cb1cf6e349eb0e583e5cc6bf2754fe6093dc24471e893eb3b8c3944
+        source: https://dl.fbaipublicfiles.com/octconv/ablation/a04_resnext-50_32x4d_alpha-0.250.tar
+    postprocessing:
+      - $type: unpack_archive
+        format: tar
+        file: a04_resnext-50_32x4d_alpha-0.250.tar
+    output: "classification/octave/resnext-50-0.25/"
+    model_optimizer_args:
+      - --framework=mxnet
+      - --data_type=FP32
+      - --mean_values=data[124,117,104]
+      - --scale_values=data[59.880239521]
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=softmax
+      - --input_model=$dl_dir/a04_resnext-50_32x4d_alpha-0.250/checkpoint-0-0000.params
+      - --input_symbol=$dl_dir/a04_resnext-50_32x4d_alpha-0.250/checkpoint-0-symbol.json
+    framework: mxnet
+    license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE
+
+  - name: "octave-resnext-101-0.25"
+    description: >-
+      The `octave-resnext-101-0.25` model is a modification of `resnext-101` from
+      the this paper <https://arxiv.org/abs/1611.05431> with octave convolutions from
+      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.25.
+      As origin, it's designed to perform image classification. For details about
+      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+
+      The model input is a blob that consists of a single image of 1x3x224x224 in
+      RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
+      before passing the image blob into the network. In addition, values must be
+      divided by 0.0167.
+
+      The model output for `octave-resnext-101-0.125` is the typical object classifier
+      output for the 1000 different classifications matching those in the ImageNet
+      database.
+    task_type: "classification"
+    files:
+      - name: a07_resnext-101_32x4d_alpha-0.250.tar
+        sha256: 00c2c7d7048eb0c07509414b4aff845cd1cc6f92b8414a2837b2344e6c6400d3
+        source: https://dl.fbaipublicfiles.com/octconv/ablation/a07_resnext-101_32x4d_alpha-0.250.tar
+    postprocessing:
+      - $type: unpack_archive
+        format: tar
+        file: a07_resnext-101_32x4d_alpha-0.250.tar
+    output: "classification/octave/resnext-101-0.25/"
+    model_optimizer_args:
+      - --framework=mxnet
+      - --data_type=FP32
+      - --mean_values=data[124,117,104]
+      - --scale_values=data[59.880239521]
+      - --input_shape=[1,3,224,224]
+      - --input=data
+      - --output=softmax
+      - --input_model=$dl_dir/a07_resnext-101_32x4d_alpha-0.250/checkpoint-0-0000.params
+      - --input_symbol=$dl_dir/a07_resnext-101_32x4d_alpha-0.250/checkpoint-0-symbol.json
+    framework: mxnet
+    license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/tools/downloader/list_topologies.yml
+++ b/tools/downloader/list_topologies.yml
@@ -3633,9 +3633,9 @@ topologies:
   - name: "octave-densenet-121-0.125"
     description: >-
       The `octave-densenet-121-0.125` model is a modification of `densenet-121` from
-      the this paper <https://arxiv.org/pdf/1608.06993> with octave convolutions from
+      this paper <https://arxiv.org/pdf/1608.06993> with octave convolutions from
       Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
-      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with `alpha=0.125`.
       As origin, it's designed to perform image classification. For details about
       family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
 
@@ -3660,6 +3660,7 @@ topologies:
     model_optimizer_args:
       - --framework=mxnet
       - --data_type=FP32
+      - --reverse_input_channels
       - --mean_values=data[124,117,104]
       - --scale_values=data[59.880239521]
       - --input_shape=[1,3,224,224]
@@ -3672,12 +3673,12 @@ topologies:
 
   - name: "octave-resnet-26-0.25"
     description: >-
-      The `octave-resnet-26-0.25` model is a modification of `resnet-26` from the
-      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
-      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
-      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.25.
-      As origin, it's designed to perform image classification. For details about
-      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+      The `octave-resnet-26-0.25` model is a modification of `resnet-26` from this
+      paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from Drop
+      an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with
+      Octave Convolution <https://arxiv.org/abs/1904.05049> with `alpha=0.25`. As
+      origin, it's designed to perform image classification. For details about family
+      of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
 
       The model input is a blob that consists of a single image of 1x3x224x224 in
       RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
@@ -3700,6 +3701,7 @@ topologies:
     model_optimizer_args:
       - --framework=mxnet
       - --data_type=FP32
+      - --reverse_input_channels
       - --mean_values=data[124,117,104]
       - --scale_values=data[59.880239521]
       - --input_shape=[1,3,224,224]
@@ -3712,12 +3714,12 @@ topologies:
 
   - name: "octave-resnet-50-0.125"
     description: >-
-      The `octave-resnet-50-0.125` model is a modification of `resnet-50` from the
-      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
-      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
-      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
-      As origin, it's designed to perform image classification. For details about
-      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+      The `octave-resnet-50-0.125` model is a modification of `resnet-50` from this
+      paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from Drop
+      an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with
+      Octave Convolution <https://arxiv.org/abs/1904.05049> with `alpha=0.125`. As
+      origin, it's designed to perform image classification. For details about family
+      of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
 
       The model input is a blob that consists of a single image of 1x3x224x224 in
       RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
@@ -3740,6 +3742,7 @@ topologies:
     model_optimizer_args:
       - --framework=mxnet
       - --data_type=FP32
+      - --reverse_input_channels
       - --mean_values=data[124,117,104]
       - --scale_values=data[59.880239521]
       - --input_shape=[1,3,224,224]
@@ -3752,12 +3755,12 @@ topologies:
 
   - name: "octave-resnet-101-0.125"
     description: >-
-      The `octave-resnet-101-0.125` model is a modification of `resnet-101` from the
-      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
-      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
-      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
-      As origin, it's designed to perform image classification. For details about
-      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+      The `octave-resnet-101-0.125` model is a modification of `resnet-101` from this
+      paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from Drop
+      an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with
+      Octave Convolution <https://arxiv.org/abs/1904.05049> with `alpha=0.125`. As
+      origin, it's designed to perform image classification. For details about family
+      of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
 
       The model input is a blob that consists of a single image of 1x3x224x224 in
       RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
@@ -3780,6 +3783,7 @@ topologies:
     model_optimizer_args:
       - --framework=mxnet
       - --data_type=FP32
+      - --reverse_input_channels
       - --mean_values=data[124,117,104]
       - --scale_values=data[59.880239521]
       - --input_shape=[1,3,224,224]
@@ -3792,12 +3796,12 @@ topologies:
 
   - name: "octave-resnet-200-0.125"
     description: >-
-      The `octave-resnet-200-0.125` model is a modification of `resnet-200` from the
-      this paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from
-      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
-      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.125.
-      As origin, it's designed to perform image classification. For details about
-      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+      The `octave-resnet-200-0.125` model is a modification of `resnet-200` from this
+      paper <https://arxiv.org/pdf/1512.03385.pdf> with octave convolutions from Drop
+      an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with
+      Octave Convolution <https://arxiv.org/abs/1904.05049> with `alpha=0.125`. As
+      origin, it's designed to perform image classification. For details about family
+      of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
 
       The model input is a blob that consists of a single image of 1x3x224x224 in
       RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
@@ -3820,6 +3824,7 @@ topologies:
     model_optimizer_args:
       - --framework=mxnet
       - --data_type=FP32
+      - --reverse_input_channels
       - --mean_values=data[124,117,104]
       - --scale_values=data[59.880239521]
       - --input_shape=[1,3,224,224]
@@ -3832,12 +3837,12 @@ topologies:
 
   - name: "octave-resnext-50-0.25"
     description: >-
-      The `octave-resnext-50-0.25` model is a modification of `resnext-50` from the
-      this paper <https://arxiv.org/abs/1611.05431> with octave convolutions from
-      Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
-      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.25.
-      As origin, it's designed to perform image classification. For details about
-      family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
+      The `octave-resnext-50-0.25` model is a modification of `resnext-50` from this
+      paper <https://arxiv.org/abs/1611.05431> with octave convolutions from Drop
+      an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks with
+      Octave Convolution <https://arxiv.org/abs/1904.05049> with `alpha=0.25`. As
+      origin, it's designed to perform image classification. For details about family
+      of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
 
       The model input is a blob that consists of a single image of 1x3x224x224 in
       RGB order. The RGB mean values need to be subtracted as follows: [124,117,104]
@@ -3860,6 +3865,7 @@ topologies:
     model_optimizer_args:
       - --framework=mxnet
       - --data_type=FP32
+      - --reverse_input_channels
       - --mean_values=data[124,117,104]
       - --scale_values=data[59.880239521]
       - --input_shape=[1,3,224,224]
@@ -3873,9 +3879,9 @@ topologies:
   - name: "octave-resnext-101-0.25"
     description: >-
       The `octave-resnext-101-0.25` model is a modification of `resnext-101` from
-      the this paper <https://arxiv.org/abs/1611.05431> with octave convolutions from
+      this paper <https://arxiv.org/abs/1611.05431> with octave convolutions from
       Drop an Octave: Reducing Spatial Redundancy in Convolutional Neural Networks
-      with Octave Convolution <https://arxiv.org/abs/1904.05049> with &alpha;=0.25.
+      with Octave Convolution <https://arxiv.org/abs/1904.05049> with `alpha=0.25`.
       As origin, it's designed to perform image classification. For details about
       family of octave convolution models, check out the repository <https://github.com/facebookresearch/OctConv>.
 
@@ -3900,6 +3906,7 @@ topologies:
     model_optimizer_args:
       - --framework=mxnet
       - --data_type=FP32
+      - --reverse_input_channels
       - --mean_values=data[124,117,104]
       - --scale_values=data[59.880239521]
       - --input_shape=[1,3,224,224]


### PR DESCRIPTION
Added modificated with octave convolutions models:
- densenet-121 (&alpha;=0.125) 
- resnet-26 (&alpha;=0.25)
- resnet-50 (&alpha;=0.125)
- resnet-101 (&alpha;=0.125)
- resnet-200 (&alpha;=0.125)
- resnext-50 (&alpha;=0.25)
- resnext-101 (&alpha;=0.25)

[Paper](https://arxiv.org/abs/1904.05049)
[Source](https://github.com/facebookresearch/OctConv)
[License](https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE)