### PR TITLE
OpenCV-ify object_detection_demo_faster_rcnn

### DIFF
--- a/demos/common/samples/common.hpp
+++ b/demos/common/samples/common.hpp
@@ -191,15 +191,15 @@ public:
           unsigned char g,
           unsigned char b) : _r(r), _g(g), _b(b) {}
 
-    inline unsigned char red() {
+    inline unsigned char red() const {
         return _r;
     }
 
-    inline unsigned char blue() {
+    inline unsigned char blue() const {
         return _b;
     }
 
-    inline unsigned char green() {
+    inline unsigned char green() const {
         return _g;
     }
 };
@@ -228,8 +228,6 @@ static UNUSED const Color CITYSCAPES_COLORS[] = {
     { 0,   74,  111 },
     { 81,  0,   81 }
 };
-
-// TODO : keep only one version of writeOutputBMP
 
 /**
  * @brief Writes output data to image
@@ -318,236 +316,6 @@ static UNUSED void writeOutputBmp(std::vector<std::vector<size_t>> data, size_t 
         }
         outFile.write(reinterpret_cast<char *>(pad), padSize);
     }
-}
-
-/**
-* @brief Writes output data to BMP image
-* @param name - image name
-* @param data - output data
-* @param height - height of the target image
-* @param width - width of the target image
-* @return false if error else true
-*/
-static UNUSED bool writeOutputBmp(std::string name, unsigned char *data, size_t height, size_t width) {
-    std::ofstream outFile;
-    outFile.open(name, std::ofstream::binary);
-    if (!outFile.is_open()) {
-        return false;
-    }
-
-    unsigned char file[14] = {
-        'B', 'M',           // magic
-        0, 0, 0, 0,         // size in bytes
-        0, 0,               // app data
-        0, 0,               // app data
-        40 + 14, 0, 0, 0      // start of data offset
-    };
-    unsigned char info[40] = {
-        40, 0, 0, 0,        // info hd size
-        0, 0, 0, 0,         // width
-        0, 0, 0, 0,         // height
-        1, 0,               // number color planes
-        24, 0,              // bits per pixel
-        0, 0, 0, 0,         // compression is none
-        0, 0, 0, 0,         // image bits size
-        0x13, 0x0B, 0, 0,   // horz resolution in pixel / m
-        0x13, 0x0B, 0, 0,   // vert resolution (0x03C3 = 96 dpi, 0x0B13 = 72 dpi)
-        0, 0, 0, 0,         // #colors in palette
-        0, 0, 0, 0,         // #important colors
-    };
-
-    if (height > (size_t)std::numeric_limits<int32_t>::max || width > (size_t)std::numeric_limits<int32_t>::max) {
-        THROW_IE_EXCEPTION << "File size is too big: " << height << " X " << width;
-    }
-
-    int padSize = static_cast<int>(4 - (width * 3) % 4) % 4;
-    int sizeData = static_cast<int>(width * height * 3 + height * padSize);
-    int sizeAll = sizeData + sizeof(file) + sizeof(info);
-
-    file[2] = (unsigned char)(sizeAll);
-    file[3] = (unsigned char)(sizeAll >> 8);
-    file[4] = (unsigned char)(sizeAll >> 16);
-    file[5] = (unsigned char)(sizeAll >> 24);
-
-    info[4] = (unsigned char)(width);
-    info[5] = (unsigned char)(width >> 8);
-    info[6] = (unsigned char)(width >> 16);
-    info[7] = (unsigned char)(width >> 24);
-
-    int32_t negativeHeight = -(int32_t)height;
-    info[8] = (unsigned char)(negativeHeight);
-    info[9] = (unsigned char)(negativeHeight >> 8);
-    info[10] = (unsigned char)(negativeHeight >> 16);
-    info[11] = (unsigned char)(negativeHeight >> 24);
-
-    info[20] = (unsigned char)(sizeData);
-    info[21] = (unsigned char)(sizeData >> 8);
-    info[22] = (unsigned char)(sizeData >> 16);
-    info[23] = (unsigned char)(sizeData >> 24);
-
-    outFile.write(reinterpret_cast<char *>(file), sizeof(file));
-    outFile.write(reinterpret_cast<char *>(info), sizeof(info));
-
-    unsigned char pad[3] = { 0, 0, 0 };
-
-    for (size_t y = 0; y < height; y++) {
-        for (size_t x = 0; x < width; x++) {
-            unsigned char pixel[3];
-            pixel[0] = data[y * width * 3 + x * 3];
-            pixel[1] = data[y * width * 3 + x * 3 + 1];
-            pixel[2] = data[y * width * 3 + x * 3 + 2];
-
-            outFile.write(reinterpret_cast<char *>(pixel), 3);
-        }
-        outFile.write(reinterpret_cast<char *>(pad), padSize);
-    }
-    return true;
-}
-
-
-/**
-* @brief Adds colored rectangles to the image
-* @param data - data where rectangles are put
-* @param height - height of the rectangle
-* @param width - width of the rectangle
-* @param rectangles - vector points for the rectangle, should be 4x compared to num classes
-* @param classes - vector of classes
-* @param thickness - thickness of a line (in pixels) to be used for bounding boxes
-*/
-static UNUSED void addRectangles(unsigned char *data, size_t height, size_t width, std::vector<int> rectangles, std::vector<int> classes, int thickness = 1) {
-    if (rectangles.size() % 4 != 0 || rectangles.size() / 4 != classes.size()) {
-        return;
-    }
-
-    for (size_t i = 0; i < classes.size(); i++) {
-        int x = rectangles.at(i * 4);
-        int y = rectangles.at(i * 4 + 1);
-        int w = rectangles.at(i * 4 + 2);
-        int h = rectangles.at(i * 4 + 3);
-
-        Color color = CITYSCAPES_COLORS[classes.at(i) % arraySize(CITYSCAPES_COLORS)]; // color of a bounding box line
-
-        if (x < 0) x = 0;
-        if (y < 0) y = 0;
-        if (w < 0) w = 0;
-        if (h < 0) h = 0;
-
-        if (static_cast<std::size_t>(x) >= width) { x = width - 1; w = 0; thickness = 1; }
-        if (static_cast<std::size_t>(y) >= height) { y = height - 1; h = 0; thickness = 1; }
-
-        if (static_cast<std::size_t>(x + w) >= width) { w = width - x - 1; }
-        if (static_cast<std::size_t>(y + h) >= height) { h = height - y - 1; }
-
-        thickness = std::min(std::min(thickness, w / 2 + 1), h / 2 + 1);
-
-        size_t shift_first;
-        size_t shift_second;
-        for (int t = 0; t < thickness; t++) {
-            shift_first = (y + t) * width * 3;
-            shift_second = (y + h - t) * width * 3;
-            for (int ii = x; ii < x + w + 1; ii++) {
-                data[shift_first + ii * 3] = color.red();
-                data[shift_first + ii * 3 + 1] = color.green();
-                data[shift_first + ii * 3 + 2] = color.blue();
-                data[shift_second + ii * 3] = color.red();
-                data[shift_second + ii * 3 + 1] = color.green();
-                data[shift_second + ii * 3 + 2] = color.blue();
-            }
-        }
-
-        for (int t = 0; t < thickness; t++) {
-            shift_first = (x + t) * 3;
-            shift_second = (x + w - t) * 3;
-            for (int ii = y; ii < y + h + 1; ii++) {
-                data[shift_first + ii * width * 3] = color.red();
-                data[shift_first + ii * width * 3 + 1] = color.green();
-                data[shift_first + ii * width * 3 + 2] = color.blue();
-                data[shift_second + ii * width * 3] = color.red();
-                data[shift_second + ii * width * 3 + 1] = color.green();
-                data[shift_second + ii * width * 3 + 2] = color.blue();
-            }
-        }
-    }
-}
-
-
-
-/**
- * Write output data to image
- * \param name - image name
- * \param data - output data
- * \param classesNum - the number of classes
- * \return false if error else true
- */
-
-static UNUSED bool writeOutputBmp(unsigned char *data, size_t height, size_t width, std::ostream &outFile) {
-    unsigned char file[14] = {
-            'B', 'M',           // magic
-            0, 0, 0, 0,         // size in bytes
-            0, 0,               // app data
-            0, 0,               // app data
-            40+14, 0, 0, 0      // start of data offset
-    };
-    unsigned char info[40] = {
-            40, 0, 0, 0,        // info hd size
-            0, 0, 0, 0,         // width
-            0, 0, 0, 0,         // height
-            1, 0,               // number color planes
-            24, 0,              // bits per pixel
-            0, 0, 0, 0,         // compression is none
-            0, 0, 0, 0,         // image bits size
-            0x13, 0x0B, 0, 0,   // horz resolution in pixel / m
-            0x13, 0x0B, 0, 0,   // vert resolution (0x03C3 = 96 dpi, 0x0B13 = 72 dpi)
-            0, 0, 0, 0,         // #colors in palette
-            0, 0, 0, 0,         // #important colors
-    };
-
-    if (height > (size_t)std::numeric_limits<int32_t>::max || width > (size_t)std::numeric_limits<int32_t>::max) {
-        THROW_IE_EXCEPTION << "File size is too big: " << height << " X " << width;
-    }
-
-    int padSize  = static_cast<int>(4 - (width * 3) % 4) % 4;
-    int sizeData = static_cast<int>(width * height * 3 + height * padSize);
-    int sizeAll  = sizeData + sizeof(file) + sizeof(info);
-
-    file[ 2] = (unsigned char)(sizeAll      );
-    file[ 3] = (unsigned char)(sizeAll >>  8);
-    file[ 4] = (unsigned char)(sizeAll >> 16);
-    file[ 5] = (unsigned char)(sizeAll >> 24);
-
-    info[ 4] = (unsigned char)(width      );
-    info[ 5] = (unsigned char)(width >>  8);
-    info[ 6] = (unsigned char)(width >> 16);
-    info[ 7] = (unsigned char)(width >> 24);
-
-    int32_t negativeHeight = -(int32_t)height;
-    info[ 8] = (unsigned char)(negativeHeight      );
-    info[ 9] = (unsigned char)(negativeHeight >>  8);
-    info[10] = (unsigned char)(negativeHeight >> 16);
-    info[11] = (unsigned char)(negativeHeight >> 24);
-
-    info[20] = (unsigned char)(sizeData      );
-    info[21] = (unsigned char)(sizeData >>  8);
-    info[22] = (unsigned char)(sizeData >> 16);
-    info[23] = (unsigned char)(sizeData >> 24);
-
-    outFile.write(reinterpret_cast<char*>(file), sizeof(file));
-    outFile.write(reinterpret_cast<char*>(info), sizeof(info));
-
-    unsigned char pad[3] = {0, 0, 0};
-
-    for (size_t y = 0; y < height; y++) {
-        for (size_t x = 0; x < width; x++) {
-            unsigned char pixel[3];
-            pixel[0] = data[y*width*3 + x*3];
-            pixel[1] = data[y*width*3 + x*3 + 1];
-            pixel[2] = data[y*width*3 + x*3 + 2];
-            outFile.write(reinterpret_cast<char *>(pixel), 3);
-        }
-        outFile.write(reinterpret_cast<char *>(pad), padSize);
-    }
-
-    return true;
 }
 
 static std::vector<std::pair<std::string, InferenceEngine::InferenceEngineProfileInfo>>

--- a/demos/object_detection_demo_faster_rcnn/CMakeLists.txt
+++ b/demos/object_detection_demo_faster_rcnn/CMakeLists.txt
@@ -6,4 +6,4 @@ ie_add_sample(NAME object_detection_demo_faster_rcnn
               SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
               HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/object_detection_demo_faster_rcnn.h"
                       "${CMAKE_CURRENT_SOURCE_DIR}/detectionoutput.h"
-              DEPENDENCIES format_reader)
+              OPENCV_DEPENDENCIES core imgcodecs imgproc)

--- a/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
+++ b/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
@@ -14,11 +14,6 @@
 #include <limits>
 #include <chrono>
 
-#include <format_reader_ptr.h>
-#include <inference_engine.hpp>
-
-#include "samples/common.hpp"
-
 /// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 


### PR DESCRIPTION
This allows us to remove a ton of redundant code, at the cost of a couple slight disadvantages:

* the demo now requires OpenCV to build, which shouldn't be a problem,   since nearly every other demo does so as well (the only exception being segmentation_demo);

* the demo no longer accepts files in the MNIST format as input, which also shouldn't be a problem, since it doesn't make sense to run object detection on the MNIST dataset.