### PR TITLE
demos/tests/cases.py: avoid an out-of-bounds access in smart_classroom_demo

### DIFF
--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -187,12 +187,16 @@ NATIVE_DEMOS = [
             '-i': ImagePatternArg('smart-classroom-demo'),
             '-m_fd': ModelArg('face-detection-adas-0001')}),
         device_cases('-d_act', '-d_fd', '-d_lm', '-d_reid'),
-        single_option_cases('-m_act', ModelArg('person-detection-action-recognition-0005'),
-                                      ModelArg('person-detection-action-recognition-0006'),
-                                      ModelArg('person-detection-raisinghand-recognition-0001'),
-                                      ModelArg('person-detection-action-recognition-teacher-0002')),
-        single_option_cases('-m_lm', None, ModelArg('landmarks-regression-retail-0009')),
-        single_option_cases('-m_reid', None, ModelArg('face-reidentification-retail-0095')),
+        [
+            *combine_cases(
+                single_option_cases('-m_act',
+                    ModelArg('person-detection-action-recognition-0005'),
+                    ModelArg('person-detection-action-recognition-0006'),
+                    ModelArg('person-detection-action-recognition-teacher-0002')),
+                single_option_cases('-m_lm', None, ModelArg('landmarks-regression-retail-0009')),
+                single_option_cases('-m_reid', None, ModelArg('face-reidentification-retail-0095'))),
+            TestCase(options={'-m_act': ModelArg('person-detection-raisinghand-recognition-0001'), '-a_top': '5'}),
+        ],
     )),
 
     NativeDemo(name='super_resolution_demo', test_cases=combine_cases(


### PR DESCRIPTION
This demo assumes by default that the action recognition model recognizes 3 actions, but person-detection-raisinghand-recognition-0001 only recognizes 2. This causes the demo to go out of bounds when retrieving the action probabilities.

We could fix it by adding a `-student_ac` option to the test case, but a better fix is to use the top-k mode (via the `-a_top` option) for this model, since:

a) in top-k mode the demo already defaults to 2 actions; and
b) this gives us better code coverage.

In top-k mode the other 3 models aren't used, so don't add cases with them.