### PR TITLE
Add supporting reid models with NCHW layout to pedestrian_tracker_demo

### DIFF
--- a/demos/pedestrian_tracker_demo/src/cnn.cpp
+++ b/demos/pedestrian_tracker_demo/src/cnn.cpp
@@ -51,9 +51,10 @@ void CnnBase::Load() {
 
     for (auto&& item : outInfo_) {
         SizeVector outputDims = item.second->getTensorDesc().getDims();
+        auto outputLayout = item.second->getTensorDesc().getLayout();
         item.second->setPrecision(Precision::FP32);
         TBlob<float>::Ptr output =
-            make_shared_blob<float>(TensorDesc(Precision::FP32, outputDims, Layout::NC));
+            make_shared_blob<float>(TensorDesc(Precision::FP32, outputDims, outputLayout));
         output->allocate();
         outputs_[item.first] = output;
     }

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -154,7 +154,10 @@ NATIVE_DEMOS = [
             TestCase(options={'-m_det': ModelArg('person-detection-retail-0002')}),
             TestCase(options={'-m_det': ModelArg('person-detection-retail-0013')}),
         ],
-        TestCase(options={'-m_reid': ModelArg('person-reidentification-retail-0031')}),
+        single_option_cases('-m_reid',
+            ModelArg('person-reidentification-retail-0031'),
+            ModelArg('person-reidentification-retail-0076'),
+            ModelArg('person-reidentification-retail-0079')),
     )),
 
     NativeDemo(name='security_barrier_camera_demo', test_cases=combine_cases(


### PR DESCRIPTION
Earlier only models with NC layout were supported.