### PR TITLE
tools/downloader/downloader.py: restore the correct exit code on failure

### DIFF
--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -269,6 +269,7 @@ def main():
         reporter.print('FAILED:')
         for failed_model_name in failed_models:
             reporter.print(failed_model_name)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I accidentally removed this in #345.