### PR TITLE
AC: moving on IECore API

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/config/config_validator.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_validator.py
@@ -171,8 +171,13 @@ class StringField(BaseField):
         super().__init__(**kwargs)
         self.choices = choices if case_sensitive or not choices else list(map(str.lower, choices))
         self.allow_own_choice = allow_own_choice
-        self._regex = re.compile(regex, flags=re.IGNORECASE if not case_sensitive else 0) if regex else None
         self.case_sensitive = case_sensitive
+        self.set_regex(regex)
+
+    def set_regex(self, regex):
+        if regex is None:
+            self._regex = regex
+        self._regex = re.compile(regex, flags=re.IGNORECASE if not self.case_sensitive else 0) if regex else None
 
     def validate(self, entry, field_uri=None):
         super().validate(entry, field_uri)

--- a/tools/accuracy_checker/accuracy_checker/config/config_validator.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_validator.py
@@ -60,6 +60,7 @@ class _ExtraArgumentBehaviour(enum.Enum):
 def _is_dict_like(entry):
     return hasattr(entry, '__iter__') and hasattr(entry, '__getitem__')
 
+
 class ConfigValidator(BaseValidator):
     WARN_ON_EXTRA_ARGUMENT = _ExtraArgumentBehaviour.WARN
     ERROR_ON_EXTRA_ARGUMENT = _ExtraArgumentBehaviour.ERROR

--- a/tools/accuracy_checker/accuracy_checker/evaluators/model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/model_evaluator.py
@@ -275,7 +275,7 @@ class ModelEvaluator(BaseEvaluator):
 
         return free_irs, queued_irs
 
-    def compute_metrics(self, print_results=True, output_callback=None, ignore_results_formatting=False):
+    def compute_metrics(self, print_results=True, ignore_results_formatting=False):
         if self._metrics_results:
             del self._metrics_results
             self._metrics_results = []
@@ -284,16 +284,16 @@ class ModelEvaluator(BaseEvaluator):
                 self._annotations, self._predictions):
             self._metrics_results.append(evaluated_metric)
             if print_results:
-                result_presenter.write_result(evaluated_metric, output_callback, ignore_results_formatting)
+                result_presenter.write_result(evaluated_metric, ignore_results_formatting)
         return self._metrics_results
 
-    def print_metrics_results(self, output_callback=None, ignore_results_formatting=False):
+    def print_metrics_results(self, ignore_results_formatting=False):
         if not self._metrics_results:
-            self.compute_metrics(True, output_callback, ignore_results_formatting)
+            self.compute_metrics(True, ignore_results_formatting)
             return
         result_presenters = self.metric_executor.get_metric_presenters()
         for presenter, metric_result in zip(result_presenters, self._metrics_results):
-            presenter.write_results(metric_result, output_callback, ignore_results_formatting)
+            presenter.write_results(metric_result, ignore_results_formatting)
 
     def load(self, stored_predictions, progress_reporter):
         self._annotations = self.dataset.annotation

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -330,10 +330,12 @@ class DLSDKLauncher(Launcher):
             self.network.layers[layer].affinity = device
 
     def _is_fpga(self):
-        return 'FPGA' in self._devices_list()
+        device_list = map(lambda device: device.split('.')[0], self._devices_list())
+        return 'FPGA' in device_list
 
     def _is_vpu(self):
-        return contains_any(self._devices_list(), VPU_PLUGINS)
+        device_list = map(lambda device: device.split('.')[0], self._devices_list())
+        return contains_any(device_list, VPU_PLUGINS)
 
     def _prepare_bitstream_firmware(self, config):
         if not self._is_fpga():

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -264,6 +264,10 @@ class DLSDKLauncher(Launcher):
     def output_blob(self):
         return next(iter(self.original_outputs))
 
+    @property
+    def device(self):
+        return self._device
+
     def predict(self, inputs, metadata=None, **kwargs):
         """
         Args:

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -515,35 +515,13 @@ class DLSDKLauncher(Launcher):
 
         return data.reshape(input_shape)
 
-<<<<<<< 4eb8c1df2479e2dcc35a7e76ec2c7ba8086dfa10
-    def create_ie_plugin(self, log=True):
-        def set_nireq():
-            num_requests = self.config.get('num_requests')
-            if num_requests is not None:
-                num_requests = get_or_parse_value(num_requests, casting_type=int)
-                if len(num_requests) != 1:
-                    raise ConfigError('Several values for _num_requests specified')
-                self._num_requests = num_requests[0]
-                if self._num_requests != 1 and not self.async_mode:
-                    warning('{} infer requests in sync mode is not supported. Only 1 infer request will be used.')
-                    self._num_requests = 1
-            elif not self.async_mode:
-                self._num_requests = 1
-            else:
-                self._num_requests = self.auto_num_requests()
-
-        if hasattr(self, 'plugin'):
-            del self.plugin
-=======
     def _prepare_ie(self, log=True):
->>>>>>> AC: moving on IECore API
         if log:
             print_info('IE version: {}'.format(ie.get_version()))
         if self._is_multi():
             self._prepare_multi_device(log)
         else:
             self.async_mode = self.get_value_from_config('async_mode')
-            set_nireq()
 
             if log:
                 self._log_versions()

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -228,7 +228,8 @@ class DLSDKLauncher(Launcher):
             available_devices=self.ie_core.available_devices
         )
         dlsdk_launcher_config.validate(self.config)
-        self._device = self.config['device'].upper()
+        device = self.config['device'].split('.')
+        self._device = '.'.join((device[0].upper(), device[1])) if len(device) > 1 else device[0].upper()
         self._prepare_bitstream_firmware(self.config)
         self._prepare_ie()
         if not delayed_model_loading:

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -306,7 +306,7 @@ class DLSDKLauncher(Launcher):
         return [platform_.upper().strip() for platform_ in device.split(',')]
 
     def _set_affinity(self, affinity_map_path):
-        automatic_affinity = ie_core.query_network(self.network, self._device)
+        automatic_affinity = self.ie_core.query_network(self.network, self._device)
         layers = self.network.layers
         for layer, device in read_yaml(affinity_map_path).items():
             if layer not in layers:
@@ -615,7 +615,13 @@ class DLSDKLauncher(Launcher):
                 print_info('    {} - {}'.format(device, nreq))
 
     def _log_versions(self):
-        pass
+        versions = ie_core.get_versions(self._device)
+        print_info("Loaded {} plugin version:".format(self._device))
+        for device_name, device_version in versions.items():
+            print_info("    {device_name} - {descr}: {maj}.{min}.{num}".format(
+                device_name=device_name, descr=device_version.description, maj=device_version.major,
+                min=device_version.minor, num=device_version.build_number
+            ))
 
     def _create_network(self, input_shapes=None):
         self.network = ie.IENetwork(model=str(self._model), weights=str(self._weights))
@@ -699,5 +705,7 @@ class DLSDKLauncher(Launcher):
             del self.network
         if 'exec_network' in self.__dict__:
             del self.exec_network
+        if 'ie_core' in self.__dict__:
+            del self.ie_core
         if self._set_variable:
             del os.environ[FPGA_COMPILER_MODE_VAR]

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -39,7 +39,6 @@ from .launcher import Launcher, LauncherConfigValidator
 from .model_conversion import convert_model, FrameworkParameters
 from ..logging import print_info
 
-ie_core = ie.IECore()
 HETERO_KEYWORD = 'HETERO:'
 MULTI_DEVICE_KEYWORD = 'MULTI:'
 FPGA_COMPILER_MODE_VAR = 'CL_CONTEXT_COMPILER_MODE_INTELFPGA'
@@ -222,7 +221,7 @@ class DLSDKLauncher(Launcher):
         self._device = self.config['device'].upper()
         self._set_variable = False
         self._prepare_bitstream_firmware(self.config)
-        self.ie_core = ie_core
+        self.ie_core = ie.IECore()
         self._prepare_ie()
         self._delayed_model_loading = delayed_model_loading
 
@@ -615,7 +614,7 @@ class DLSDKLauncher(Launcher):
                 print_info('    {} - {}'.format(device, nreq))
 
     def _log_versions(self):
-        versions = ie_core.get_versions(self._device)
+        versions = self.ie_core.get_versions(self._device)
         print_info("Loaded {} plugin version:".format(self._device))
         for device_name, device_version in versions.items():
             print_info("    {device_name} - {descr}: {maj}.{min}.{num}".format(

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -166,7 +166,8 @@ class DLSDKLauncher(Launcher):
         parameters.update({
             'model': PathField(description="Path to model."),
             'weights': PathField(description="Path to model."),
-            'device': StringField(regex=SUPPORTED_DEVICE_REGEX, description="Device name."),
+            'ie_config': PathField(description='Path to Inference Engine config'),
+            'device': StringField(description="Device name."),
             'caffe_model': PathField(optional=True, description="Path to Caffe model file."),
             'caffe_weights': PathField(optional=True, description="Path to Caffe weights file."),
             'mxnet_weights': PathField(optional=True, description="Path to MxNet weights file."),

--- a/tools/accuracy_checker/accuracy_checker/launcher/launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/launcher.py
@@ -180,6 +180,7 @@ def create_launcher(launcher_config, delayed_model_loading=False):
     """
     Args:
         launcher_config: launcher configuration file entry.
+        delayed_model_loading: allows postpone model loading to the launcher
     Returns:
         framework-specific launcher object.
     """

--- a/tools/accuracy_checker/accuracy_checker/presenters.py
+++ b/tools/accuracy_checker/accuracy_checker/presenters.py
@@ -31,14 +31,14 @@ EvaluationResult = namedtuple(
 class BasePresenter(ClassProvider):
     __provider_type__ = "presenter"
 
-    def write_result(self, evaluation_result, output_callback=None, ignore_results_formatting=False):
+    def write_result(self, evaluation_result, ignore_results_formatting=False):
         raise NotImplementedError
 
 
 class ScalarPrintPresenter(BasePresenter):
     __provider__ = "print_scalar"
 
-    def write_result(self, evaluation_result: EvaluationResult, output_callback=None, ignore_results_formatting=False):
+    def write_result(self, evaluation_result: EvaluationResult, ignore_results_formatting=False):
         value, reference, name, _, threshold, meta = evaluation_result
         value = np.mean(value)
         postfix, scale, result_format = get_result_format_parameters(meta, ignore_results_formatting)
@@ -54,7 +54,7 @@ class ScalarPrintPresenter(BasePresenter):
 class VectorPrintPresenter(BasePresenter):
     __provider__ = "print_vector"
 
-    def write_result(self, evaluation_result: EvaluationResult, output_callback=None, ignore_results_formatting=False):
+    def write_result(self, evaluation_result: EvaluationResult, ignore_results_formatting=False):
         value, reference, name, _, threshold, meta = evaluation_result
         if threshold:
             threshold = float(threshold)
@@ -120,14 +120,6 @@ def write_scalar_result(
 
 def compare_with_ref(reference, res_value, scale):
     return abs(reference - (res_value * scale))
-
-
-class ReturnValuePresenter(BasePresenter):
-    __provider__ = "return_value"
-
-    def write_result(self, evaluation_result: EvaluationResult, output_callback=None, ignore_results_formatting=False):
-        if output_callback:
-            output_callback(evaluation_result)
 
 
 def get_result_format_parameters(meta, use_default_formatting):

--- a/tools/accuracy_checker/custom_evaluators/sequential_action_recognition_evaluator.py
+++ b/tools/accuracy_checker/custom_evaluators/sequential_action_recognition_evaluator.py
@@ -212,9 +212,7 @@ class EncoderModelDLSDKL(BaseModel):
             model_xml = str(network_info['model'])
             model_bin = str(network_info['weights'])
         self.network = launcher.create_ie_network(model_xml, model_bin)
-        if not hasattr(launcher, 'plugin'):
-            launcher.create_ie_plugin()
-        self.exec_network = launcher.plugin.load(self.network)
+        self.exec_network = launcher.ie_core.load_network(self.network, launcher.device)
         self.input_blob = next(iter(self.network.inputs))
         self.output_blob = next(iter(self.network.outputs))
 
@@ -242,11 +240,7 @@ class DecoderModelDLSDKL(BaseModel):
             model_bin = str(network_info['weights'])
 
         self.network = launcher.create_ie_network(model_xml, model_bin)
-        if hasattr(launcher, 'plugin'):
-            self.exec_network = launcher.plugin.load(self.network)
-        else:
-            launcher.load_network(self.network)
-            self.exec_network = launcher.exec_network
+        self.exec_network = launcher.ie_core.load_network(self.network, launcher.device)
         self.input_blob = next(iter(self.network.inputs))
         self.output_blob = next(iter(self.network.outputs))
         self.adapter = create_adapter('classification')

--- a/tools/accuracy_checker/tests/test_dlsdk_launcher.py
+++ b/tools/accuracy_checker/tests/test_dlsdk_launcher.py
@@ -1134,6 +1134,7 @@ class TestDLSDKLauncherConfig:
 
     def test_hetero_endswith_comma(self):
         with pytest.raises(ConfigError):
+            self.config.create_device_regex(['CPU', 'FPGA'])
             self.config.validate(update_dict(self.launcher, device='HETERO:CPU,FPGA,'))
 
     def test_multi_device_correct(self):
@@ -1143,20 +1144,25 @@ class TestDLSDKLauncherConfig:
 
     def test_multi_device_endswith_comma(self):
         with pytest.raises(ConfigError):
+            self.config.create_device_regex(['CPU', 'FPGA'])
             self.config.validate(update_dict(self.launcher, device='MULTI:CPU,FPGA,'))
 
     def test_multi_device_empty_brackets(self):
         with pytest.raises(ConfigError):
+            self.config.create_device_regex(['CPU', 'FPGA'])
             self.config.validate(update_dict(self.launcher, device='MULTI:CPU,FPGA()'))
 
     def test_multi_device_n_requests_without_brackets(self):
         with pytest.raises(ConfigError):
+            self.config.create_device_regex(['CPU', 'FPGA'])
             self.config.validate(update_dict(self.launcher, device='MULTI:CPU(42),FPGA666'))
 
         with pytest.raises(ConfigError):
+            self.config.create_device_regex(['CPU', 'FPGA'])
             self.config.validate(update_dict(self.launcher, device='MULTI:CPU42,FPGA(666)'))
 
         with pytest.raises(ConfigError):
+            self.config.create_device_regex(['CPU', 'FPGA'])
             self.config.validate(update_dict(self.launcher, device='MULTI:CPU42,FPGA666'))
 
     def test_multi_device_missed_bracket(self):

--- a/tools/accuracy_checker/tests/test_dlsdk_launcher.py
+++ b/tools/accuracy_checker/tests/test_dlsdk_launcher.py
@@ -214,6 +214,7 @@ class TestDLSDKLauncherMultiDevice:
 class TestDLSDKLauncherBitstreamProgramming:
     def test_program_bitsream_when_device_is_fpga(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
             'framework': 'dlsdk',
             'weights': 'custom_weights',
@@ -230,6 +231,7 @@ class TestDLSDKLauncherBitstreamProgramming:
 
     def test_program_bitsream_when_fpga_in_hetero_device(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
             'framework': 'dlsdk',
             'weights': 'custom_weights',
@@ -246,6 +248,7 @@ class TestDLSDKLauncherBitstreamProgramming:
 
     def test_does_not_program_bitsream_when_device_is_not_fpga(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
             'framework': 'dlsdk',
             'weights': 'custom_weights',
@@ -261,7 +264,7 @@ class TestDLSDKLauncherBitstreamProgramming:
 
     def test_does_not_program_bitsream_when_hetero_without_fpga(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
-
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
             'framework': 'dlsdk',
             'weights': 'custom_weights',
@@ -278,7 +281,7 @@ class TestDLSDKLauncherBitstreamProgramming:
     def test_does_not_program_bitstream_if_compiler_mode_3_in_env_when_fpga_in_hetero_device(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
         mocker.patch('os.environ.get', return_value='3')
-
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
             'framework': 'dlsdk',
             'weights': 'custom_weights',
@@ -296,6 +299,7 @@ class TestDLSDKLauncherBitstreamProgramming:
     def test_does_not_program_bitstream_if_compiler_mode_3_in_env_when_fpga_in_device(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
         mocker.patch('os.environ.get', return_value='3')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
 
         config = {
             'framework': 'dlsdk',
@@ -313,6 +317,7 @@ class TestDLSDKLauncherBitstreamProgramming:
 
     def test_sets_dla_aocx_when_device_is_fpga(self, mocker):
         mocker.patch('os.environ')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
 
         config = {
             'framework': 'dlsdk',
@@ -329,6 +334,7 @@ class TestDLSDKLauncherBitstreamProgramming:
 
     def test_sets_dla_aocx_when_fpga_in_hetero_device(self, mocker):
         mocker.patch('os.environ')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
 
         config = {
             'framework': 'dlsdk',
@@ -344,6 +350,7 @@ class TestDLSDKLauncherBitstreamProgramming:
 
     def test_does_not_set_dla_aocx_when_device_is_not_fpga(self, mocker):
         mocker.patch('os.environ')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
 
         config = {
             'framework': 'dlsdk',
@@ -360,6 +367,7 @@ class TestDLSDKLauncherBitstreamProgramming:
 
     def test_does_not_set_dla_aocx_when_hetero_without_fpga(self, mocker):
         mocker.patch('os.environ')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
 
         config = {
             'framework': 'dlsdk',
@@ -377,6 +385,7 @@ class TestDLSDKLauncherBitstreamProgramming:
     def test_does_not_set_dla_aocx_if_compiler_mode_3_in_env_when_fpga_in_hetero_device(self, mocker):
         mocker.patch('os.environ')
         mocker.patch('os.environ.get', return_value='3')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
 
         config = {
             'framework': 'dlsdk',
@@ -394,6 +403,7 @@ class TestDLSDKLauncherBitstreamProgramming:
     def test_does_not_set_dla_aocx_if_compiler_mode_3_in_env_when_fpga_in_device(self, mocker):
         mocker.patch('os.environ')
         mocker.patch('os.environ.get', return_value='3')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
 
         config = {
             'framework': 'dlsdk',

--- a/tools/accuracy_checker/tests/test_dlsdk_launcher.py
+++ b/tools/accuracy_checker/tests/test_dlsdk_launcher.py
@@ -212,7 +212,7 @@ class TestDLSDKLauncherMultiDevice:
 
 @pytest.mark.usefixtures('mock_path_exists', 'mock_inference_engine', 'mock_inputs')
 class TestDLSDKLauncherBitstreamProgramming:
-    def test_program_bitsream_when_device_is_fpga(self, mocker):
+    def test_program_bitstream_when_device_is_fpga(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
         mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
@@ -229,7 +229,25 @@ class TestDLSDKLauncherBitstreamProgramming:
         subprocess_mock.assert_called_once_with(['aocl', 'program', 'acl0', 'custom_bitstream'], check=True)
         launcher.release()
 
-    def test_program_bitsream_when_fpga_in_hetero_device(self, mocker):
+    def test_program_bitstream_when_device_is_fpga_and_multiple_fpga_available(self, mocker):
+        subprocess_mock = mocker.patch('subprocess.run')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
+        mocker.patch('openvino.inference_engine.IECore.available_devices', new_callable=PropertyMock(return_value=['FPGA.1', 'FPGA.2']))
+        config = {
+            'framework': 'dlsdk',
+            'weights': 'custom_weights',
+            'model': 'custom_model',
+            'device': 'fpga.1',
+            'bitstream': Path('custom_bitstream'),
+            'adapter': 'classification',
+            '_models_prefix': 'prefix',
+            '_aocl': Path('aocl')
+        }
+        launcher = create_launcher(config, delayed_model_loading=True)
+        subprocess_mock.assert_called_once_with(['aocl', 'program', 'acl0', 'custom_bitstream'], check=True)
+        launcher.release()
+
+    def test_program_bitstream_when_fpga_in_hetero_device(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
         mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
@@ -246,7 +264,25 @@ class TestDLSDKLauncherBitstreamProgramming:
         subprocess_mock.assert_called_once_with(['aocl', 'program', 'acl0', 'custom_bitstream'], check=True)
         launcher.release()
 
-    def test_does_not_program_bitsream_when_device_is_not_fpga(self, mocker):
+    def test_program_bitstream_when_fpga_in_hetero_device_and_multiple_fpga_available(self, mocker):
+        subprocess_mock = mocker.patch('subprocess.run')
+        mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
+        mocker.patch('openvino.inference_engine.IECore.available_devices', new_callable=PropertyMock(return_value=['CPU', 'FPGA.1', 'FPGA.2']))
+        config = {
+            'framework': 'dlsdk',
+            'weights': 'custom_weights',
+            'model': 'custom_model',
+            'device': 'hetero:fpga.2,cpu',
+            'bitstream': Path('custom_bitstream'),
+            'adapter': 'classification',
+            '_models_prefix': 'prefix',
+            '_aocl': Path('aocl')
+        }
+        launcher = create_launcher(config, delayed_model_loading=True)
+        subprocess_mock.assert_called_once_with(['aocl', 'program', 'acl0', 'custom_bitstream'], check=True)
+        launcher.release()
+
+    def test_does_not_program_bitstream_when_device_is_not_fpga(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
         mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {
@@ -262,7 +298,7 @@ class TestDLSDKLauncherBitstreamProgramming:
         create_launcher(config, delayed_model_loading=True)
         subprocess_mock.assert_not_called()
 
-    def test_does_not_program_bitsream_when_hetero_without_fpga(self, mocker):
+    def test_does_not_program_bitstream_when_hetero_without_fpga(self, mocker):
         subprocess_mock = mocker.patch('subprocess.run')
         mocker.patch('accuracy_checker.launcher.dlsdk_launcher.DLSDKLauncher._log_versions')
         config = {


### PR DESCRIPTION
moving from deprecated IEPlugin API to IECore API
clean up launcher tests (removed part for working with adapter because adapter is independent entry now)

TO DO:
- [x]  device versions logging
- [x] clean up unused API
- [x] support ie config
- [x] multiple devices names 