### PR TITLE
update ref metric values for person-vehicle-bike-detection-crossroad-0078

### DIFF
--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/description/person-vehicle-bike-detection-crossroad-0078.md
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/description/person-vehicle-bike-detection-crossroad-0078.md
@@ -14,10 +14,10 @@ conditions.
 
 | Metric                          | Value                                     |
 |---------------------------------|-------------------------------------------|
-| Mean Average Precision (mAP)    | 64.48%                                    |
-| AP people                       | 76.22%                                    |
-| AP vehicles                     | 74.66%                                    |
-| AP bikes                        | 42.56%                                    |
+| Mean Average Precision (mAP)    | 65.12%                                    |
+| AP people                       | 76.28%                                    |
+| AP vehicles                     | 74.94%                                    |
+| AP bikes                        | 44.14%                                    |
 | Max objects to detect           | 200                                       |
 | GFlops                          | 3.964                                     |
 | MParams                         | 1.178                                     |


### PR DESCRIPTION
originally, ref metrics were obtained with IR from some old OpenVINO version and unknown OpenCV version. This PR updates metrics with using model in source framework format and OpenCV 4.1.1-openvino