### PR TITLE
AC: do not store annotation and predictions if they is not used for metric evaluation

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/evaluators/model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/model_evaluator.py
@@ -136,8 +136,9 @@ class ModelEvaluator:
                     if not self.postprocessor.has_dataset_processors:
                         self.metric_executor.update_metrics_on_batch(annotations, predictions)
 
-                    self._annotations.extend(annotations)
-                    self._predictions.extend(predictions)
+                    if self.metric_executor.need_store_predictions:
+                        self._annotations.extend(annotations)
+                        self._predictions.extend(predictions)
 
                     if progress_reporter:
                         progress_reporter.update(batch_id, len(batch_predictions))

--- a/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
@@ -133,9 +133,9 @@ class ModelEvaluator:
 
                     if self.metric_executor:
                         self.metric_executor.update_metrics_on_batch(annotations, predictions)
-
-                    self._annotations.extend(annotations)
-                    self._predictions.extend(predictions)
+                        if self.metric_executor.need_store_predictions:
+                            self._annotations.extend(annotations)
+                            self._predictions.extend(predictions)
 
                     if progress_reporter:
                         progress_reporter.update(batch_id, len(batch_predictions))

--- a/tools/accuracy_checker/accuracy_checker/metrics/hit_ratio.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/hit_ratio.py
@@ -20,10 +20,10 @@ import math
 import numpy as np
 
 from ..representation import HitRatioAnnotation, HitRatioPrediction
-from .metric import FullDatasetEvaluationMetric
+from .metric import PerImageEvaluationMetric
 from ..config import NumberField
 
-class BaseRecommenderMetric(FullDatasetEvaluationMetric):
+class BaseRecommenderMetric(PerImageEvaluationMetric):
     annotation_types = (HitRatioAnnotation, )
     prediction_types = (HitRatioPrediction, )
 

--- a/tools/accuracy_checker/accuracy_checker/metrics/metric_executor.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/metric_executor.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 from ..presenters import BasePresenter, EvaluationResult
 from ..config import StringField
 from ..utils import zipped_transform
-from .metric import Metric
+from .metric import Metric, FullDatasetEvaluationMetric
 from ..config import ConfigValidator, ConfigError
 
 MetricInstance = namedtuple(
@@ -47,6 +47,7 @@ class MetricsExecutor:
         reference = 'reference'
         threshold = 'threshold'
         presenter = 'presenter'
+        self.need_store_predictions = False
         for metric_config_entry in metrics_config:
             metric_config = ConfigValidator(
                 "metrics", on_extra_argument=ConfigValidator.IGNORE_ON_EXTRA_ARGUMENT,
@@ -70,6 +71,8 @@ class MetricsExecutor:
                 metric_config_entry.get(threshold),
                 metric_presenter
             ))
+            if isinstance(metric_fn, FullDatasetEvaluationMetric):
+                self.need_store_predictions = True
 
     @classmethod
     def parameters(cls):


### PR DESCRIPTION
majority of supported metrics are iterative with updating internal state, so whole range annotations and predictions in `evaluate` signature is not used for them.

Removing annotations and predictions batch if possible can reduce memory consumption.
 