### PR TITLE
demos/tests/cases.py: prepare for the disappearance of libcpu_extension.so

### DIFF
--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -52,8 +52,10 @@ class PythonDemo:
         return source_dir / 'python_demos' / self._name / 'models.lst'
 
     def fixed_args(self, source_dir, build_dir):
+        cpu_extension_path = build_dir / 'lib/libcpu_extension.so'
+
         return [sys.executable, str(source_dir / 'python_demos' / self._name / (self._name + '.py')),
-            '-l', str(build_dir / 'lib/libcpu_extension.so')]
+            *(['-l', str(cpu_extension_path)] if cpu_extension_path.exists() else [])]
 
 def join_cases(*args):
     options = {}


### PR DESCRIPTION
`libcpu_extension.so` is going to be merged into the CPU plugin in IE 2019 R4, so don't add the `-l` option if it isn't present. This will allow the test script to work with both R3 and R4. After R4 is released, we can remove the passing of the option entirely.