### PR TITLE
AC: allows to use regular expression instead of full output layer name for ssd pytorch

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -50,9 +50,9 @@ AccuracyChecker supports following set of adapters:
   * `nms_threshold` - overlap threshold for NMS (optional, default 0.5).
   * `keep_top_k ` - maximal number of boxes which should be kept (optional, default 200).
 * `ssd_onnx` - converting output of SSD-based model from Pytorch with NonMaxSuppression layer.
-  * `labels_out` - name of output layer with labels
-  * `scores_out`- name of output layer with scores
-  * `bboxes_out` - name of output layer with bboxes
+  * `labels_out` - name of output layer with labels or regular expression for it searching.
+  * `scores_out`- name of output layer with scores or regular expression for it searching.
+  * `bboxes_out` - name of output layer with bboxes or regular expression for it searching.
 * `tf_object_detection` - converting output of detection models from TensorFlow object detection API to `DetectionPrediction`.
   * `classes_out` - name of output layer with predicted classes.
   * `boxes_out` - name of output layer with predicted boxes coordinates in format [y0, x0, y1, x1].

--- a/tools/accuracy_checker/accuracy_checker/adapters/detection.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/detection.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import itertools
 import math
+import re
 
 import numpy as np
 
@@ -653,9 +654,9 @@ class SSDONNXAdapter(Adapter):
         parameters = super().parameters()
         parameters.update(
             {
-                'labels_out': StringField(description='name of output layer with labels'),
-                'scores_out': StringField(description='name of output layer with scores'),
-                'bboxes_out': StringField(description='name of output layer with bboxes')
+                'labels_out': StringField(description='name (or regex for it) of output layer with labels'),
+                'scores_out': StringField(description='name (or regex for it) of output layer with scores'),
+                'bboxes_out': StringField(description='name (or regex for it) of output layer with bboxes')
             }
         )
         return parameters
@@ -664,10 +665,13 @@ class SSDONNXAdapter(Adapter):
         self.labels_out = self.get_value_from_config('labels_out')
         self.scores_out = self.get_value_from_config('scores_out')
         self.bboxes_out = self.get_value_from_config('bboxes_out')
+        self.outputs_verified = False
 
     def process(self, raw, identifiers=None, frame_meta=None):
         raw_outputs = self._extract_predictions(raw, frame_meta)
         results = []
+        if not self.outputs_verified:
+            self._get_output_names(raw_outputs)
         for identifier, bboxes, scores, labels in zip(
                 identifiers, raw_outputs[self.bboxes_out], raw_outputs[self.scores_out], raw_outputs[self.labels_out]
         ):
@@ -675,3 +679,24 @@ class SSDONNXAdapter(Adapter):
             results.append(DetectionPrediction(identifier, labels, scores, x_mins, y_mins, x_maxs, y_maxs))
 
         return results
+
+    def _get_output_names(self, raw_outputs):
+        labels_regex = re.compile(self.labels_out)
+        scores_regex = re.compile(self.scores_out)
+        bboxes_regex = re.compile(self.bboxes_out)
+
+        def find_layer(regex, output_name, all_outputs):
+            suitable_layers = [layer_name for layer_name in all_outputs if regex.match(layer_name)]
+            if not suitable_layers:
+                raise ValueError('suitable layer for {} output is not found'.format(output_name))
+
+            if len(suitable_layers) > 1:
+                raise ValueError('more than 1 layers matched to regular expression, please specify more detailed regex')
+
+            return suitable_layers[0]
+
+        self.labels_out = find_layer(labels_regex, 'labels', raw_outputs)
+        self.scores_out = find_layer(scores_regex, 'scores', raw_outputs)
+        self.bboxes_out = find_layer(bboxes_regex, 'bboxes', raw_outputs)
+
+        self.outputs_verified = True


### PR DESCRIPTION
From one to other MO running model can have different suffixes for output layers.
It can become a problem for inplace conversion during Accuracy Checker running.