### PR TITLE
Latency metrics

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
@@ -316,7 +316,7 @@ class ModelEvaluator:
         self._predictions = []
         self._metrics_results = []
         self._ir_latency = []
-        if self.dataset.reset()
+        if self.dataset
             self.dataset.reset()
 
     def release(self):

--- a/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
@@ -316,7 +316,8 @@ class ModelEvaluator:
         self._predictions = []
         self._metrics_results = []
         self._ir_latency = []
-        self.dataset.reset()
+        if self.dataset.reset()
+            self.dataset.reset()
 
     def release(self):
         self.launcher.release()

--- a/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
@@ -316,7 +316,7 @@ class ModelEvaluator:
         self._predictions = []
         self._metrics_results = []
         self._ir_latency = []
-        if self.dataset
+        if self.dataset:
             self.dataset.reset()
 
     def release(self):

--- a/tools/accuracy_checker/accuracy_checker/metrics/metric.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/metric.py
@@ -94,13 +94,13 @@ class Metric(ClassProvider):
     def submit(self, annotation, prediction):
         self.update(annotation, prediction)
 
-    def submit_all(self, annotations, predictions):
-        return self.evaluate(annotations, predictions)
+    def submit_all(self, annotations, predictions, latency=None):
+        return self.evaluate(annotations, predictions, latency)
 
     def update(self, annotation, prediction):
         pass
 
-    def evaluate(self, annotations, predictions):
+    def evaluate(self, annotations, predictions, latency=None):
         raise NotImplementedError
 
     def configure(self):
@@ -184,14 +184,19 @@ class PerImageEvaluationMetric(Metric):
         annotation_, prediction_ = self._resolve_representation_containers(annotation, prediction)
         self.update(annotation_, prediction_)
 
-    def evaluate(self, annotations, predictions):
+    def evaluate(self, annotations, predictions, latency=None):
         raise NotImplementedError
 
 
 class FullDatasetEvaluationMetric(Metric):
-    def submit_all(self, annotations, predictions):
+    def submit_all(self, annotations, predictions, latency=None):
         annotations_, predictions_ = zipped_transform(self._resolve_representation_containers, annotations, predictions)
         return self.evaluate(annotations_, predictions_)
 
-    def evaluate(self, annotations, predictions):
+    def evaluate(self, annotations, predictions, latency=None):
+        raise NotImplementedError
+class PerInferenceMetric(Metric):
+    def submit(self, annotations, predictions):
+        pass
+    def evaluate(self, annotations, predictions, latency=None):
         raise NotImplementedError

--- a/tools/accuracy_checker/accuracy_checker/metrics/metric_executor.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/metric_executor.py
@@ -94,7 +94,7 @@ class MetricsExecutor:
         context.annotations.extend(context.annotation_batch)
         context.predictions.extend(context.prediction_batch)
 
-    def update_metrics_on_object(self, annotation, prediction):
+    def update_metrics_on_object(self, annotation, prediction, latency=None):
         """
         Updates metric value corresponding given annotation and prediction objects.
         """
@@ -102,7 +102,7 @@ class MetricsExecutor:
         for metric in self.metrics:
             metric.metric_fn.submit(annotation, prediction)
 
-    def update_metrics_on_batch(self, annotation, prediction):
+    def update_metrics_on_batch(self, annotation, prediction, latency=None):
         """
         Updates metric value corresponding given batch.
 
@@ -113,12 +113,12 @@ class MetricsExecutor:
 
         zipped_transform(self.update_metrics_on_object, annotation, prediction)
 
-    def iterate_metrics(self, annotations, predictions):
+    def iterate_metrics(self, annotations, predictions, latency=None):
         for name, metric_type, functor, reference, threshold, presenter in self.metrics:
             yield presenter, EvaluationResult(
                 name=name,
                 metric_type=metric_type,
-                evaluated_value=functor(annotations, predictions),
+                evaluated_value=functor(annotations, predictions, latency),
                 reference_value=reference,
                 threshold=threshold,
                 meta=functor.meta,


### PR DESCRIPTION
Purpose: 
	When performing module optimization and quantization, in addtional to the accuracy, another major measurement of inference performance is latency, or how long it takes to complete a prediction. Shorter latency ensures good user experience. 
	Latency will be used in our quantizations alogorithom. We here proposal to add add the latency as a basic metrics as well as the accuracy. It can be got during the infrerence of predition, and the cost is not high.
	In the poposal patch, 2 kinds of latency metrics, minimum and average latency, are provided. Minimum is for the shortest one of all inference requests. The average one is the mean value of the request that filtered out noises, which is commom during warning up period.
	
	The patch should have no impact on the cases that latency metric is not interested.
	
	and example for latency metric setting in mobilenet_v2.yaml

        metrics:
          - name: accuracy@top1
            type: accuracy
            top_k: 1

          - name: accuracy@top5
            type: accuracy
            top_k: 5
	
          - name: latency@average_ms
            type: latency

          - name: latency@minimum_ms
            type: latency	
	