### PR TITLE
Unlink the BIT-Vehicle dataset

### DIFF
--- a/models/intel/vehicle-license-plate-detection-barrier-0106/description/vehicle-license-plate-detection-barrier-0106.md
+++ b/models/intel/vehicle-license-plate-detection-barrier-0106/description/vehicle-license-plate-detection-barrier-0106.md
@@ -25,7 +25,7 @@ the "Barrier" use case.
 
 Average Precision (AP) is defined as an area under the
 [precision/recall](https://en.wikipedia.org/wiki/Precision_and_recall)
-curve. Validation dataset is [BIT-Vehicle](http://iitlab.bit.edu.cn/mcislab/vehicledb/).
+curve. Validation dataset is BIT-Vehicle.
 
 ## Performance
 


### PR DESCRIPTION
Its webpage has been down for a couple of weeks now, and it's breaking our link checking job. We'll have to remove the link, at least for now.