### PR TITLE
ci/requirements-*.txt: bump all versions

### DIFF
--- a/ci/requirements-ac.txt
+++ b/ci/requirements-ac.txt
@@ -1,12 +1,12 @@
 joblib==0.13.2            # via scikit-learn
-nibabel==2.4.1
-numpy==1.16.0
-pillow==6.0.0
+nibabel==2.5.0
+numpy==1.17.0
+pillow==6.1.0
 py-cpuinfo==4.0.0
-pyyaml==5.1.1
-scikit-learn==0.21.2
+pyyaml==5.1.2
+scikit-learn==0.21.3
 scipy==0.19.0
 shapely==1.6.4.post2
 six==1.12.0               # via nibabel
-tqdm==4.32.1
+tqdm==4.33.0
 yamlloader==0.5.5

--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -1,18 +1,18 @@
-absl-py==0.7.1            # via tensorboard, tensorflow, tensorflow-estimator
+absl-py==0.7.1            # via tensorboard, tensorflow
 astor==0.8.0              # via tensorflow
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 decorator==4.4.0          # via networkx
 defusedxml==0.6.0
 gast==0.2.2               # via tensorflow
+google-pasta==0.1.7       # via tensorflow
 graphviz==0.8.4           # via mxnet
-grpcio==1.21.1            # via tensorboard, tensorflow
+grpcio==1.22.0            # via tensorboard, tensorflow
 h5py==2.9.0               # via keras-applications
 idna==2.8                 # via requests
 keras-applications==1.0.8  # via tensorflow
-keras-preprocessing==1.0.9  # via tensorflow
+keras-preprocessing==1.1.0  # via tensorflow
 markdown==3.1.1           # via tensorboard
-mock==3.0.5               # via tensorflow-estimator
 mxnet==1.3.1
 networkx==2.3
 numpy==1.14.6
@@ -20,17 +20,21 @@ onnx==1.5.0
 pillow==6.1.0             # via torchvision
 protobuf==3.6.1
 requests==2.22.0          # via mxnet
-scipy==1.3.0              # via torchvision
-six==1.12.0               # via absl-py, grpcio, h5py, keras-preprocessing, mock, onnx, protobuf, tensorboard, tensorflow, tensorflow-estimator, test-generator
-tensorboard==1.13.1       # via tensorflow
-tensorflow-estimator==1.13.0  # via tensorflow
-tensorflow==1.13.1
+scipy==1.3.1
+six==1.12.0               # via absl-py, grpcio, h5py, keras-preprocessing, onnx, protobuf, tensorboard, tensorflow, test-generator, torchvision
+tensorboard==1.14.0       # via tensorflow
+tensorflow-estimator==1.14.0  # via tensorflow
+tensorflow==1.14.0
 termcolor==1.1.0          # via tensorflow
 test-generator==0.1.1
-torch==1.1.0
-torchvision==0.3.0
-typing-extensions==3.7.2  # via onnx
-typing==3.6.6             # via onnx
+torch==1.2.0
+torchvision==0.4.0
+typing-extensions==3.7.4  # via onnx
+typing==3.7.4             # via onnx
 urllib3==1.25.3           # via requests
-werkzeug==0.15.4          # via tensorboard
+werkzeug==0.15.5          # via tensorboard
 wheel==0.33.4             # via tensorboard, tensorflow
+wrapt==1.11.2             # via tensorflow
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via markdown, protobuf, tensorboard

--- a/ci/requirements-downloader.txt
+++ b/ci/requirements-downloader.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=ci/requirements-downloader.txt tools/downloader/requirements.in
 #
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 idna==2.8                 # via requests
-pyyaml==5.1
+pyyaml==5.1.2
 requests==2.22.0
 urllib3==1.25.3           # via requests


### PR DESCRIPTION
~Except for numpy in `requirements-ac.txt`, which needs to stay at 1.16 due to an issue with Pylint.~

EDIT: Bumped numpy too.