### PR TITLE
multi_camera_multi_person_tracking: remove person-detection-retail-0002

### DIFF
--- a/demos/python_demos/multi_camera_multi_person_tracking/models.lst
+++ b/demos/python_demos/multi_camera_multi_person_tracking/models.lst
@@ -1,3 +1,3 @@
 # This file can be used with the --list option of the model downloader.
-person-detection-retail-????
+person-detection-retail-0013
 person-reidentification-retail-????


### PR DESCRIPTION
The demo supports only single input nets, while person-detection-retail-0002 has two inputs.