### PR TITLE
tools/downloader/converter.py: serialize output of concurrent jobs

### DIFF
--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -18,6 +18,7 @@ import argparse
 import concurrent.futures
 import os
 import platform
+import queue
 import re
 import shlex
 import string
@@ -28,6 +29,53 @@ import threading
 from pathlib import Path
 
 import common
+
+class JobContext:
+    def printf(self, format, *args, flush=False):
+        raise NotImplementedError
+
+    def subprocess(self, args):
+        raise NotImplementedError
+
+
+class DirectOutputContext(JobContext):
+    def printf(self, format, *args, flush=False):
+        print(format.format(*args), flush=flush)
+
+    def subprocess(self, args):
+        return subprocess.run(args).returncode == 0
+
+
+class QueuedOutputContext(JobContext):
+    def __init__(self, output_queue):
+        self._output_queue = output_queue
+
+    def printf(self, format, *args, flush=False):
+        self._output_queue.put(format.format(*args) + '\n')
+
+    def subprocess(self, args):
+        with subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                universal_newlines=True) as p:
+            for line in p.stdout:
+                self._output_queue.put(line)
+            return p.wait() == 0
+
+
+class JobWithQueuedOutput():
+    def __init__(self, output_queue, future):
+        self._output_queue = output_queue
+        self._future = future
+        self._future.add_done_callback(lambda future: self._output_queue.put(None))
+
+    def complete(self):
+        for fragment in iter(self._output_queue.get, None):
+            print(fragment, end='', flush=True) # for simplicity, flush every fragment
+
+        return self._future.result()
+
+    def cancel(self):
+        self._future.cancel()
+
 
 def quote_windows(arg):
     if not arg: return '""'
@@ -40,35 +88,18 @@ if platform.system() == 'Windows':
 else:
     quote_arg = shlex.quote
 
-def prefixed_printf(prefix, format, *args, **kwargs):
-    if prefix is None:
-        print(format.format(*args), **kwargs)
-    else:
-        print(prefix + ': ' + format.format(*args), **kwargs)
-
-def prefixed_subprocess(prefix, args):
-    if prefix is None:
-        return subprocess.run(args).returncode == 0
-
-    with subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            universal_newlines=True) as p:
-        for line in p.stdout:
-            sys.stdout.write(prefix + ': ' + line)
-        return p.wait() == 0
-
-
-def convert_to_onnx(model, output_dir, args, stdout_prefix):
-    prefixed_printf(stdout_prefix, '========= {}Converting {} to ONNX',
-                    '(DRY RUN) ' if args.dry_run else '', model.name)
+def convert_to_onnx(context, model, output_dir, args):
+    context.printf('========= {}Converting {} to ONNX',
+                   '(DRY RUN) ' if args.dry_run else '', model.name)
 
     conversion_to_onnx_args = [string.Template(arg).substitute(conv_dir=output_dir / model.subdirectory,
                                                                dl_dir=args.download_dir / model.subdirectory)
                                for arg in model.conversion_to_onnx_args]
     cmd = [str(args.python), str(Path(__file__).absolute().parent / model.converter_to_onnx), *conversion_to_onnx_args]
 
-    prefixed_printf(stdout_prefix, 'Conversion to ONNX command: {}', ' '.join(map(quote_arg, cmd)))
+    context.printf('Conversion to ONNX command: {}', ' '.join(map(quote_arg, cmd)))
 
-    return True if args.dry_run else prefixed_subprocess(stdout_prefix, cmd)
+    return True if args.dry_run else context.subprocess(cmd)
 
 
 def num_jobs_arg(value_str):
@@ -133,26 +164,22 @@ def main():
 
     output_dir = args.download_dir if args.output_dir is None else args.output_dir
 
-    def convert(model, do_prefix_stdout=True):
-        stdout_prefix = None
-        if do_prefix_stdout:
-            stdout_prefix = threading.current_thread().name
-
+    def convert(context, model):
         if model.mo_args is None:
-            prefixed_printf(stdout_prefix, '========= Skipping {} (no conversions defined)', model.name)
-            prefixed_printf(stdout_prefix, '')
+            context.printf('========= Skipping {} (no conversions defined)', model.name)
+            context.printf('')
             return True
 
         model_precisions = requested_precisions & model.precisions
         if not model_precisions:
-            prefixed_printf(stdout_prefix, '========= Skipping {} (all conversions skipped)', model.name)
-            prefixed_printf(stdout_prefix, '')
+            context.printf('========= Skipping {} (all conversions skipped)', model.name)
+            context.printf('')
             return True
 
         model_format = model.framework
 
         if model.conversion_to_onnx_args:
-            if not convert_to_onnx(model, output_dir, args, stdout_prefix):
+            if not convert_to_onnx(context, model, output_dir, args):
                 return False
             model_format = 'onnx'
 
@@ -170,26 +197,39 @@ def main():
                 '--model_name={}'.format(model.name),
                 *expanded_mo_args, *extra_mo_args]
 
-            prefixed_printf(stdout_prefix, '========= {}Converting {} to IR ({})',
+            context.printf('========= {}Converting {} to IR ({})',
                 '(DRY RUN) ' if args.dry_run else '', model.name, model_precision)
 
-            prefixed_printf(stdout_prefix, 'Conversion command: {}', ' '.join(map(quote_arg, mo_cmd)))
+            context.printf('Conversion command: {}', ' '.join(map(quote_arg, mo_cmd)))
 
             if not args.dry_run:
-                prefixed_printf(stdout_prefix, '', flush=True)
+                context.printf('', flush=True)
 
-                if not prefixed_subprocess(stdout_prefix, mo_cmd):
+                if not context.subprocess(mo_cmd):
                     return False
 
-            prefixed_printf(stdout_prefix, '')
+            context.printf('')
 
         return True
 
     if args.jobs == 1 or args.dry_run:
-        results = [convert(model, do_prefix_stdout=False) for model in models]
+        context = DirectOutputContext()
+        results = [convert(context, model) for model in models]
     else:
         with concurrent.futures.ThreadPoolExecutor(args.jobs) as executor:
-            results = list(executor.map(convert, models))
+            def start(model):
+                output_queue = queue.Queue()
+                return JobWithQueuedOutput(
+                    output_queue,
+                    executor.submit(convert, QueuedOutputContext(output_queue), model))
+
+            jobs = list(map(start, models))
+
+            try:
+                results = [job.complete() for job in jobs]
+            except:
+                for job in jobs: job.cancel()
+                raise
 
     failed_models = [model.name for model, successful in zip(models, results) if not successful]
 


### PR DESCRIPTION
Currently, when we are in multithreaded mode, we prefix each output line with the name of the thread to disambiguate it. This makes the output unambiguous, but also very ugly and difficult to read.

So remove that logic, and instead make it so that the output of the converter in multithreaded mode is exactly like it is in single-threaded mode. Do it by buffering each job's output in an queue, and emptying each such queue into stdout in turn.

The downside of this approach is that we have to keep in memory the output of all jobs whose turn hasn't come yet, and that output can potentially be unbounded. However, it shouldn't be a problem in practice, since the amount of output produced by the conversion tools we run (and the converter itself) is fairly small. It's probably also less efficient due to the inter-thread communication, however, I failed to find any actual performance degradation in my experiments.

You might wonder if there's any point in keeping the single-threaded mode if the multi-threaded mode now produces the exact same output. The reason I'm keeping it is that the single-threaded mode still works a bit better due to not redirecting the subprocesses' stdout and stderr:

* the subprocess's stderr output will go to the converter's stderr, while in multithreaded mode it will go to the converter's stdout;

* if the converter's stdout is a terminal, so will be the subprocess's stdout, and so the subprocess will be able to use terminal features, like color output (although this is only hypothetical for now, since none of the tools we run have any terminal-specific logic).