### PR TITLE
Enbale check availability of HDDL plugin without booting HDDL

### DIFF
--- a/demos/common/samples/common.hpp
+++ b/demos/common/samples/common.hpp
@@ -1114,11 +1114,14 @@ inline std::size_t getTensorBatch(const InferenceEngine::TensorDesc& desc) {
 inline void showAvailableDevices() {
     InferenceEngine::Core ie;
     std::vector<std::string> devices = ie.GetAvailableDevices();
-
-    std::cout << std::endl;
-    std::cout << "Available target devices:";
-    for (const auto& device : devices) {
-        std::cout << "  " << device;
+    if (!devices.empty()) {
+        std::cout << std::endl;
+        std::cout << "Available target devices:";
+        for (const auto& device : devices) {
+            std::cout << "  " << device;
+        }
     }
-    std::cout << "  HDDL" << std::endl;
+    else {
+        THROW_IE_EXCEPTION << "Not available any target device to infer on";
+    }
 }


### PR DESCRIPTION
Previously, when querying the availability of HDDL, it will cost too much time to boot daemon which resulting in bad experience. As a workarouond, it print "HDDL" by default regardless of the result. Now, HDDL plugin supports availability of without booting HDDL.

Signed-off-by: Lu, Gaoyong <gaoyong.lu@intel.com>