### PR TITLE
AC configs: remove cpu extensions from configs

### DIFF
--- a/tools/accuracy_checker/configs/deeplabv3.yml
+++ b/tools/accuracy_checker/configs/deeplabv3.yml
@@ -7,7 +7,6 @@ models:
         model:   public/deeplabv3/FP32/deeplabv3.xml
         weights: public/deeplabv3/FP32/deeplabv3.bin
         adapter: segmentation
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -15,7 +14,6 @@ models:
         model:   public/deeplabv3/FP16/deeplabv3.xml
         weights: public/deeplabv3/FP16/deeplabv3.bin
         adapter: segmentation
-        cpu_extensions: AUTO
 
     datasets:
       - name: VOC2012_Segmentation

--- a/tools/accuracy_checker/configs/densenet-121-caffe2.yml
+++ b/tools/accuracy_checker/configs/densenet-121-caffe2.yml
@@ -26,7 +26,6 @@ models:
         model:   public/densenet-121-caffe2/FP32/densenet-121-caffe2.xml
         weights: public/densenet-121-caffe2/FP32/densenet-121-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -34,7 +33,6 @@ models:
         model:   public/densenet-121-caffe2/FP16/densenet-121-caffe2.xml
         weights: public/densenet-121-caffe2/FP16/densenet-121-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/efficientnet-b0-pytorch.yml
+++ b/tools/accuracy_checker/configs/efficientnet-b0-pytorch.yml
@@ -46,7 +46,6 @@ models:
         model:   public/efficientnet-b0-pytorch/FP16/efficientnet-b0-pytorch.xml
         weights: public/efficientnet-b0-pytorch/FP16/efficientnet-b0-pytorch.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/efficientnet-b0_auto_aug.yml
+++ b/tools/accuracy_checker/configs/efficientnet-b0_auto_aug.yml
@@ -33,7 +33,6 @@ models:
         model:   public/efficientnet-b0_auto_aug/FP32/efficientnet-b0_auto_aug.xml
         weights: public/efficientnet-b0_auto_aug/FP32/efficientnet-b0_auto_aug.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -41,7 +40,6 @@ models:
         model:   public/efficientnet-b0_auto_aug/FP16/efficientnet-b0_auto_aug.xml
         weights: public/efficientnet-b0_auto_aug/FP16/efficientnet-b0_auto_aug.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/efficientnet-b5-pytorch.yml
+++ b/tools/accuracy_checker/configs/efficientnet-b5-pytorch.yml
@@ -39,7 +39,6 @@ models:
         model:   public/efficientnet-b5-pytorch/FP32/efficientnet-b5-pytorch.xml
         weights: public/efficientnet-b5-pytorch/FP32/efficientnet-b5-pytorch.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -47,7 +46,6 @@ models:
         model:   public/efficientnet-b5-pytorch/FP16/efficientnet-b5-pytorch.xml
         weights: public/efficientnet-b5-pytorch/FP16/efficientnet-b5-pytorch.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/efficientnet-b5.yml
+++ b/tools/accuracy_checker/configs/efficientnet-b5.yml
@@ -33,7 +33,6 @@ models:
         model:   public/efficientnet-b5/FP32/efficientnet-b5.xml
         weights: public/efficientnet-b5/FP32/efficientnet-b5.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -41,7 +40,6 @@ models:
         model:   public/efficientnet-b5/FP16/efficientnet-b5.xml
         weights: public/efficientnet-b5/FP16/efficientnet-b5.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/efficientnet-b7-pytorch.yml
+++ b/tools/accuracy_checker/configs/efficientnet-b7-pytorch.yml
@@ -38,7 +38,6 @@ models:
         model:   public/efficientnet-b7-pytorch/FP32/efficientnet-b7-pytorch.xml
         weights: public/efficientnet-b7-pytorch/FP32/efficientnet-b7-pytorch.bin
         adapter: classification
-        cpu_extensions: AUTO
 
 
       - framework: dlsdk
@@ -47,7 +46,6 @@ models:
         model:   public/efficientnet-b7-pytorch/FP16/efficientnet-b7-pytorch.xml
         weights: public/efficientnet-b7-pytorch/FP16/efficientnet-b7-pytorch.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/efficientnet-b7_auto_aug.yml
+++ b/tools/accuracy_checker/configs/efficientnet-b7_auto_aug.yml
@@ -33,7 +33,6 @@ models:
         model:   public/efficientnet-b7_auto_aug/FP32/efficientnet-b7_auto_aug.xml
         weights: public/efficientnet-b7_auto_aug/FP32/efficientnet-b7_auto_aug.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -41,7 +40,6 @@ models:
         model:   public/efficientnet-b7_auto_aug/FP16/efficientnet-b7_auto_aug.xml
         weights: public/efficientnet-b7_auto_aug/FP16/efficientnet-b7_auto_aug.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/emotions-recognition-retail-0003.yml
+++ b/tools/accuracy_checker/configs/emotions-recognition-retail-0003.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
         weights: intel/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
         weights: intel/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.xml
         weights: intel/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: emotions_recognition

--- a/tools/accuracy_checker/configs/face-detection-retail-0005.yml
+++ b/tools/accuracy_checker/configs/face-detection-retail-0005.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
         weights: intel/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
         weights: intel/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/face-detection-retail-0005/INT8/face-detection-retail-0005.xml
         weights: intel/face-detection-retail-0005/INT8/face-detection-retail-0005.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: wider

--- a/tools/accuracy_checker/configs/face-detection-retail-0044.yml
+++ b/tools/accuracy_checker/configs/face-detection-retail-0044.yml
@@ -14,7 +14,6 @@ models:
         model:   public/face-detection-retail-0044/FP32/face-detection-retail-0044.xml
         weights: public/face-detection-retail-0044/FP32/face-detection-retail-0044.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:

--- a/tools/accuracy_checker/configs/facial-landmarks-35-adas-0002.yml
+++ b/tools/accuracy_checker/configs/facial-landmarks-35-adas-0002.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
         weights: intel/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
         adapter: landmarks_regression
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
         weights: intel/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
         adapter: landmarks_regression
-        cpu_extensions: AUTO
 
     datasets:
       - name: facial_landmarks_35

--- a/tools/accuracy_checker/configs/gaze-estimation-adas-0002.yml
+++ b/tools/accuracy_checker/configs/gaze-estimation-adas-0002.yml
@@ -19,7 +19,6 @@ models:
             type: INPUT
             value: ".*.json"
         adapter: gaze_estimation
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -37,7 +36,6 @@ models:
             type: INPUT
             value: ".*.json"
         adapter: gaze_estimation
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -55,7 +53,6 @@ models:
             type: INPUT
             value: ".*.json"
         adapter: gaze_estimation
-        cpu_extensions: AUTO
 
     datasets:
       - name: gaze_estimation_dataset

--- a/tools/accuracy_checker/configs/handwritten-score-recognition-0003.yml
+++ b/tools/accuracy_checker/configs/handwritten-score-recognition-0003.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
         weights: intel/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
         adapter: beam_search_decoder
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
         weights: intel/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
         adapter: beam_search_decoder
-        cpu_extensions: AUTO
 
     datasets:
       - name: handwritten_score_recognition

--- a/tools/accuracy_checker/configs/human-pose-estimation-3d-0001.yml
+++ b/tools/accuracy_checker/configs/human-pose-estimation-3d-0001.yml
@@ -42,3 +42,4 @@ models:
 
         metrics:
           - type: mpjpe_multiperson
+global_definitions: ../dataset_definitions.yml

--- a/tools/accuracy_checker/configs/image-retrieval-0001.yml
+++ b/tools/accuracy_checker/configs/image-retrieval-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/image-retrieval-0001/FP32/image-retrieval-0001.xml
         weights: intel/image-retrieval-0001/FP32/image-retrieval-0001.bin
         adapter: reid
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/image-retrieval-0001/FP16/image-retrieval-0001.xml
         weights: intel/image-retrieval-0001/FP16/image-retrieval-0001.bin
         adapter: reid
-        cpu_extensions: AUTO
 
     datasets:
       - name: image_retrieval

--- a/tools/accuracy_checker/configs/inceptionv3-int8-sparse-v1-tf-0001.yml
+++ b/tools/accuracy_checker/configs/inceptionv3-int8-sparse-v1-tf-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/inceptionv3-int8-sparse-v1-tf-0001/FP32/inceptionv3-int8-sparse-v1-tf-0001.xml
         weights: intel/inceptionv3-int8-sparse-v1-tf-0001/FP32/inceptionv3-int8-sparse-v1-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1001_classes

--- a/tools/accuracy_checker/configs/inceptionv3-int8-sparse-v2-tf-0001.yml
+++ b/tools/accuracy_checker/configs/inceptionv3-int8-sparse-v2-tf-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/inceptionv3-int8-sparse-v2-tf-0001/FP32/inceptionv3-int8-sparse-v2-tf-0001.xml
         weights: intel/inceptionv3-int8-sparse-v2-tf-0001/FP32/inceptionv3-int8-sparse-v2-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1001_classes

--- a/tools/accuracy_checker/configs/inceptionv3-int8-tf-0001.yml
+++ b/tools/accuracy_checker/configs/inceptionv3-int8-tf-0001.yml
@@ -8,8 +8,6 @@ models:
         model:   intel/inceptionv3-int8-tf-0001/FP32/inceptionv3-int8-tf-0001.xml
         weights: intel/inceptionv3-int8-tf-0001/FP32/inceptionv3-int8-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
-
 
     datasets:
       - name: imagenet_1001_classes

--- a/tools/accuracy_checker/configs/instance-segmentation-security-0010.yml
+++ b/tools/accuracy_checker/configs/instance-segmentation-security-0010.yml
@@ -13,7 +13,6 @@ models:
           scores_out: scores
           boxes_out: boxes
           raw_masks_out: raw_masks
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: IMAGE_INFO
@@ -29,7 +28,6 @@ models:
           scores_out: scores
           boxes_out: boxes
           raw_masks_out: raw_masks
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: IMAGE_INFO

--- a/tools/accuracy_checker/configs/instance-segmentation-security-0050.yml
+++ b/tools/accuracy_checker/configs/instance-segmentation-security-0050.yml
@@ -13,7 +13,6 @@ models:
           scores_out: scores
           boxes_out: boxes
           raw_masks_out: raw_masks
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: IMAGE_INFO
@@ -29,7 +28,6 @@ models:
           scores_out: scores
           boxes_out: boxes
           raw_masks_out: raw_masks
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: IMAGE_INFO

--- a/tools/accuracy_checker/configs/instance-segmentation-security-0083.yml
+++ b/tools/accuracy_checker/configs/instance-segmentation-security-0083.yml
@@ -13,7 +13,6 @@ models:
           scores_out: scores
           boxes_out: boxes
           raw_masks_out: raw_masks
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: IMAGE_INFO
@@ -29,7 +28,6 @@ models:
           scores_out: scores
           boxes_out: boxes
           raw_masks_out: raw_masks
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: IMAGE_INFO

--- a/tools/accuracy_checker/configs/license-plate-recognition-barrier-0001.yml
+++ b/tools/accuracy_checker/configs/license-plate-recognition-barrier-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
         weights: intel/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
         adapter: lpr
-        cpu_extensions: AUTO
         inputs:
           - name: seq_ind
             type: CONST_INPUT
@@ -20,7 +19,6 @@ models:
         model:   intel/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
         weights: intel/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
         adapter: lpr
-        cpu_extensions: AUTO
         inputs:
           - name: seq_ind
             type: CONST_INPUT
@@ -32,7 +30,6 @@ models:
         model:   intel/license-plate-recognition-barrier-0001/INT8/license-plate-recognition-barrier-0001.xml
         weights: intel/license-plate-recognition-barrier-0001/INT8/license-plate-recognition-barrier-0001.bin
         adapter: lpr
-        cpu_extensions: AUTO
         inputs:
           - name: seq_ind
             type: CONST_INPUT

--- a/tools/accuracy_checker/configs/license-plate-recognition-barrier-0007.yml
+++ b/tools/accuracy_checker/configs/license-plate-recognition-barrier-0007.yml
@@ -8,7 +8,6 @@ models:
         model:   public/license-plate-recognition-barrier-0007/FP32/license-plate-recognition-barrier-0007.xml
         weights: public/license-plate-recognition-barrier-0007/FP32/license-plate-recognition-barrier-0007.bin
         adapter: lpr
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   public/license-plate-recognition-barrier-0007/FP16/license-plate-recognition-barrier-0007.xml
         weights: public/license-plate-recognition-barrier-0007/FP16/license-plate-recognition-barrier-0007.bin
         adapter: lpr
-        cpu_extensions: AUTO
 
     datasets:
       - name: synthetic_chinese_license_plates

--- a/tools/accuracy_checker/configs/mask_rcnn_inception_resnet_v2_atrous_coco.yml
+++ b/tools/accuracy_checker/configs/mask_rcnn_inception_resnet_v2_atrous_coco.yml
@@ -11,7 +11,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO
@@ -25,7 +24,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO

--- a/tools/accuracy_checker/configs/mask_rcnn_inception_v2_coco.yml
+++ b/tools/accuracy_checker/configs/mask_rcnn_inception_v2_coco.yml
@@ -10,7 +10,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO
@@ -24,7 +23,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO

--- a/tools/accuracy_checker/configs/mask_rcnn_resnet101_atrous_coco.yml
+++ b/tools/accuracy_checker/configs/mask_rcnn_resnet101_atrous_coco.yml
@@ -11,7 +11,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO
@@ -25,7 +24,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO

--- a/tools/accuracy_checker/configs/mask_rcnn_resnet50_atrous_coco.yml
+++ b/tools/accuracy_checker/configs/mask_rcnn_resnet50_atrous_coco.yml
@@ -11,7 +11,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO
@@ -25,7 +24,6 @@ models:
           type: mask_rcnn
           detection_out: reshape_do_2d
           raw_masks_out: masks
-        cpu_extensions: AUTO
         inputs:
           - name: image_info
             type: IMAGE_INFO

--- a/tools/accuracy_checker/configs/mobilenet-ssd.yml
+++ b/tools/accuracy_checker/configs/mobilenet-ssd.yml
@@ -24,7 +24,6 @@ models:
         model:   public/mobilenet-ssd/FP32/mobilenet-ssd.xml
         weights: public/mobilenet-ssd/FP32/mobilenet-ssd.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -32,7 +31,6 @@ models:
         model:   public/mobilenet-ssd/FP16/mobilenet-ssd.xml
         weights: public/mobilenet-ssd/FP16/mobilenet-ssd.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: VOC2012

--- a/tools/accuracy_checker/configs/mobilenetv2-int8-sparse-v1-tf-0001.yml
+++ b/tools/accuracy_checker/configs/mobilenetv2-int8-sparse-v1-tf-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/mobilenetv2-int8-sparse-v1-tf-0001/FP32/mobilenetv2-int8-sparse-v1-tf-0001.xml
         weights: intel/mobilenetv2-int8-sparse-v1-tf-0001/FP32/mobilenetv2-int8-sparse-v1-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1001_classes

--- a/tools/accuracy_checker/configs/mobilenetv2-int8-sparse-v2-tf-0001.yml
+++ b/tools/accuracy_checker/configs/mobilenetv2-int8-sparse-v2-tf-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/mobilenetv2-int8-sparse-v2-tf-0001/FP32/mobilenetv2-int8-sparse-v2-tf-0001.xml
         weights: intel/mobilenetv2-int8-sparse-v2-tf-0001/FP32/mobilenetv2-int8-sparse-v2-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1001_classes

--- a/tools/accuracy_checker/configs/mobilenetv2-int8-tf-0001.yml
+++ b/tools/accuracy_checker/configs/mobilenetv2-int8-tf-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/mobilenetv2-int8-tf-0001/FP32/mobilenetv2-int8-tf-0001.xml
         weights: intel/mobilenetv2-int8-tf-0001/FP32/mobilenetv2-int8-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1001_classes

--- a/tools/accuracy_checker/configs/octave-densenet-121-0.125.yml
+++ b/tools/accuracy_checker/configs/octave-densenet-121-0.125.yml
@@ -48,7 +48,6 @@ models:
         model:   public/octave-densenet-121-0.125/FP32/octave-densenet-121-0.125.xml
         weights: public/octave-densenet-121-0.125/FP32/octave-densenet-121-0.125.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:

--- a/tools/accuracy_checker/configs/octave-resnet-101-0.125.yml
+++ b/tools/accuracy_checker/configs/octave-resnet-101-0.125.yml
@@ -6,7 +6,6 @@ models:
       - framework: mxnet
         model: public/octave-resnet-101-0.125/checkpoint-0-0000.params
         adapter: classification
-        cpu_extensions: AUTO
         inputs: 
           - name: 'data'
             type: INPUT
@@ -49,17 +48,14 @@ models:
         model:   public/octave-resnet-101-0.125/FP32/octave-resnet-101-0.125.xml
         weights: public/octave-resnet-101-0.125/FP32/octave-resnet-101-0.125.bin
         adapter: classification
-        cpu_extensions: AUTO
 
 
       - framework: dlsdk
-        device: GPU
         tags:
           - FP16
         model:   public/octave-resnet-101-0.125/FP16/octave-resnet-101-0.125.xml
         weights: public/octave-resnet-101-0.125/FP16/octave-resnet-101-0.125.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/octave-resnet-200-0.125.yml
+++ b/tools/accuracy_checker/configs/octave-resnet-200-0.125.yml
@@ -45,31 +45,18 @@ models:
 
     launchers:
       - framework: dlsdk
-        device: CPU
         tags:
           - FP32
         model:   public/octave-resnet-200-0.125/FP32/octave-resnet-200-0.125.xml
         weights: public/octave-resnet-200-0.125/FP32/octave-resnet-200-0.125.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
-        device: GPU
-        tags:
-          - FP32
-        model: octave-resnet-200-0.125/FP32/octave-resnet-200-0.125.xml
-        weights: octave-resnet-200-0.125/FP32/octave-resnet-200-0.125.bin
-        adapter: classification
-        cpu_extensions: AUTO
-
-      - framework: dlsdk
-        device: GPU
         tags:
           - FP16
         model: octave-resnet-200-0.125/FP16/octave-resnet-200-0.125.xml
         weights: octave-resnet-200-0.125/FP16/octave-resnet-200-0.125.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/octave-resnet-26-0.25.yml
+++ b/tools/accuracy_checker/configs/octave-resnet-26-0.25.yml
@@ -49,7 +49,6 @@ models:
         model:   public/octave-resnet-26-0.25/FP32/octave-resnet-26-0.25.xml
         weights: public/octave-resnet-26-0.25/FP32/octave-resnet-26-0.25.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -57,7 +56,6 @@ models:
         model:   public/octave-resnet-26-0.25/FP16/octave-resnet-26-0.25.xml
         weights: public/octave-resnet-26-0.25/FP16/octave-resnet-26-0.25.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/octave-resnet-50-0.125.yml
+++ b/tools/accuracy_checker/configs/octave-resnet-50-0.125.yml
@@ -6,7 +6,6 @@ models:
       - framework: mxnet
         model: public/octave-resnet-50-0.125/checkpoint-0-0000.params
         adapter: classification
-        cpu_extensions: AUTO
         inputs: 
           - name: 'data'
             type: INPUT

--- a/tools/accuracy_checker/configs/octave-resnext-101-0.25.yml
+++ b/tools/accuracy_checker/configs/octave-resnext-101-0.25.yml
@@ -42,7 +42,6 @@ models:
         model:   public/octave-resnext-101-0.25/FP32/octave-resnext-101-0.25.xml
         weights: public/octave-resnext-101-0.25/FP32/octave-resnext-101-0.25.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -50,7 +49,6 @@ models:
         model:   public/octave-resnext-101-0.25/FP16/octave-resnext-101-0.25.xml
         weights: public/octave-resnext-101-0.25/FP16/octave-resnext-101-0.25.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/octave-resnext-50-0.25.yml
+++ b/tools/accuracy_checker/configs/octave-resnext-50-0.25.yml
@@ -7,7 +7,6 @@ models:
         device: CPU
         model: public/octave-resnext-50-0.25/checkpoint-0-0000.params
         adapter: classification
-        cpu_extensions: AUTO
         inputs: 
           - name: 'data'
             type: INPUT
@@ -44,7 +43,6 @@ models:
         model:   public/octave-resnext-50-0.25/FP32/octave-resnext-50-0.25.xml
         weights: public/octave-resnext-50-0.25/FP32/octave-resnext-50-0.25.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -52,7 +50,6 @@ models:
         model:   public/octave-resnext-50-0.25/FP16/octave-resnext-50-0.25.xml
         weights: public/octave-resnext-50-0.25/FP16/octave-resnext-50-0.25.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/octave-se-resnet-50-0.125.yml
+++ b/tools/accuracy_checker/configs/octave-se-resnet-50-0.125.yml
@@ -7,7 +7,6 @@ models:
         device: CPU
         model: public/octave-se-resnet-50-0.125/checkpoint-0-0000.params
         adapter: classification
-        cpu_extensions: AUTO
         inputs: 
           - name: 'data'
             type: INPUT
@@ -37,31 +36,18 @@ models:
 
     launchers:
       - framework: dlsdk
-        device: CPU
         tags:
           - FP32
         model:   public/octave-se-resnet-50-0.125/FP32/octave-se-resnet-50-0.125.xml
         weights: public/octave-se-resnet-50-0.125/FP32/octave-se-resnet-50-0.125.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
-        device: GPU
-        tags:
-          - FP32
-        model:   public/octave-se-resnet-50-0.125/FP32/octave-se-resnet-50-0.125.xml
-        weights: public/octave-se-resnet-50-0.125/FP32/octave-se-resnet-50-0.125.bin
-        adapter: classification
-        cpu_extensions: AUTO
-
-      - framework: dlsdk
-        device: GPU
         tags:
           - FP16
         model:   public/octave-se-resnet-50-0.125/FP16/octave-se-resnet-50-0.125.xml
         weights: public/octave-se-resnet-50-0.125/FP16/octave-se-resnet-50-0.125.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/pedestrian-and-vehicle-detector-adas-0001.yml
+++ b/tools/accuracy_checker/configs/pedestrian-and-vehicle-detector-adas-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
         weights: intel/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
         weights: intel/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.xml
         weights: intel/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: pedestrian_and_vehicle_dataset

--- a/tools/accuracy_checker/configs/pedestrian-detection-adas-0002.yml
+++ b/tools/accuracy_checker/configs/pedestrian-detection-adas-0002.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
         weights: intel/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
         weights: intel/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.xml
         weights: intel/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: pedestrian_detection_dataset

--- a/tools/accuracy_checker/configs/pedestrian-detection-adas-binary-0001.yml
+++ b/tools/accuracy_checker/configs/pedestrian-detection-adas-binary-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.xml
         weights: intel/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: pedestrian_detection_dataset

--- a/tools/accuracy_checker/configs/person-detection-action-recognition-0005.yml
+++ b/tools/accuracy_checker/configs/person-detection-action-recognition-0005.yml
@@ -18,7 +18,6 @@ models:
           detection_threshold: 0.4
           action_confidence_threshold: 0.75
           action_scale: 3
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -36,7 +35,6 @@ models:
           detection_threshold: 0.4
           action_confidence_threshold: 0.75
           action_scale: 3
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -54,7 +52,6 @@ models:
           detection_threshold: 0.4
           action_confidence_threshold: 0.75
           action_scale: 3
-        cpu_extensions: AUTO
 
     datasets:
       - name: action_detection_dataset_3_classes

--- a/tools/accuracy_checker/configs/person-detection-action-recognition-0006.yml
+++ b/tools/accuracy_checker/configs/person-detection-action-recognition-0006.yml
@@ -26,7 +26,6 @@ models:
          num_action_classes: 6
          detection_threshold: 0.3
          action_scale: 16.0
-       cpu_extensions: AUTO
 
      - framework: dlsdk
        tags:
@@ -52,7 +51,6 @@ models:
          num_action_classes: 6
          detection_threshold: 0.3
          action_scale: 16.0
-       cpu_extensions: AUTO
 
      - framework: dlsdk
        tags:
@@ -78,7 +76,6 @@ models:
          num_action_classes: 6
          detection_threshold: 0.3
          action_scale: 16.0
-       cpu_extensions: AUTO
 
    datasets:
    - name: action_detection_dataset_6_classes

--- a/tools/accuracy_checker/configs/person-detection-action-recognition-teacher-0002.yml
+++ b/tools/accuracy_checker/configs/person-detection-action-recognition-teacher-0002.yml
@@ -18,7 +18,6 @@ models:
           detection_threshold: 0.4
           action_confidence_threshold: 0.75
           action_scale: 3
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -36,7 +35,6 @@ models:
           detection_threshold: 0.4
           action_confidence_threshold: 0.75
           action_scale: 3
-        cpu_extensions: AUTO
 
     datasets:
       - name: action_detection_dataset_teacher

--- a/tools/accuracy_checker/configs/person-detection-raisinghand-recognition-0001.yml
+++ b/tools/accuracy_checker/configs/person-detection-raisinghand-recognition-0001.yml
@@ -18,7 +18,6 @@ models:
           detection_threshold: 0.4
           action_confidence_threshold: 0.75
           action_scale: 3
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -36,7 +35,6 @@ models:
           detection_threshold: 0.4
           action_confidence_threshold: 0.75
           action_scale: 3
-        cpu_extensions: AUTO
 
     datasets:
       - name: action_detection_dataset_raising_hand

--- a/tools/accuracy_checker/configs/person-detection-retail-0002.yml
+++ b/tools/accuracy_checker/configs/person-detection-retail-0002.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
         weights: intel/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: CONST_INPUT
@@ -20,7 +19,6 @@ models:
         model:   intel/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
         weights: intel/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
         inputs:
           - name: im_info
             type: CONST_INPUT

--- a/tools/accuracy_checker/configs/person-detection-retail-0013.yml
+++ b/tools/accuracy_checker/configs/person-detection-retail-0013.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
         weights: intel/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
         weights: intel/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/person-detection-retail-0013/INT8/person-detection-retail-0013.xml
         weights: intel/person-detection-retail-0013/INT8/person-detection-retail-0013.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: person_detection

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0031.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0031.yml
@@ -19,7 +19,6 @@ models:
       - framework: dlsdk
         tags:
           - INT8
-        device: CPU
         model:   intel/person-reidentification-retail-0031/INT8/person-reidentification-retail-0031.xml
         weights: intel/person-reidentification-retail-0031/INT8/person-reidentification-retail-0031.bin
         adapter: reid

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0076.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0076.yml
@@ -19,7 +19,6 @@ models:
       - framework: dlsdk
         tags:
           - INT8
-        device: CPU
         model:   intel/person-reidentification-retail-0076/INT8/person-reidentification-retail-0076.xml
         weights: intel/person-reidentification-retail-0076/INT8/person-reidentification-retail-0076.bin
         adapter: reid

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0079.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0079.yml
@@ -19,7 +19,6 @@ models:
       - framework: dlsdk
         tags:
           - INT8
-        device: CPU
         model:   intel/person-reidentification-retail-0079/INT8/person-reidentification-retail-0079.xml
         weights: intel/person-reidentification-retail-0079/INT8/person-reidentification-retail-0079.bin
         adapter: reid

--- a/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-0078.yml
+++ b/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-0078.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
         weights: intel/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
         weights: intel/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/person-vehicle-bike-detection-crossroad-0078/INT8/person-vehicle-bike-detection-crossroad-0078.xml
         weights: intel/person-vehicle-bike-detection-crossroad-0078/INT8/person-vehicle-bike-detection-crossroad-0078.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: crossroad_dataset_0078

--- a/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-1016.yml
+++ b/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-1016.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
         weights: intel/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
         weights: intel/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: crossroad_dataset_1016

--- a/tools/accuracy_checker/configs/resnet-50-caffe2.yml
+++ b/tools/accuracy_checker/configs/resnet-50-caffe2.yml
@@ -26,7 +26,6 @@ models:
         model:   public/resnet-50-caffe2/FP32/resnet-50-caffe2.xml
         weights: public/resnet-50-caffe2/FP32/resnet-50-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -34,7 +33,6 @@ models:
         model:   public/resnet-50-caffe2/FP16/resnet-50-caffe2.xml
         weights: public/resnet-50-caffe2/FP16/resnet-50-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/resnet-50-int8-sparse-v1-tf-0001.yml
+++ b/tools/accuracy_checker/configs/resnet-50-int8-sparse-v1-tf-0001.yml
@@ -8,8 +8,6 @@ models:
         model:   intel/resnet-50-int8-sparse-v1-tf-0001/FP32/resnet-50-int8-sparse-v1-tf-0001.xml
         weights: intel/resnet-50-int8-sparse-v1-tf-0001/FP32/resnet-50-int8-sparse-v1-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
-
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/resnet-50-int8-sparse-v2-tf-0001.yml
+++ b/tools/accuracy_checker/configs/resnet-50-int8-sparse-v2-tf-0001.yml
@@ -8,8 +8,6 @@ models:
         model:   intel/resnet-50-int8-sparse-v2-tf-0001/FP32/resnet-50-int8-sparse-v2-tf-0001.xml
         weights: intel/resnet-50-int8-sparse-v2-tf-0001/FP32/resnet-50-int8-sparse-v2-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
-
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/resnet-50-int8-tf-0001.yml
+++ b/tools/accuracy_checker/configs/resnet-50-int8-tf-0001.yml
@@ -8,8 +8,6 @@ models:
         model:   intel/resnet-50-int8-tf-0001/FP32/resnet-50-int8-tf-0001.xml
         weights: intel/resnet-50-int8-tf-0001/FP32/resnet-50-int8-tf-0001.bin
         adapter: classification
-        cpu_extensions: AUTO
-
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/road-segmentation-adas-0001.yml
+++ b/tools/accuracy_checker/configs/road-segmentation-adas-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
         weights: intel/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
         adapter: segmentation
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
         weights: intel/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
         adapter: segmentation
-        cpu_extensions: AUTO
 
     datasets:
       - name: road_segmentation

--- a/tools/accuracy_checker/configs/semantic-segmentation-adas-0001.yml
+++ b/tools/accuracy_checker/configs/semantic-segmentation-adas-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
         weights: intel/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
         adapter: segmentation
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
         weights: intel/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
         adapter: segmentation
-        cpu_extensions: AUTO
 
     datasets:
       - name: semantic_segmentation_adas

--- a/tools/accuracy_checker/configs/single-image-super-resolution-1032.yml
+++ b/tools/accuracy_checker/configs/single-image-super-resolution-1032.yml
@@ -10,7 +10,6 @@ models:
         adapter:
           type: super_resolution
           reverse_channels: True
-        cpu_extensions: AUTO
         inputs:
           - name: "0"
             type: INPUT
@@ -27,7 +26,6 @@ models:
         adapter:
           type: super_resolution
           reverse_channels: True
-        cpu_extensions: AUTO
         inputs:
           - name: "0"
             type: INPUT
@@ -44,7 +42,6 @@ models:
         adapter:
           type: super_resolution
           reverse_channels: True
-        cpu_extensions: AUTO
         inputs:
           - name: "0"
             type: INPUT

--- a/tools/accuracy_checker/configs/single-image-super-resolution-1033.yml
+++ b/tools/accuracy_checker/configs/single-image-super-resolution-1033.yml
@@ -10,7 +10,6 @@ models:
         adapter:
           type: super_resolution
           reverse_channels: True
-        cpu_extensions: AUTO
         inputs:
           - name: "0"
             type: INPUT
@@ -27,7 +26,6 @@ models:
         adapter:
           type: super_resolution
           reverse_channels: True
-        cpu_extensions: AUTO
         inputs:
           - name: "0"
             type: INPUT
@@ -44,7 +42,6 @@ models:
         adapter:
           type: super_resolution
           reverse_channels: True
-        cpu_extensions: AUTO
         inputs:
           - name: "0"
             type: INPUT

--- a/tools/accuracy_checker/configs/squeezenet1.1-caffe2.yml
+++ b/tools/accuracy_checker/configs/squeezenet1.1-caffe2.yml
@@ -24,7 +24,6 @@ models:
         model:   public/squeezenet1.1-caffe2/FP32/squeezenet1.1-caffe2.xml
         weights: public/squeezenet1.1-caffe2/FP32/squeezenet1.1-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -32,7 +31,6 @@ models:
         model:   public/squeezenet1.1-caffe2/FP16/squeezenet1.1-caffe2.xml
         weights: public/squeezenet1.1-caffe2/FP16/squeezenet1.1-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/ssd300.yml
+++ b/tools/accuracy_checker/configs/ssd300.yml
@@ -23,7 +23,6 @@ models:
         model:   public/ssd300/FP32/ssd300.xml
         weights: public/ssd300/FP32/ssd300.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -31,7 +30,6 @@ models:
         model:   public/ssd300/FP16/ssd300.xml
         weights: public/ssd300/FP16/ssd300.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: VOC2012

--- a/tools/accuracy_checker/configs/ssd512.yml
+++ b/tools/accuracy_checker/configs/ssd512.yml
@@ -23,7 +23,6 @@ models:
         model:   public/ssd512/FP32/ssd512.xml
         weights: public/ssd512/FP32/ssd512.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -31,7 +30,6 @@ models:
         model:   public/ssd512/FP16/ssd512.xml
         weights: public/ssd512/FP16/ssd512.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: VOC2012

--- a/tools/accuracy_checker/configs/text-detection-0004.yml
+++ b/tools/accuracy_checker/configs/text-detection-0004.yml
@@ -15,7 +15,6 @@ models:
           pixel_link_confidence_threshold: 0.8
           min_area: 300
           min_height: 10
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -30,7 +29,6 @@ models:
           pixel_link_confidence_threshold: 0.8
           min_area: 300
           min_height: 10
-        cpu_extensions: AUTO
 
     datasets:
       - name: ICDAR2015

--- a/tools/accuracy_checker/configs/text-image-super-resolution-0001.yml
+++ b/tools/accuracy_checker/configs/text-image-super-resolution-0001.yml
@@ -9,7 +9,6 @@ models:
         weights: intel/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
         adapter:
           type: super_resolution
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -18,7 +17,6 @@ models:
         weights: intel/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
         adapter:
           type: super_resolution
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -27,7 +25,6 @@ models:
         weights: intel/text-image-super-resolution-0001/INT8/text-image-super-resolution-0001.bin
         adapter:
           type: super_resolution
-        cpu_extensions: AUTO
 
     datasets:
       - name: text_super_resolution_x3

--- a/tools/accuracy_checker/configs/vehicle-detection-adas-0002.yml
+++ b/tools/accuracy_checker/configs/vehicle-detection-adas-0002.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
         weights: intel/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
         weights: intel/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.xml
         weights: intel/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: vehicle_detection_dataset

--- a/tools/accuracy_checker/configs/vehicle-detection-adas-binary-0001.yml
+++ b/tools/accuracy_checker/configs/vehicle-detection-adas-binary-0001.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.xml
         weights: intel/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: vehicle_detection_dataset

--- a/tools/accuracy_checker/configs/vehicle-license-plate-detection-barrier-0106.yml
+++ b/tools/accuracy_checker/configs/vehicle-license-plate-detection-barrier-0106.yml
@@ -8,7 +8,6 @@ models:
         model:   intel/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
         weights: intel/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -16,7 +15,6 @@ models:
         model:   intel/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
         weights: intel/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -24,7 +22,6 @@ models:
         model:   intel/vehicle-license-plate-detection-barrier-0106/INT8/vehicle-license-plate-detection-barrier-0106.xml
         weights: intel/vehicle-license-plate-detection-barrier-0106/INT8/vehicle-license-plate-detection-barrier-0106.bin
         adapter: ssd
-        cpu_extensions: AUTO
 
     datasets:
       - name: vehicle_license_plate_detection

--- a/tools/accuracy_checker/configs/vgg19-caffe2.yml
+++ b/tools/accuracy_checker/configs/vgg19-caffe2.yml
@@ -25,7 +25,6 @@ models:
         model:   public/vgg19-caffe2/FP32/vgg19-caffe2.xml
         weights: public/vgg19-caffe2/FP32/vgg19-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
       - framework: dlsdk
         tags:
@@ -33,7 +32,6 @@ models:
         model:   public/vgg19-caffe2/FP16/vgg19-caffe2.xml
         weights: public/vgg19-caffe2/FP16/vgg19-caffe2.bin
         adapter: classification
-        cpu_extensions: AUTO
 
     datasets:
       - name: imagenet_1000_classes


### PR DESCRIPTION
removed cpu extensions from AC configs, they stay compatible with R3 due to cpu_extension in dataset_definitions.yml. After CI migration on pre-release package, cpu_extension from dataset_definitions will be also removed 