### PR TITLE
Fix parseDevices() to enumerate multi-VPUs

### DIFF
--- a/demos/common/samples/args_helper.hpp
+++ b/demos/common/samples/args_helper.hpp
@@ -109,7 +109,7 @@ inline std::vector<std::string> parseDevices(const std::string& device_string) {
 	std::string device_type = device_string.substr(0, colon_position);
 	if (device_type.compare("HETERO") == 0 || device_type.compare("MULTI") == 0) {
             std::string comma_separated_devices = device_string.substr(colon_position + 1);
-	    devices = split(comma_separated_devices, ',');
+	    std::vector<std::string> devices = split(comma_separated_devices, ',');
 	    for (auto& device : devices)
         	device = device.substr(0, device.find("("));
 	    return devices;

--- a/demos/common/samples/args_helper.hpp
+++ b/demos/common/samples/args_helper.hpp
@@ -103,14 +103,19 @@ inline std::vector<std::string> split(const std::string &s, char delim) {
 }
 
 inline std::vector<std::string> parseDevices(const std::string& device_string) {
-    std::string comma_separated_devices = device_string;
-    const std::string::size_type colon_position = comma_separated_devices.find(":");
+    std::vector<std::string> devices;
+    const std::string::size_type colon_position = device_string.find_first_of(":");
     if (colon_position != std::string::npos) {
-        comma_separated_devices = comma_separated_devices.substr(colon_position + 1);
+	std::string device_type = device_string.substr(0, colon_position);
+	if (device_type.compare("HETERO") == 0 || device_type.compare("MULTI") == 0) {
+            std::string comma_separated_devices = device_string.substr(colon_position + 1);
+	    devices = split(comma_separated_devices, ',');
+	    for (auto& device : devices)
+        	device = device.substr(0, device.find("("));
+	    return devices;
+	}
     }
-    auto devices = split(comma_separated_devices, ',');
-    for (auto& device : devices)
-        device = device.substr(0, device.find("("));
+    devices.push_back(device_string);
     return devices;
 }
 


### PR DESCRIPTION
In Linux, MYRIAD M.2 form factor enumurates as "MYRIAD./dev/mxlk0:0".
This conflicts with the current implementation of parseDevices
which accounts only for MULTI or HETERO having a":" in devicename.
This fix allows to have multiple ":" in devcename and yet parse them correctly.