### PR TITLE
Add compatibility with LPR model from openvino_training_extensions

### DIFF
--- a/demos/security_barrier_camera_demo/README.md
+++ b/demos/security_barrier_camera_demo/README.md
@@ -5,7 +5,7 @@ of the detection results. You can use a set of the following pre-trained models 
 * `vehicle-license-plate-detection-barrier-0106`, which is a primary detection network to find the vehicles and license plates
 * `vehicle-attributes-recognition-barrier-0039`, which is executed on top of the results from the first network and
 reports general vehicle attributes, for example, vehicle type (car/van/bus/track) and color
-* `license-plate-recognition-barrier-0001` and `license-plate-recognition-barrier-0007`, which is executed on top of the results from the first network
+* `license-plate-recognition-barrier-0001` or `license-plate-recognition-barrier-0007`, which is executed on top of the results from the first network
 and reports a string per recognized license plate
 
 For more information about the pre-trained models, refer to the [model documentation](../../models/intel/index.md).

--- a/demos/security_barrier_camera_demo/README.md
+++ b/demos/security_barrier_camera_demo/README.md
@@ -5,7 +5,7 @@ of the detection results. You can use a set of the following pre-trained models 
 * `vehicle-license-plate-detection-barrier-0106`, which is a primary detection network to find the vehicles and license plates
 * `vehicle-attributes-recognition-barrier-0039`, which is executed on top of the results from the first network and
 reports general vehicle attributes, for example, vehicle type (car/van/bus/track) and color
-* `license-plate-recognition-barrier-0001`, which is executed on top of the results from the first network
+* `license-plate-recognition-barrier-0001` and `license-plate-recognition-barrier-0007`, which is executed on top of the results from the first network
 and reports a string per recognized license plate
 
 For more information about the pre-trained models, refer to the [model documentation](../../models/intel/index.md).
@@ -123,7 +123,7 @@ If you build the Inference Engine with the OMP, you can use the following parame
 
 The demo uses OpenCV to display the resulting frame with detections rendered as bounding boxes and text.
 
-> **NOTE**: On VPU devices (Intel® Movidius™ Neural Compute Stick, Intel® Neural Compute Stick 2, and Intel® Vision Accelerator Design with Intel® Movidius™ VPUs) this demo has been tested on the following Model Downloader available topologies: 
+> **NOTE**: On VPU devices (Intel® Movidius™ Neural Compute Stick, Intel® Neural Compute Stick 2, and Intel® Vision Accelerator Design with Intel® Movidius™ VPUs) this demo has been tested on the following Model Downloader available topologies:
 >* `license-plate-recognition-barrier-0001`
 >* `vehicle-attributes-recognition-barrier-0039`
 >* `vehicle-license-plate-detection-barrier-0106`

--- a/demos/security_barrier_camera_demo/net_wrappers.hpp
+++ b/demos/security_barrier_camera_demo/net_wrappers.hpp
@@ -282,7 +282,7 @@ public:
             // it should have the leading 0.0f and rest 1.0f
             float* blob_data = seqBlob->buffer().as<float*>();
             blob_data[0] = 0.0f;
-            std::fill(blob_data + 1, blob_data + maxSequenceSizePerPlate, 1.0f);
+            std::fill(blob_data + 1, blob_data + seqBlob->getTensorDesc().getDims()[0], 1.0f);
         }
     }
 

--- a/demos/security_barrier_camera_demo/net_wrappers.hpp
+++ b/demos/security_barrier_camera_demo/net_wrappers.hpp
@@ -250,11 +250,11 @@ public:
             throw std::logic_error("LPR should have 1 output");
         }
         LprOutputName = LprOutputInfo.begin()->first;
-        auto lprOutputInput = (LprOutputInfo.begin());
+        auto lprOutputInfo = (LprOutputInfo.begin());
 
         // Shape of output tensor for model that converted from Caffe is [1,88,1,1], from TF [1,1,88,1]
         size_t indexOfSequenceSize = LprInputSeqName == "" ? 2 : 1;
-        maxSequenceSizePerPlate = lprOutputInput->second->getTensorDesc().getDims()[indexOfSequenceSize];
+        maxSequenceSizePerPlate = lprOutputInfo->second->getTensorDesc().getDims()[indexOfSequenceSize];
 
         net = ie_.LoadNetwork(LprNetReader.getNetwork(), deviceName, pluginConfig);
     }

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -185,7 +185,10 @@ NATIVE_DEMOS = [
             '-i': ImageDirectoryArg('vehicle-license-plate-detection-barrier')}),
         device_cases('-d', '-d_lpr', '-d_va'),
         TestCase(options={'-m': ModelArg('vehicle-license-plate-detection-barrier-0106')}),
-        single_option_cases('-m_lpr', None, ModelArg('license-plate-recognition-barrier-0001')),
+        single_option_cases('-m_lpr',
+            None,
+            ModelArg('license-plate-recognition-barrier-0001'),
+            ModelArg('license-plate-recognition-barrier-0007')),
         single_option_cases('-m_va', None, ModelArg('vehicle-attributes-recognition-barrier-0039')),
     )),
 


### PR DESCRIPTION

- `license-plate-recognition-barrier-0001` model converted from Caffe and have two input blobs
- implementation this LPR model in [TensorFlow from openvino_training_extensions](https://github.com/opencv/openvino_training_extensions/tree/develop/tensorflow_toolkit/lpr) have one