### PR TITLE
AC: remove usage deprecated scipy image api

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/data_readers/README.md
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/README.md
@@ -30,7 +30,10 @@ reader:
 AccuracyChecker supports following list of data readers:
 * `opencv_imread` - read images using OpenCV library. Default color space is BGR.
 * `pillow_imread` - read images using Pillow library. Default color space is RGB.
-* `scipy_imread` - read images using Scipy library.
+* `scipy_imread` - read images using similar approach as in `scipy.misc.imread` 
+```
+Note: since 1.3.0 version the image processing module is not a part of scipy library. This reader does not use scipy anymore.
+```
 * `tf_imred`- read images using Tensorflow. Default color space is RGB. Requires Tensorflow installation.
 * `opencv_capture` - read frames from video using OpenCV.
 * `json_reader` - read value from json file.

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -20,7 +20,6 @@ from collections import OrderedDict, namedtuple
 import re
 import cv2
 from PIL import Image
-import scipy.misc
 import numpy as np
 import nibabel as nib
 
@@ -180,8 +179,164 @@ class PillowImageReader(BaseReader):
 class ScipyImageReader(BaseReader):
     __provider__ = 'scipy_imread'
 
+    @staticmethod
+    def _from_image(image, flatten=False, mode=None):
+        if mode is not None:
+            if mode != image.mode:
+                image = image.convert(mode)
+        elif image.mode == 'P':
+            image = image.convert('RGBA') if 'transparency' in image.info else image.convert('RGB')
+
+        if flatten:
+            image = image.convert('F')
+        elif image.mode == '1':
+            image = image.convert('L')
+
+        return np.array(image)
+
+    @staticmethod
+    def _to_image(arr, high=255, low=0, cmin=None, cmax=None, pal=None, mode=None, channel_axis=None):
+        _errstr = "Mode is unknown or incompatible with input array shape."
+        data = np.asarray(arr)
+        if np.iscomplexobj(data):
+            raise ValueError("Cannot convert a complex-valued array.")
+        shape = list(data.shape)
+        valid = len(shape) == 2 or ((len(shape) == 3) and ((3 in shape) or (4 in shape)))
+        if not valid:
+            raise ValueError("'arr' does not have a suitable array shape for any mode.")
+        if len(shape) == 2:
+            shape = (shape[1], shape[0])  # columns show up first
+            if mode == 'F':
+                data32 = data.astype(np.float32)
+                image = Image.frombytes(mode, shape, data32.tostring())
+
+                return image
+            if mode in [None, 'L', 'P']:
+                bytedata = ScipyImageReader._bytescale(data, high=high, low=low, cmin=cmin, cmax=cmax)
+                image = Image.frombytes('L', shape, bytedata.tostring())
+                if pal is not None:
+                    image.putpalette(np.asarray(pal, dtype=np.uint8).tostring())
+                    # Becomes a mode='P' automagically.
+                elif mode == 'P':  # default gray-scale
+                    pal = (
+                            np.arange(0, 256, 1, dtype=np.uint8)[:, np.newaxis] *
+                            np.ones((3,), dtype=np.uint8)[np.newaxis, :]
+                    )
+                    image.putpalette(np.asarray(pal, dtype=np.uint8).tostring())
+
+                return image
+            if mode == '1':  # high input gives threshold for 1
+                bytedata = (data > high)
+                image = Image.frombytes('1', shape, bytedata.tostring())
+
+                return image
+
+            cmin = cmin or np.amin(np.ravel(data))
+            cmax = cmax or np.amax(np.ravel(data))
+            data = (data * 1.0 - cmin) * (high - low) / (cmax - cmin) + low
+            if mode == 'I':
+                data32 = data.astype(np.uint32)
+                image = Image.frombytes(mode, shape, data32.tostring())
+            else:
+                raise ValueError(_errstr)
+
+            return image
+
+        # if here then 3-d array with a 3 or a 4 in the shape length.
+        # Check for 3 in datacube shape --- 'RGB' or 'YCbCr'
+        if channel_axis is None:
+            ca = np.flatnonzero(np.asarray(shape) == 3) if 3 in shape else np.flatnonzero(np.asarray(shape) == 4)
+            if np.size(ca):
+                ca = ca[0]
+            else:
+                raise ValueError("Could not find channel dimension.")
+        else:
+            ca = channel_axis
+
+        numch = shape[ca]
+        if numch not in [3, 4]:
+            raise ValueError("Channel axis dimension is not valid.")
+
+        bytedata = ScipyImageReader._bytescale(data, high=high, low=low, cmin=cmin, cmax=cmax)
+        if ca == 2:
+            strdata = bytedata.tostring()
+            shape = (shape[1], shape[0])
+        elif ca == 1:
+            strdata = np.transpose(bytedata, (0, 2, 1)).tostring()
+            shape = (shape[2], shape[0])
+        elif ca == 0:
+            strdata = np.transpose(bytedata, (1, 2, 0)).tostring()
+            shape = (shape[2], shape[1])
+        if mode is None:
+            if numch == 3:
+                mode = 'RGB'
+            else:
+                mode = 'RGBA'
+
+        if mode not in ['RGB', 'RGBA', 'YCbCr', 'CMYK']:
+            raise ValueError(_errstr)
+
+        if mode in ['RGB', 'YCbCr']:
+            if numch != 3:
+                raise ValueError("Invalid array shape for mode.")
+        if mode in ['RGBA', 'CMYK']:
+            if numch != 4:
+                raise ValueError("Invalid array shape for mode.")
+
+        # Here we know data and mode is correct
+        image = Image.frombytes(mode, shape, strdata)
+        return image
+
+    @staticmethod
+    def _imread(name):
+        # reimplementation scipy.misc.imread
+        image = Image.open(name)
+
+        return ScipyImageReader._from_image(image)
+
+    @staticmethod
+    def _bytescale(data, cmin=None, cmax=None, high=255, low=0):
+        if data.dtype == np.uint8:
+            return data
+
+        if high > 255:
+            raise ValueError("`high` should be less than or equal to 255.")
+        if low < 0:
+            raise ValueError("`low` should be greater than or equal to 0.")
+        if high < low:
+            raise ValueError("`high` should be greater than or equal to `low`.")
+        cmin = cmin or data.min()
+        cmax = cmax or data.max()
+
+        cscale = cmax - cmin
+        if cscale < 0:
+            raise ValueError("`cmax` should be larger than `cmin`.")
+        elif cscale == 0:
+            cscale = 1
+
+        scale = float(high - low) / cscale
+        bytedata = (data - cmin) * scale + low
+
+        return (bytedata.clip(low, high) + 0.5).astype(np.uint8)
+
+    @staticmethod
+    def imresize(arr, size, interp='bilinear', mode=None):
+        im = ScipyImageReader._to_image(arr, mode=mode)
+        ts = type(size)
+        if np.issubdtype(ts, np.signedinteger):
+            percent = size / 100.0
+            size = tuple((np.array(im.size) * percent).astype(int))
+        elif np.issubdtype(type(size), np.floating):
+            size = tuple((np.array(im.size) * size).astype(int))
+        else:
+            size = (size[1], size[0])
+        func = {'nearest': 0, 'lanczos': 1, 'bilinear': 2, 'bicubic': 3, 'cubic': 3}
+        imnew = im.resize(size, resample=func[interp])
+
+        return ScipyImageReader._from_image(imnew)
+
     def read(self, data_id):
-        return np.array(scipy.misc.imread(str(get_path(self.data_source / data_id))))
+        return ScipyImageReader._imread(str(get_path(self.data_source / data_id)))
 
 
 class OpenCVFrameReader(BaseReader):

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -180,101 +180,50 @@ class ScipyImageReader(BaseReader):
     __provider__ = 'scipy_imread'
 
     @staticmethod
-    def _from_image(image, flatten=False, mode=None):
-        if mode is not None:
-            if mode != image.mode:
-                image = image.convert(mode)
-        elif image.mode == 'P':
+    def _from_image(image):
+        if image.mode == 'P':
             image = image.convert('RGBA') if 'transparency' in image.info else image.convert('RGB')
-
-        if flatten:
-            image = image.convert('F')
-        elif image.mode == '1':
-            image = image.convert('L')
 
         return np.array(image)
 
     @staticmethod
-    def _process_2d(data, shape, mode, pal, high, low, cmax, cmin):
+    def _process_2d(data, shape):
         shape = (shape[1], shape[0])  # columns show up first
-        if mode == 'F':
-            data32 = data.astype(np.float32)
-            image = Image.frombytes(mode, shape, data32.tostring())
-
-            return image
-        if mode in [None, 'L', 'P']:
-            bytedata = ScipyImageReader._bytescale(data, high=high, low=low, cmin=cmin, cmax=cmax)
-            image = Image.frombytes('L', shape, bytedata.tostring())
-            if pal is not None:
-                image.putpalette(np.asarray(pal, dtype=np.uint8).tostring())
-                # Becomes a mode='P' automagically.
-            elif mode == 'P':  # default gray-scale
-                pal1 = np.arange(0, 256, 1, dtype=np.uint8)[:, np.newaxis]
-                pal2 = np.ones((3,), dtype=np.uint8)[np.newaxis, :]
-                pal = pal1 * pal2
-                image.putpalette(np.asarray(pal, dtype=np.uint8).tostring())
-
-            return image
-        if mode == '1':  # high input gives threshold for 1
-            bytedata = (data > high)
-            image = Image.frombytes('1', shape, bytedata.tostring())
-
-            return image
-
-        cmin = cmin or np.amin(np.ravel(data))
-        cmax = cmax or np.amax(np.ravel(data))
-        data = (data * 1.0 - cmin) * (high - low) / (cmax - cmin) + low
-        if mode == 'I':
-            data32 = data.astype(np.uint32)
-            image = Image.frombytes(mode, shape, data32.tostring())
-        else:
-            raise ValueError("Mode is unknown or incompatible with input array shape.")
+        bytedata = ScipyImageReader._bytescale(data)
+        image = Image.frombytes('L', shape, bytedata.tostring())
 
         return image
 
     @staticmethod
-    def _process_3d(data, shape, mode, channel_axis, high, low, cmin, cmax):
+    def _process_3d(data, shape):
         # if here then 3-d array with a 3 or a 4 in the shape length.
         # Check for 3 in datacube shape --- 'RGB' or 'YCbCr'
-        if channel_axis is None:
-            ca = np.flatnonzero(np.asarray(shape) == 3) if 3 in shape else np.flatnonzero(np.asarray(shape) == 4)
-            if not np.size(ca):
-                raise ValueError("Could not find channel dimension.")
-            ca = ca[0]
-        else:
-            ca = channel_axis
+        ca = np.flatnonzero(np.asarray(shape) == 3) if 3 in shape else np.flatnonzero(np.asarray(shape) == 4)
+        if not np.size(ca):
+            raise ValueError("Could not find channel dimension.")
+        ca = ca[0]
 
         numch = shape[ca]
         if numch not in [3, 4]:
             raise ValueError("Channel axis dimension is not valid.")
 
-        bytedata = ScipyImageReader._bytescale(data, high=high, low=low, cmin=cmin, cmax=cmax)
+        bytedata = ScipyImageReader._bytescale(data)
         channel_axis_mapping = {
             0: ((1, 2, 0), (shape[1], shape[0])),
             1: ((0, 2, 1), (shape[2], shape[0])),
             2: ((0, 1, 2), (shape[1], shape[0]))
         }
-        if ca in channel_axis_mapping:
-            transposition, shape = channel_axis_mapping[ca]
-            strdata = np.transpose(bytedata, transposition).tostring()
+        transposition, shape = channel_axis_mapping[ca]
+        strdata = np.transpose(bytedata, transposition).tostring()
 
-        if mode is None:
-            mode = 'RGB' if numch == 3 else 'RGBA'
-
-        if mode not in ['RGB', 'RGBA', 'YCbCr', 'CMYK']:
-            raise ValueError("Mode is unknown or incompatible with input array shape.")
-
-        if mode in ['RGB', 'YCbCr'] and numch != 3:
-            raise ValueError("Invalid array shape for mode.")
-        if mode in ['RGBA', 'CMYK'] and numch != 4:
-            raise ValueError("Invalid array shape for mode.")
-
+        mode = 'RGB' if numch == 3 else 'RGBA'
         # Here we know data and mode is correct
         image = Image.frombytes(mode, shape, strdata)
+
         return image
 
     @staticmethod
-    def _to_image(arr, high=255, low=0, cmin=None, cmax=None, pal=None, mode=None, channel_axis=None):
+    def _to_image(arr):
         data = np.asarray(arr)
         if np.iscomplexobj(data):
             raise ValueError("Cannot convert a complex-valued array.")
@@ -283,8 +232,8 @@ class ScipyImageReader(BaseReader):
         if not valid:
             raise ValueError("'arr' does not have a suitable array shape for any mode.")
         if len(shape) == 2:
-            return ScipyImageReader._process_2d(data, shape, mode, pal, high, low, cmax, cmin)
-        return ScipyImageReader._process_3d(data, shape, mode, channel_axis, high, low, cmin, cmax)
+            return ScipyImageReader._process_2d(data, shape)
+        return ScipyImageReader._process_3d(data, shape)
 
     @staticmethod
     def _imread(name):
@@ -294,43 +243,25 @@ class ScipyImageReader(BaseReader):
         return ScipyImageReader._from_image(image)
 
     @staticmethod
-    def _bytescale(data, cmin=None, cmax=None, high=255, low=0):
+    def _bytescale(data):
         if data.dtype == np.uint8:
             return data
-
-        if high > 255:
-            raise ValueError("`high` should be less than or equal to 255.")
-        if low < 0:
-            raise ValueError("`low` should be greater than or equal to 0.")
-        if high < low:
-            raise ValueError("`high` should be greater than or equal to `low`.")
-        cmin = cmin or data.min()
-        cmax = cmax or data.max()
-
+        cmin = data.min()
+        cmax = data.max()
         cscale = cmax - cmin
-        if cscale < 0:
-            raise ValueError("`cmax` should be larger than `cmin`.")
         if cscale == 0:
             cscale = 1
 
-        scale = float(high - low) / cscale
-        bytedata = (data - cmin) * scale + low
+        scale = float(255) / cscale
+        bytedata = (data - cmin) * scale
 
-        return (bytedata.clip(low, high) + 0.5).astype(np.uint8)
+        return (bytedata.clip(0, 255) + 0.5).astype(np.uint8)
 
     @staticmethod
-    def imresize(arr, size, interp='bilinear', mode=None):
-        im = ScipyImageReader._to_image(arr, mode=mode)
-        ts = type(size)
-        if np.issubdtype(ts, np.signedinteger):
-            percent = size / 100.0
-            size = tuple((np.array(im.size) * percent).astype(int))
-        elif np.issubdtype(type(size), np.floating):
-            size = tuple((np.array(im.size) * size).astype(int))
-        else:
-            size = (size[1], size[0])
-        func = {'nearest': 0, 'lanczos': 1, 'bilinear': 2, 'bicubic': 3, 'cubic': 3}
-        imnew = im.resize(size, resample=func[interp])
+    def imresize(arr, size):
+        im = ScipyImageReader._to_image(arr)
+        size = (size[1], size[0])
+        imnew = im.resize(size, resample=0)
 
         return ScipyImageReader._from_image(imnew)
 

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/resample_segmentation_prediction.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/resample_segmentation_prediction.py
@@ -56,8 +56,9 @@ class SegmentationPredictionResample(Postprocessor):
 
         label = np.zeros(shape=(prediction_shape[0],) + image_shape)
 
-        label[:, low[0]:high[0], low[1]:high[1], low[2]:high[2]] = resample(prediction_.mask,
-                                                                            (prediction_shape[0],) + box_shape)
+        label[:, low[0]:high[0], low[1]:high[1], low[2]:high[2]] = resample(
+            prediction_.mask, (prediction_shape[0],) + box_shape
+        )
 
         prediction[0].mask = label
 

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/resize_segmentation_mask.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/resize_segmentation_mask.py
@@ -15,13 +15,14 @@ limitations under the License.
 """
 
 from functools import singledispatch
-import scipy.misc
 import numpy as np
 
 from ..config import NumberField
 from ..utils import get_size_from_config
 from .postprocessor import PostprocessorWithSpecificTargets
 from ..representation import SegmentationPrediction, SegmentationAnnotation
+from ..data_readers import ScipyImageReader
+
 
 class ResizeSegmentationMask(PostprocessorWithSpecificTargets):
     __provider__ = 'resize_segmentation_mask'
@@ -61,7 +62,7 @@ class ResizeSegmentationMask(PostprocessorWithSpecificTargets):
         def _(entry, height, width):
             entry_mask = []
             for class_mask in entry.mask:
-                resized_mask = scipy.misc.imresize(class_mask, (height, width), 'nearest')
+                resized_mask =  ScipyImageReader.imresize(class_mask, (height, width), 'nearest')
                 entry_mask.append(resized_mask)
             entry.mask = np.array(entry_mask)
 
@@ -69,7 +70,7 @@ class ResizeSegmentationMask(PostprocessorWithSpecificTargets):
 
         @resize_segmentation_mask.register(SegmentationAnnotation)
         def _(entry, height, width):
-            entry.mask = scipy.misc.imresize(entry.mask, (height, width), 'nearest')
+            entry.mask = ScipyImageReader.imresize(entry.mask, (height, width), 'nearest')
             return entry
 
         for target in annotation:

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/resize_segmentation_mask.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/resize_segmentation_mask.py
@@ -62,7 +62,7 @@ class ResizeSegmentationMask(PostprocessorWithSpecificTargets):
         def _(entry, height, width):
             entry_mask = []
             for class_mask in entry.mask:
-                resized_mask =  ScipyImageReader.imresize(class_mask, (height, width), 'nearest')
+                resized_mask = ScipyImageReader.imresize(class_mask, (height, width), 'nearest')
                 entry_mask.append(resized_mask)
             entry.mask = np.array(entry_mask)
 

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/resize_segmentation_mask.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/resize_segmentation_mask.py
@@ -62,7 +62,7 @@ class ResizeSegmentationMask(PostprocessorWithSpecificTargets):
         def _(entry, height, width):
             entry_mask = []
             for class_mask in entry.mask:
-                resized_mask = ScipyImageReader.imresize(class_mask, (height, width), 'nearest')
+                resized_mask = ScipyImageReader.imresize(class_mask, (height, width))
                 entry_mask.append(resized_mask)
             entry.mask = np.array(entry_mask)
 
@@ -70,7 +70,7 @@ class ResizeSegmentationMask(PostprocessorWithSpecificTargets):
 
         @resize_segmentation_mask.register(SegmentationAnnotation)
         def _(entry, height, width):
-            entry.mask = ScipyImageReader.imresize(entry.mask, (height, width), 'nearest')
+            entry.mask = ScipyImageReader.imresize(entry.mask, (height, width))
             return entry
 
         for target in annotation:

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/zoom_segmentation_mask.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/zoom_segmentation_mask.py
@@ -21,6 +21,7 @@ from ..representation import SegmentationAnnotation, SegmentationPrediction
 from ..config import NumberField
 from ..logging import warning
 
+
 class ZoomSegMask(Postprocessor):
     """
     Zoom probabilities of segmentation prediction.

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -29,7 +29,7 @@ requirements = OrderedDict([
     ('ymlloader', 'yamlloader'),
     ('Pillow', 'pillow'),
     ('scikit-learn', 'scikit-learn'),
-    ('scipy', 'scipy<1.2'),
+    ('scipy', 'scipy'),
     ('cpuinfo', 'py-cpuinfo<=4.0'),
     ('shapely', 'shapely'),
     ('nibabel', 'nibabel')


### PR DESCRIPTION
removed `scipy.misc.imread` and `scipy.misc.imresize` usage. Changes allow deleting restriction on supported scipy version