### PR TITLE
Use maskUtils to match the import on line 113

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
+++ b/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
@@ -18,6 +18,11 @@ from enum import Enum
 
 import numpy as np
 
+try:
+    import pycocotools.mask as maskUtils
+except ImportError:
+    maskUtils = None
+
 from .base_representation import BaseRepresentation
 from ..data_readers import BaseReader
 from ..utils import remove_difficult
@@ -108,10 +113,7 @@ class BrainTumorSegmentationPrediction(SegmentationPrediction):
 
 class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
     def __init__(self, identifier, mask, labels):
-        try:
-            # pylint: disable=W0611
-            import pycocotools.mask as maskUtils
-        except ImportError:
+        if not maskUtils
             raise ValueError('can not create representation')
         super().__init__(identifier)
         self.raw_mask = mask

--- a/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
+++ b/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
@@ -163,7 +163,7 @@ class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
         masks = self.mask
         areas = []
         for mask in masks:
-            areas.append(pycocotools.mask.area(mask))
+            areas.append(maskUtils.area(mask))
         return areas
 
 

--- a/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
+++ b/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
@@ -138,10 +138,10 @@ class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
 
     @staticmethod
     def _convert_mask(mask, height, width):
-        if isinstance(mask, list):
+        if maskUtils and isinstance(mask, list):
             rles = maskUtils.frPyObjects(mask, height, width)
             rle = maskUtils.merge(rles)
-        elif isinstance(mask['counts'], list):
+        elif maskUtils and isinstance(mask['counts'], list):
             # uncompressed RLE
             rle = maskUtils.frPyObjects(mask, height, width)
         else:

--- a/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
+++ b/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
@@ -113,7 +113,7 @@ class BrainTumorSegmentationPrediction(SegmentationPrediction):
 
 class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
     def __init__(self, identifier, mask, labels):
-        if not maskUtils
+        if not maskUtils:
             raise ValueError('can not create representation')
         super().__init__(identifier)
         self.raw_mask = mask


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/opencv/open_model_zoo on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py:132:20: F821 undefined name 'maskUtils'
            rles = maskUtils.frPyObjects(mask, height, width)
                   ^
./tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py:133:19: F821 undefined name 'maskUtils'
            rle = maskUtils.merge(rles)
                  ^
./tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py:136:19: F821 undefined name 'maskUtils'
            rle = maskUtils.frPyObjects(mask, height, width)
                  ^
./tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py:158:26: F821 undefined name 'pycocotools'
            areas.append(pycocotools.mask.area(mask))
                         ^
4     F821 undefined name 'maskUtils'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree