### PR TITLE
models/public/densenet-*-tf: remove the --input_checkpoint option

### DIFF
--- a/models/public/densenet-121-tf/model.yml
+++ b/models/public/densenet-121-tf/model.yml
@@ -37,6 +37,5 @@ model_optimizer_args:
   - --scale_values=Placeholder[58.8235294117647]
   - --output=densenet121/predictions/Reshape_1
   - --input_meta_graph=$dl_dir/tf-densenet121.ckpt.meta
-  - --input_checkpoint=$dl_dir/tf-densenet121.ckpt.data-00000-of-00001
 framework: tf
 license: https://raw.githubusercontent.com/pudae/tensorflow-densenet/master/LICENSE

--- a/models/public/densenet-161-tf/model.yml
+++ b/models/public/densenet-161-tf/model.yml
@@ -37,6 +37,5 @@ model_optimizer_args:
   - --scale_values=Placeholder[58.8235294117647]
   - --output=densenet161/predictions/Reshape_1
   - --input_meta_graph=$dl_dir/tf-densenet161.ckpt.meta
-  - --input_checkpoint=$dl_dir/tf-densenet161.ckpt.data-00000-of-00001
 framework: tf
 license: https://raw.githubusercontent.com/pudae/tensorflow-densenet/master/LICENSE

--- a/models/public/densenet-169-tf/model.yml
+++ b/models/public/densenet-169-tf/model.yml
@@ -37,6 +37,5 @@ model_optimizer_args:
   - --scale_values=Placeholder[58.8235294117647]
   - --output=densenet169/predictions/Reshape_1
   - --input_meta_graph=$dl_dir/tf-densenet169.ckpt.meta
-  - --input_checkpoint=$dl_dir/tf-densenet169.ckpt.data-00000-of-00001
 framework: tf
 license: https://raw.githubusercontent.com/pudae/tensorflow-densenet/master/LICENSE


### PR DESCRIPTION
Model Optimizer doesn't need it (and, in fact, ignores it) when `--input_meta_graph` is specified.