### PR TITLE
tools/downloader: Document a workaround for a TLS connection issue

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -39,6 +39,20 @@ conversion to ONNX format. To use automatic conversion install additional depend
 python3 -mpip install --user -r ./requirements-pytorch.in
 ```
 
+When running the model downloader with Python 3.5.x on macOS, you may encounter
+an error similar to the following:
+
+> requests.exceptions.SSLError: [...] (Caused by SSLError(SSLError(1, '[SSL: TLSV1_ALERT_PROTOCOL_VERSION]
+tlsv1 alert protocol version (_ssl.c:719)'),))
+
+You can work around this by installing additional packages:
+
+```sh
+python3 -mpip install --user 'requests[security]'
+```
+
+Alternatively, upgrade to Python 3.6 or a later version.
+
 Model downloader usage
 ----------------------
 


### PR DESCRIPTION
The official macOS Python 3.5 binaries are linked with system OpenSSL, which doesn't support TLS 1.2. Unfortunately, some of our file sources only support TLS 1.2 and up.

The workaround is to install 'requests[security]', which includes pyOpenSSL (which Requests will automatically use if it's available).

Since Python 3.6, the official binaries bundle a newer version of OpenSSL, so the issue no longer exists.