### PR TITLE
demos: replace vectors with arrays where possible

### DIFF
--- a/demos/common/samples/common.hpp
+++ b/demos/common/samples/common.hpp
@@ -48,6 +48,11 @@ class ConsoleErrorListener : public InferenceEngine::IErrorListener {
     }
 };
 
+template <typename T, std::size_t N>
+constexpr std::size_t arraySize(const T (&)[N]) noexcept {
+    return N;
+}
+
 /**
  * @brief Trims from both ends (in place)
  * @param s - string to trim
@@ -199,6 +204,31 @@ public:
     }
 };
 
+// Known colors for training classes from the Cityscapes dataset
+static UNUSED const Color CITYSCAPES_COLORS[] = {
+    { 128, 64,  128 },
+    { 232, 35,  244 },
+    { 70,  70,  70 },
+    { 156, 102, 102 },
+    { 153, 153, 190 },
+    { 153, 153, 153 },
+    { 30,  170, 250 },
+    { 0,   220, 220 },
+    { 35,  142, 107 },
+    { 152, 251, 152 },
+    { 180, 130, 70 },
+    { 60,  20,  220 },
+    { 0,   0,   255 },
+    { 142, 0,   0 },
+    { 70,  0,   0 },
+    { 100, 60,  0 },
+    { 90,  0,   0 },
+    { 230, 0,   0 },
+    { 32,  11,  119 },
+    { 0,   74,  111 },
+    { 81,  0,   81 }
+};
+
 // TODO : keep only one version of writeOutputBMP
 
 /**
@@ -210,30 +240,7 @@ public:
  */
 static UNUSED void writeOutputBmp(std::vector<std::vector<size_t>> data, size_t classesNum, std::ostream &outFile) {
     unsigned int seed = (unsigned int) time(NULL);
-    // Known colors for training classes from Cityscape dataset
-    static std::vector<Color> colors = {
-        {128, 64,  128},
-        {232, 35,  244},
-        {70,  70,  70},
-        {156, 102, 102},
-        {153, 153, 190},
-        {153, 153, 153},
-        {30,  170, 250},
-        {0,   220, 220},
-        {35,  142, 107},
-        {152, 251, 152},
-        {180, 130, 70},
-        {60,  20,  220},
-        {0,   0,   255},
-        {142, 0,   0},
-        {70,  0,   0},
-        {100, 60,  0},
-        {90,  0,   0},
-        {230, 0,   0},
-        {32,  11,  119},
-        {0,   74,  111},
-        {81,  0,   81}
-    };
+    static std::vector<Color> colors(std::begin(CITYSCAPES_COLORS), std::end(CITYSCAPES_COLORS));
 
     while (classesNum > colors.size()) {
         static std::mt19937 rng(seed);
@@ -408,29 +415,6 @@ static UNUSED bool writeOutputBmp(std::string name, unsigned char *data, size_t 
 * @param thickness - thickness of a line (in pixels) to be used for bounding boxes
 */
 static UNUSED void addRectangles(unsigned char *data, size_t height, size_t width, std::vector<int> rectangles, std::vector<int> classes, int thickness = 1) {
-    std::vector<Color> colors = {  // colors to be used for bounding boxes
-        { 128, 64,  128 },
-        { 232, 35,  244 },
-        { 70,  70,  70 },
-        { 156, 102, 102 },
-        { 153, 153, 190 },
-        { 153, 153, 153 },
-        { 30,  170, 250 },
-        { 0,   220, 220 },
-        { 35,  142, 107 },
-        { 152, 251, 152 },
-        { 180, 130, 70 },
-        { 60,  20,  220 },
-        { 0,   0,   255 },
-        { 142, 0,   0 },
-        { 70,  0,   0 },
-        { 100, 60,  0 },
-        { 90,  0,   0 },
-        { 230, 0,   0 },
-        { 32,  11,  119 },
-        { 0,   74,  111 },
-        { 81,  0,   81 }
-    };
     if (rectangles.size() % 4 != 0 || rectangles.size() / 4 != classes.size()) {
         return;
     }
@@ -441,7 +425,7 @@ static UNUSED void addRectangles(unsigned char *data, size_t height, size_t widt
         int w = rectangles.at(i * 4 + 2);
         int h = rectangles.at(i * 4 + 3);
 
-        int cls = classes.at(i) % colors.size();  // color of a bounding box line
+        Color color = CITYSCAPES_COLORS[classes.at(i) % arraySize(CITYSCAPES_COLORS)]; // color of a bounding box line
 
         if (x < 0) x = 0;
         if (y < 0) y = 0;
@@ -462,12 +446,12 @@ static UNUSED void addRectangles(unsigned char *data, size_t height, size_t widt
             shift_first = (y + t) * width * 3;
             shift_second = (y + h - t) * width * 3;
             for (int ii = x; ii < x + w + 1; ii++) {
-                data[shift_first + ii * 3] = colors.at(cls).red();
-                data[shift_first + ii * 3 + 1] = colors.at(cls).green();
-                data[shift_first + ii * 3 + 2] = colors.at(cls).blue();
-                data[shift_second + ii * 3] = colors.at(cls).red();
-                data[shift_second + ii * 3 + 1] = colors.at(cls).green();
-                data[shift_second + ii * 3 + 2] = colors.at(cls).blue();
+                data[shift_first + ii * 3] = color.red();
+                data[shift_first + ii * 3 + 1] = color.green();
+                data[shift_first + ii * 3 + 2] = color.blue();
+                data[shift_second + ii * 3] = color.red();
+                data[shift_second + ii * 3 + 1] = color.green();
+                data[shift_second + ii * 3 + 2] = color.blue();
             }
         }
 
@@ -475,12 +459,12 @@ static UNUSED void addRectangles(unsigned char *data, size_t height, size_t widt
             shift_first = (x + t) * 3;
             shift_second = (x + w - t) * 3;
             for (int ii = y; ii < y + h + 1; ii++) {
-                data[shift_first + ii * width * 3] = colors.at(cls).red();
-                data[shift_first + ii * width * 3 + 1] = colors.at(cls).green();
-                data[shift_first + ii * width * 3 + 2] = colors.at(cls).blue();
-                data[shift_second + ii * width * 3] = colors.at(cls).red();
-                data[shift_second + ii * width * 3 + 1] = colors.at(cls).green();
-                data[shift_second + ii * width * 3 + 2] = colors.at(cls).blue();
+                data[shift_first + ii * width * 3] = color.red();
+                data[shift_first + ii * width * 3 + 1] = color.green();
+                data[shift_first + ii * width * 3 + 2] = color.blue();
+                data[shift_second + ii * width * 3] = color.red();
+                data[shift_second + ii * width * 3 + 1] = color.green();
+                data[shift_second + ii * width * 3 + 2] = color.blue();
             }
         }
     }

--- a/demos/crossroad_camera_demo/main.cpp
+++ b/demos/crossroad_camera_demo/main.cpp
@@ -294,7 +294,7 @@ struct PersonAttribsDetection : BaseDetection {
     }
 
     AttributesAndColorPoints GetPersonAttributes() {
-        static const std::vector<std::string> attributesVec = {
+        static const char *const attributeStrings[] = {
                 "is male", "has_bag", "has_backpack" , "has hat", "has longsleeves", "has longpants", "has longhair", "has coat_jacket"
         };
 
@@ -305,10 +305,10 @@ struct PersonAttribsDetection : BaseDetection {
         size_t numOfTCPointChannels = topColorPointBlob->getTensorDesc().getDims().at(1);
         size_t numOfBCPointChannels = bottomColorPointBlob->getTensorDesc().getDims().at(1);
 
-        if (numOfAttrChannels != attributesVec.size()) {
+        if (numOfAttrChannels != arraySize(attributeStrings)) {
             throw std::logic_error("Output size (" + std::to_string(numOfAttrChannels) + ") of the "
-                                   "Person Attributes Recognition network is not equal to used person "
-                                   "attributes vector size (" + std::to_string(attributesVec.size()) + ")");
+                                   "Person Attributes Recognition network is not equal to expected "
+                                   "number of attributes (" + std::to_string(arraySize(attributeStrings)) + ")");
         }
         if (numOfTCPointChannels != 2) {
             throw std::logic_error("Output size (" + std::to_string(numOfTCPointChannels) + ") of the "
@@ -331,8 +331,8 @@ struct PersonAttribsDetection : BaseDetection {
         returnValue.bottom_color_point.x = outputBCPointValues[0];
         returnValue.bottom_color_point.y = outputBCPointValues[1];
 
-        for (size_t i = 0; i < attributesVec.size(); i++) {
-            returnValue.attributes_strings.push_back(attributesVec[i]);
+        for (size_t i = 0; i < arraySize(attributeStrings); i++) {
+            returnValue.attributes_strings.push_back(attributeStrings[i]);
             returnValue.attributes_indicators.push_back(outputAttrValues[i] > 0.5);
         }
 

--- a/demos/gaze_estimation_demo/main.cpp
+++ b/demos/gaze_estimation_demo/main.cpp
@@ -140,8 +140,8 @@ int main(int argc, char *argv[]) {
         LandmarksEstimator landmarksEstimator(ie, FLAGS_m_lm, FLAGS_d_lm);
         GazeEstimator gazeEstimator(ie, FLAGS_m, FLAGS_d);
 
-        // Put pointers to all estimators in a vector so that they could be processed uniformly in a loop
-        std::vector<BaseEstimator*> estimators = {&headPoseEstimator, &landmarksEstimator, &gazeEstimator};
+        // Put pointers to all estimators in an array so that they could be processed uniformly in a loop
+        BaseEstimator* estimators[] = {&headPoseEstimator, &landmarksEstimator, &gazeEstimator};
 
         // Each element of the vector contains inference results on one face
         std::vector<FaceInferenceResults> inferenceResults;

--- a/demos/human_pose_estimation_demo/include/human_pose_estimator.hpp
+++ b/demos/human_pose_estimation_demo/include/human_pose_estimator.hpp
@@ -15,7 +15,7 @@
 namespace human_pose_estimation {
 class HumanPoseEstimator {
 public:
-    static const size_t keypointsNumber;
+    static const size_t keypointsNumber = 18;
 
     HumanPoseEstimator(const std::string& modelPath,
                        const std::string& targetDeviceName,

--- a/demos/human_pose_estimation_demo/src/human_pose_estimator.cpp
+++ b/demos/human_pose_estimation_demo/src/human_pose_estimator.cpp
@@ -14,8 +14,6 @@
 #include "peak.hpp"
 
 namespace human_pose_estimation {
-const size_t HumanPoseEstimator::keypointsNumber = 18;
-
 HumanPoseEstimator::HumanPoseEstimator(const std::string& modelPath,
                                        const std::string& targetDeviceName_,
                                        bool enablePerformanceReport)

--- a/demos/human_pose_estimation_demo/src/peak.cpp
+++ b/demos/human_pose_estimation_demo/src/peak.cpp
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include <samples/common.hpp>
+
 #include "peak.hpp"
 
 namespace human_pose_estimation {
@@ -112,11 +114,11 @@ std::vector<HumanPose> groupPeaksToPoses(const std::vector<std::vector<Peak> >& 
                                          const float foundMidPointsRatioThreshold,
                                          const int minJointsNumber,
                                          const float minSubsetScore) {
-    const std::vector<std::pair<int, int> > limbIdsHeatmap = {
+    static const std::pair<int, int> limbIdsHeatmap[] = {
         {2, 3}, {2, 6}, {3, 4}, {4, 5}, {6, 7}, {7, 8}, {2, 9}, {9, 10}, {10, 11}, {2, 12}, {12, 13}, {13, 14},
         {2, 1}, {1, 15}, {15, 17}, {1, 16}, {16, 18}, {3, 17}, {6, 18}
     };
-    const std::vector<std::pair<int, int> > limbIdsPaf = {
+    static const std::pair<int, int> limbIdsPaf[] = {
         {31, 32}, {39, 40}, {33, 34}, {35, 36}, {41, 42}, {43, 44}, {19, 20}, {21, 22}, {23, 24}, {25, 26},
         {27, 28}, {29, 30}, {47, 48}, {49, 50}, {53, 54}, {51, 52}, {55, 56}, {37, 38}, {45, 46}
     };
@@ -126,7 +128,7 @@ std::vector<HumanPose> groupPeaksToPoses(const std::vector<std::vector<Peak> >& 
          candidates.insert(candidates.end(), peaks.begin(), peaks.end());
     }
     std::vector<HumanPoseByPeaksIndices> subset(0, HumanPoseByPeaksIndices(keypointsNumber));
-    for (size_t k = 0; k < limbIdsPaf.size(); k++) {
+    for (size_t k = 0; k < arraySize(limbIdsPaf); k++) {
         std::vector<TwoJointsConnection> connections;
         const int mapIdxOffset = keypointsNumber + 1;
         std::pair<cv::Mat, cv::Mat> scoreMid = { pafs[limbIdsPaf[k].first - mapIdxOffset],

--- a/demos/human_pose_estimation_demo/src/render_human_pose.cpp
+++ b/demos/human_pose_estimation_demo/src/render_human_pose.cpp
@@ -14,7 +14,7 @@ namespace human_pose_estimation {
 void renderHumanPose(const std::vector<HumanPose>& poses, cv::Mat& image) {
     CV_Assert(image.type() == CV_8UC3);
 
-    const std::vector<cv::Scalar> colors = {
+    static const cv::Scalar colors[HumanPoseEstimator::keypointsNumber] = {
         cv::Scalar(255, 0, 0), cv::Scalar(255, 85, 0), cv::Scalar(255, 170, 0),
         cv::Scalar(255, 255, 0), cv::Scalar(170, 255, 0), cv::Scalar(85, 255, 0),
         cv::Scalar(0, 255, 0), cv::Scalar(0, 255, 85), cv::Scalar(0, 255, 170),
@@ -22,7 +22,7 @@ void renderHumanPose(const std::vector<HumanPose>& poses, cv::Mat& image) {
         cv::Scalar(0, 0, 255), cv::Scalar(85, 0, 255), cv::Scalar(170, 0, 255),
         cv::Scalar(255, 0, 255), cv::Scalar(255, 0, 170), cv::Scalar(255, 0, 85)
     };
-    const std::vector<std::pair<int, int> > limbKeypointsIds = {
+    static const std::pair<int, int> limbKeypointsIds[] = {
         {1, 2},  {1, 5},   {2, 3},
         {3, 4},  {5, 6},   {6, 7},
         {1, 8},  {8, 9},   {9, 10},

--- a/demos/interactive_face_detection_demo/detectors.cpp
+++ b/demos/interactive_face_detection_demo/detectors.cpp
@@ -538,8 +538,6 @@ void EmotionsDetection::enqueue(const cv::Mat &face) {
 }
 
 std::map<std::string, float> EmotionsDetection::operator[] (int idx) const {
-    // Vector of supported emotions
-    static const std::vector<std::string> emotionsVec = {"neutral", "happy", "sad", "surprise", "anger"};
     auto emotionsVecSize = emotionsVec.size();
 
     Blob::Ptr emotionsBlob = request->GetBlob(outputEmotions);

--- a/demos/interactive_face_detection_demo/main.cpp
+++ b/demos/interactive_face_detection_demo/main.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
         Core ie;
 
         std::set<std::string> loadedDevices;
-        std::vector<std::pair<std::string, std::string>> cmdOptions = {
+        std::pair<std::string, std::string> cmdOptions[] = {
             {FLAGS_d, FLAGS_m},
             {FLAGS_d_ag, FLAGS_m_ag},
             {FLAGS_d_hp, FLAGS_m_hp},

--- a/demos/mask_rcnn_demo/main.cpp
+++ b/demos/mask_rcnn_demo/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char *argv[]) {
         size_t box_stride = W * H * C;
 
         // some colours
-        std::vector<std::vector<short>> colors = {
+        const unsigned char colors[][3] = {
             {128, 64,  128},
             {232, 35,  244},
             {70,  70,  70},

--- a/demos/multi_channel/human_pose_estimation_demo/peak.cpp
+++ b/demos/multi_channel/human_pose_estimation_demo/peak.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <vector>
 
+#include <samples/common.hpp>
+
 #include "peak.hpp"
 
 Peak::Peak(const int id, const cv::Point2f& pos, const float score)
@@ -123,11 +125,11 @@ std::vector<HumanPose> groupPeaksToPoses(const std::vector<std::vector<Peak> >& 
                                          const float foundMidPointsRatioThreshold,
                                          const int minJointsNumber,
                                          const float minSubsetScore) {
-    const std::vector<std::pair<int, int> > limbIdsHeatmap = {
+    static const std::pair<int, int> limbIdsHeatmap[] = {
         {2, 3}, {2, 6}, {3, 4}, {4, 5}, {6, 7}, {7, 8}, {2, 9}, {9, 10}, {10, 11}, {2, 12}, {12, 13}, {13, 14},
         {2, 1}, {1, 15}, {15, 17}, {1, 16}, {16, 18}, {3, 17}, {6, 18}
     };
-    const std::vector<std::pair<int, int> > limbIdsPaf = {
+    static const std::pair<int, int> limbIdsPaf[] = {
         {31, 32}, {39, 40}, {33, 34}, {35, 36}, {41, 42}, {43, 44}, {19, 20}, {21, 22}, {23, 24}, {25, 26},
         {27, 28}, {29, 30}, {47, 48}, {49, 50}, {53, 54}, {51, 52}, {55, 56}, {37, 38}, {45, 46}
     };
@@ -137,7 +139,7 @@ std::vector<HumanPose> groupPeaksToPoses(const std::vector<std::vector<Peak> >& 
          candidates.insert(candidates.end(), peaks.begin(), peaks.end());
     }
     std::vector<HumanPoseByPeaksIndices> subset(0, HumanPoseByPeaksIndices(keypointsNumber));
-    for (size_t k = 0; k < limbIdsPaf.size(); k++) {
+    for (size_t k = 0; k < arraySize(limbIdsPaf); k++) {
         std::vector<TwoJointsConnection> connections;
         const int mapIdxOffset = keypointsNumber + 1;
         std::pair<cv::Mat, cv::Mat> scoreMid = { pafs[limbIdsPaf[k].first - mapIdxOffset],

--- a/demos/multi_channel/human_pose_estimation_demo/render_human_pose.cpp
+++ b/demos/multi_channel/human_pose_estimation_demo/render_human_pose.cpp
@@ -19,12 +19,13 @@
 
 #include <opencv2/imgproc/imgproc.hpp>
 
+#include "postprocess.hpp"
 #include "render_human_pose.hpp"
 
 void renderHumanPose(const std::vector<HumanPose>& poses, cv::Mat& image) {
     CV_Assert(image.type() == CV_8UC3);
 
-    const std::vector<cv::Scalar> colors = {
+    static const cv::Scalar colors[keypointsNumber] = {
         cv::Scalar(255, 0, 0), cv::Scalar(255, 85, 0), cv::Scalar(255, 170, 0),
         cv::Scalar(255, 255, 0), cv::Scalar(170, 255, 0), cv::Scalar(85, 255, 0),
         cv::Scalar(0, 255, 0), cv::Scalar(0, 255, 85), cv::Scalar(0, 255, 170),
@@ -32,7 +33,7 @@ void renderHumanPose(const std::vector<HumanPose>& poses, cv::Mat& image) {
         cv::Scalar(0, 0, 255), cv::Scalar(85, 0, 255), cv::Scalar(170, 0, 255),
         cv::Scalar(255, 0, 255), cv::Scalar(255, 0, 170), cv::Scalar(255, 0, 85)
     };
-    const std::vector<std::pair<int, int> > limbKeypointsIds = {
+    static const std::pair<int, int> limbKeypointsIds[] = {
         {1, 2},  {1, 5},   {2, 3},
         {3, 4},  {5, 6},   {6, 7},
         {1, 8},  {8, 9},   {9, 10},

--- a/demos/security_barrier_camera_demo/net_wrappers.hpp
+++ b/demos/security_barrier_camera_demo/net_wrappers.hpp
@@ -274,7 +274,7 @@ public:
     }
 
     std::string getResults(InferenceEngine::InferRequest& inferRequest) {
-        static const std::vector<std::string> items = {
+        static const char *const items[] = {
                 "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
                 "<Anhui>", "<Beijing>", "<Chongqing>", "<Fujian>",
                 "<Gansu>", "<Guangdong>", "<Guangxi>", "<Guizhou>",
@@ -297,7 +297,7 @@ public:
             if (data[i] == -1) {
                 break;
             }
-            result += items[static_cast<std::vector<std::string>::size_type>(data[i])];
+            result += items[std::size_t(data[i])];
         }
         return result;
     }

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -351,10 +351,10 @@ std::string GetActionTextLabel(const unsigned label, const std::vector<std::stri
 }
 
 cv::Scalar GetActionTextColor(const unsigned label) {
-    static std::vector<cv::Scalar> actions_map = {
+    static const cv::Scalar label_colors[] = {
         cv::Scalar(0, 255, 0), cv::Scalar(255, 0, 0), cv::Scalar(0, 0, 255), cv::Scalar(0, 255, 255)};
-    if (label < actions_map.size()) {
-        return actions_map[label];
+    if (label < arraySize(label_colors)) {
+        return label_colors[label];
     }
     return cv::Scalar(0, 0, 0);
 }


### PR DESCRIPTION
The impetus for this is that an internal static analysis tool gets confused by vectors initialized with initializer lists. However, it's a good change in its own right: by using arrays we avoid unnecessary dynamic allocation and, in some cases, dynamic initialization.

In one case, the vector isn't necessary at all (it shadows another identical vector), so remove it completely.