### PR TITLE
Add a list of representative models for downloader testing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 /demos/build_demos.sh omz.package=l,m
 /demos/build_demos_msvc.bat omz.package=w
 /demos/tests/** -omz.package
+/tools/downloader/tests/** -omz.package

--- a/tools/downloader/tests/representative-models.lst
+++ b/tools/downloader/tests/representative-models.lst
@@ -1,0 +1,8 @@
+# A list of models that covers all Model Downloader/Converter features
+
+mobilenet-v1-0.25-128 # TensorFlow, HTTP downloads
+mobilenet-v2-pytorch # PyTorch (external module), Google Drive downloads
+mtcnn-p # Caffe, HTTPS downloads, regex replacement
+octave-densenet-121-0.125 # MXNet, archive unpacking
+resnet-50-pytorch # PyTorch (torchvision)
+single-image-super-resolution-1032 # DLDT


### PR DESCRIPTION
These models cover the full spectrum of downloader and converter features, while weighting ~100 times less than the full set. We can use this list to make precommit builds take much less time while still being reasonably comprehensive.