### PR TITLE
demos/mask_rcnn_demo: prevent OOB accesses to the colors array

### DIFF
--- a/demos/mask_rcnn_demo/main.cpp
+++ b/demos/mask_rcnn_demo/main.cpp
@@ -318,9 +318,8 @@ int main(int argc, char *argv[]) {
             int box_height = std::min(static_cast<int>(std::max(0.0f, y2 - y1)), images_cv[batch].size().height);
             auto class_id = static_cast<size_t>(box_info[1] + 1e-6f);
             if (prob > PROBABILITY_THRESHOLD) {
-                if (class_color.find(class_id) == class_color.end())
-                    class_color[class_id] = class_color.size();
-                auto& color = colors[class_color[class_id]];
+                size_t color_index = class_color.emplace(class_id, class_color.size()).first->second;
+                auto& color = colors[color_index % arraySize(colors)];
                 float* mask_arr = masks_data + box_stride * box + H * W * (class_id - 1);
                 slog::info << "Detected class " << class_id << " with probability " << prob << " from batch " << batch
                            << ": [" << x1 << ", " << y1 << "], [" << x2 << ", " << y2 << "]" << slog::endl;


### PR DESCRIPTION
There's no guarantee that the number of unique classes in the image is less than the number of colors, so use a remainder operation to wrap the color index.

Also, change the way that `class_color` is populated to prevent dependence on evaluation order. Evaluating `class_color[class_id]` can change the size, so the color indexes could change depending on whether the LHS or the RHS was evaluated first. Use `emplace` to set the default value instead.