### PR TITLE
AC: support 3 dim tensors for ONNX runtime

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/onnx_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/onnx_launcher.py
@@ -78,10 +78,13 @@ class ONNXLauncher(Launcher):
 
         return results
 
-    @staticmethod
-    def fit_to_input(data, layer_name, layout):
+    def fit_to_input(self, data, layer_name, layout):
+        layer_shape = self.inputs[layer_name]
         if len(np.shape(data)) == 4:
-            return np.transpose(data, layout).astype(np.float32)
+            data = np.transpose(data, layout).astype(np.float32)
+            if len(layer_shape) == 3:
+                return data[0]
+            return data
         if len(np.shape(data)) == 5 and len(layout) == 5:
             return np.transpose(data, layout).astype(np.float32)
         return np.array(data).astype(np.float32)

--- a/tools/accuracy_checker/accuracy_checker/launcher/onnx_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/onnx_launcher.py
@@ -83,6 +83,8 @@ class ONNXLauncher(Launcher):
         if len(np.shape(data)) == 4:
             data = np.transpose(data, layout).astype(np.float32)
             if len(layer_shape) == 3:
+                if np.shape(data)[0] != 1:
+                    raise ValueError('Only for batch size 1 first dimension can be omitted')
                 return data[0]
             return data
         if len(np.shape(data)) == 5 and len(layout) == 5:


### PR DESCRIPTION
make onnx runtime launcher work when batch is ommited.
it is necessary for Pytorch/ONNX mask rcnn support (e.g this [model](https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/mask-rcnn)) 