### PR TITLE
AC: upgrade scipy version requirements

### DIFF
--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -29,7 +29,7 @@ requirements = OrderedDict([
     ('ymlloader', 'yamlloader'),
     ('Pillow', 'pillow'),
     ('scikit-learn', 'scikit-learn'),
-    ('scipy', 'scipy<=0.19'),
+    ('scipy', 'scipy<1.2'),
     ('cpuinfo', 'py-cpuinfo<=4.0'),
     ('shapely', 'shapely'),
     ('nibabel', 'nibabel')


### PR DESCRIPTION
python3.7 does not have prebuilt scipy version