### PR TITLE
Preemptively bump the release number in the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [OpenVINO™ Toolkit](https://01.org/openvinotoolkit) - Open Model Zoo repository
 [![Build Status](http://134.191.240.124/buildStatus/icon?job=omz/2018/trigger)](http://134.191.240.124/job/omz/job/2018/job/trigger/)
-[![Stable release](https://img.shields.io/badge/version-2019_R2-green.svg)](https://github.com/opencv/open_model_zoo/releases/tag/2019_R2)
+[![Stable release](https://img.shields.io/badge/version-2019_R3-green.svg)](https://github.com/opencv/open_model_zoo/releases/tag/2019_R3)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/open_model_zoo/community)
 [![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE)
 


### PR DESCRIPTION
We want the README file in the OpenVINO package to say R3, and for that to happen we need to bump the release number before the release.

This does mean that the README will be pointing to a nonexistent tag until the release is out.