### PR TITLE
Add greedy matcher to smart classroom demo

### DIFF
--- a/demos/smart_classroom_demo/README.md
+++ b/demos/smart_classroom_demo/README.md
@@ -52,6 +52,7 @@ Options:
     -d_lm '<device>'               Optional. Specify the target device for Landmarks Regression Retail (the list of available devices is shown below). Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -d_reid '<device>'             Optional. Specify the target device for Face Reidentification Retail (the list of available devices is shown below). Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -out_v  '<path>'               Optional. File to write output video with visualization to.
+    -greedy_reid_matching          Optional. Use faster greedy matching algorithm in face reid.
     -pc                            Optional. Enables per-layer performance statistics.
     -r                             Optional. Output Inference results as raw values.
     -ad                            Optional. Output file name to save per-person action statistics in.

--- a/demos/smart_classroom_demo/include/face_reid.hpp
+++ b/demos/smart_classroom_demo/include/face_reid.hpp
@@ -36,7 +36,8 @@ public:
     EmbeddingsGallery(const std::string& ids_list, double threshold, int min_size_fr,
                       bool crop_gallery, detection::FaceDetection& detector,
                       const VectorCNN& landmarks_det,
-                      const VectorCNN& image_reid);
+                      const VectorCNN& image_reid,
+                      bool use_greedy_matcher=false);
     size_t size() const;
     std::vector<int> GetIDsByEmbeddings(const std::vector<cv::Mat>& embeddings) const;
     std::string GetLabelByID(int id) const;
@@ -55,6 +56,7 @@ private:
     std::vector<int> idx_to_id;
     double reid_threshold;
     std::vector<GalleryObject> identities;
+    bool use_greedy_matcher;
 };
 
 void AlignFaces(std::vector<cv::Mat>* face_images,

--- a/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
+++ b/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
@@ -45,6 +45,9 @@ static const char target_device_message_face_reid[] = "Optional. Specify the tar
                                                       "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                       "The application looks for a suitable plugin for the specified device.";
 
+/// @brief Message for greedy reid matching
+static const char greedy_reid_matching_message[] = "Optional. Use faster greedy matching algorithm in face reid.";
+
 /// @brief Message for performance counters
 static const char performance_counter_message[] = "Optional. Enables per-layer performance statistics.";
 
@@ -169,6 +172,9 @@ DEFINE_string(d_lm, "CPU", target_device_message_landmarks_regression);
 
 /// @brief device the target device for face reidentification infer on <br>
 DEFINE_string(d_reid, "CPU", target_device_message_face_reid);
+
+/// @brief Use greedy matching algorithm in face reid
+DEFINE_bool(greedy_reid_matching, false, greedy_reid_matching_message);
 
 /// @brief Enable per-layer performance report
 DEFINE_bool(pc, false, performance_counter_message);
@@ -307,6 +313,7 @@ static void showUsage() {
     std::cout << "    -d_lm '<device>'               " << target_device_message_landmarks_regression << std::endl;
     std::cout << "    -d_reid '<device>'             " << target_device_message_face_reid << std::endl;
     std::cout << "    -out_v  '<path>'               " << output_video_message << std::endl;
+    std::cout << "    -greedy_reid_matching          " << greedy_reid_matching_message << std::endl;
     std::cout << "    -pc                            " << performance_counter_message << std::endl;
     std::cout << "    -r                             " << raw_output_message << std::endl;
     std::cout << "    -ad                            " << act_stat_output_message << std::endl;

--- a/demos/smart_classroom_demo/include/tracker.hpp
+++ b/demos/smart_classroom_demo/include/tracker.hpp
@@ -40,7 +40,10 @@ using TrackedObjects = std::vector<TrackedObject>;
 ///
 class KuhnMunkres {
 public:
-    KuhnMunkres();
+    ///
+    /// \brief Initializes the class for assignment problem solving.
+    /// \param[in] greedy If a faster greedy matching algorithm should be used.
+    KuhnMunkres(bool greedy = false);
 
     ///
     /// \brief Solves the assignment problem for given dissimilarity matrix.

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -608,10 +608,9 @@ int main(int argc, char* argv[]) {
         VectorCNN landmarks_detector(landmarks_config);
 
         // Create face gallery
-        bool use_greedy_matcher = false;
         EmbeddingsGallery face_gallery(FLAGS_fg, FLAGS_t_reid, FLAGS_min_size_fr, FLAGS_crop_gallery,
                                        face_detector_for_registration, landmarks_detector, face_reid,
-                                       use_greedy_matcher);
+                                       FLAGS_greedy_reid_matching);
 
         if (!reid_config.enabled) {
             slog::warn << "Face recognition models are disabled!"  << slog::endl;

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -608,8 +608,10 @@ int main(int argc, char* argv[]) {
         VectorCNN landmarks_detector(landmarks_config);
 
         // Create face gallery
+        bool use_greedy_matcher = false;
         EmbeddingsGallery face_gallery(FLAGS_fg, FLAGS_t_reid, FLAGS_min_size_fr, FLAGS_crop_gallery,
-                                       face_detector_for_registration, landmarks_detector, face_reid);
+                                       face_detector_for_registration, landmarks_detector, face_reid,
+                                       use_greedy_matcher);
 
         if (!reid_config.enabled) {
             slog::warn << "Face recognition models are disabled!"  << slog::endl;

--- a/demos/smart_classroom_demo/src/reid_gallery.cpp
+++ b/demos/smart_classroom_demo/src/reid_gallery.cpp
@@ -84,8 +84,10 @@ EmbeddingsGallery::EmbeddingsGallery(const std::string& ids_list,
                                      double threshold, int min_size_fr,
                                      bool crop_gallery, detection::FaceDetection& detector,
                                      const VectorCNN& landmarks_det,
-                                     const VectorCNN& image_reid)
-    : reid_threshold(threshold) {
+                                     const VectorCNN& image_reid,
+                                     bool use_greedy_matcher)
+    : reid_threshold(threshold),
+      use_greedy_matcher(use_greedy_matcher) {
     if (ids_list.empty()) {
         return;
     }
@@ -147,7 +149,7 @@ std::vector<int> EmbeddingsGallery::GetIDsByEmbeddings(const std::vector<cv::Mat
             }
         }
     }
-    KuhnMunkres matcher;
+    KuhnMunkres matcher(use_greedy_matcher);
     auto matched_idx = matcher.Solve(distances);
     std::vector<int> output_ids;
     for (auto col_idx : matched_idx) {

--- a/demos/smart_classroom_demo/src/tracker.cpp
+++ b/demos/smart_classroom_demo/src/tracker.cpp
@@ -17,7 +17,7 @@ const int TrackedObject::UNKNOWN_LABEL_IDX = -1;
 
 class KuhnMunkres::Impl {
 public:
-    Impl() : n_() {}
+    Impl(bool greedy) : n_(), greedy_(greedy) {}
 
     std::vector<size_t> Solve(const cv::Mat &dissimilarity_matrix) {
         CV_Assert(dissimilarity_matrix.type() == CV_32F);
@@ -131,6 +131,10 @@ public:
 
     void Run() {
         TrySimpleCase();
+
+        if (greedy_)
+            return;
+
         while (!CheckIfOptimumIsFound()) {
             while (true) {
                 auto point = FindUncoveredMinValPos();
@@ -188,9 +192,10 @@ private:
     std::vector<int> is_col_visited_;
 
     int n_;
+    bool greedy_;
 };
 
-KuhnMunkres::KuhnMunkres() { impl_ = std::make_shared<Impl>(); }
+KuhnMunkres::KuhnMunkres(bool greedy) { impl_ = std::make_shared<Impl>(greedy); }
 
 std::vector<size_t> KuhnMunkres::Solve(const cv::Mat &dissimilarity_matrix) {
     CV_Assert(impl_ != nullptr);


### PR DESCRIPTION
The greedy matcher allows to run the demo in the cases when 
the number of gallery images is greater than 1000, although it
may decrease quality of face reidentification a bit.