### PR TITLE
AC: fix segmentation metrics for non-existed classes

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/metrics/semantic_segmentation.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/semantic_segmentation.py
@@ -91,7 +91,7 @@ class SegmentationIOU(SegmentationMetric):
         cm = super().update(annotation, prediction)
         diagonal = np.diag(cm).astype(float)
         union = cm.sum(axis=1) + cm.sum(axis=0) - diagonal
-        iou = np.divide(diagonal, union, out=np.zeros_like(diagonal), where=union != 0)
+        iou = np.divide(diagonal, union, out=np.full_like(diagonal, np.nan), where=union != 0)
 
         return iou
 
@@ -99,7 +99,7 @@ class SegmentationIOU(SegmentationMetric):
         confusion_matrix = self.state[self.CONFUSION_MATRIX_KEY]
         diagonal = np.diag(confusion_matrix)
         union = confusion_matrix.sum(axis=1) + confusion_matrix.sum(axis=0) - diagonal
-        iou = np.divide(diagonal, union, out=np.zeros_like(diagonal), where=union != 0)
+        iou = np.divide(diagonal, union, out=np.full_like(diagonal, np.nan), where=union != 0)
 
         values, names = finalize_metric_result(iou, list(self.dataset.labels.values()))
         self.meta['names'] = names
@@ -114,7 +114,7 @@ class SegmentationMeanAccuracy(SegmentationMetric):
         cm = super().update(annotation, prediction)
         diagonal = np.diag(cm).astype(float)
         per_class_count = cm.sum(axis=1)
-        acc_cls = np.divide(diagonal, per_class_count, out=np.zeros_like(diagonal), where=per_class_count != 0)
+        acc_cls = np.divide(diagonal, per_class_count, out=np.full_like(diagonal, np.nan), where=per_class_count != 0)
 
         return acc_cls
 
@@ -122,7 +122,7 @@ class SegmentationMeanAccuracy(SegmentationMetric):
         confusion_matrix = self.state[self.CONFUSION_MATRIX_KEY]
         diagonal = np.diag(confusion_matrix)
         per_class_count = confusion_matrix.sum(axis=1)
-        acc_cls = np.divide(diagonal, per_class_count, out=np.zeros_like(diagonal), where=per_class_count != 0)
+        acc_cls = np.divide(diagonal, per_class_count, out=np.full_like(diagonal, np.nan), where=per_class_count != 0)
 
         values, names = finalize_metric_result(acc_cls, list(self.dataset.labels.values()))
         self.meta['names'] = names

--- a/tools/accuracy_checker/tests/test_segmentation_metrics.py
+++ b/tools/accuracy_checker/tests/test_segmentation_metrics.py
@@ -87,7 +87,7 @@ class TestMeanAccuracy:
         dataset = single_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([1.0, 0.0], self.name, dataset.labels)
+        expected = generate_expected_result([1.0], self.name, {0: 'dog'})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 
@@ -97,7 +97,7 @@ class TestMeanAccuracy:
         dataset = multi_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([0.0, 0.0, 0.0, 0.0], self.name, dataset.labels)
+        expected = generate_expected_result([0.0], self.name, {0: 'cat'})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 
@@ -130,7 +130,7 @@ class TestMeanIOU:
         dataset = single_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([1.0, 0.0], self.name, dataset.labels)
+        expected = generate_expected_result([1.0], self.name, {0: 'dog'})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 
@@ -140,7 +140,7 @@ class TestMeanIOU:
         dataset = multi_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([0.0, 0.0, 0.0, 0.0], self.name, dataset.labels)
+        expected = generate_expected_result([0.0, 0.0], self.name, {0: 'dog', 1: 'cat'})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 

--- a/tools/accuracy_checker/tests/test_segmentation_metrics.py
+++ b/tools/accuracy_checker/tests/test_segmentation_metrics.py
@@ -87,7 +87,7 @@ class TestMeanAccuracy:
         dataset = single_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([1.0], self.name, {0: 'dog'})
+        expected = generate_expected_result([1.0], self.name, {0: dataset.labels[0]})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 
@@ -97,7 +97,7 @@ class TestMeanAccuracy:
         dataset = multi_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([0.0], self.name, {0: 'cat'})
+        expected = generate_expected_result([0.0], self.name, {1: dataset.labels[1]})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 
@@ -107,7 +107,7 @@ class TestMeanAccuracy:
         predictions = make_segmentation_representation(np.array([[1, 0, 3, 0, 0], [0, 0, 0, 0, 0]]), False)
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([1.0, 1.0, 0.0, 0.5], self.name, dataset.labels)
+        expected = generate_expected_result([1.0, 1.0, 0.0, 0.5], self.name, dataset.label_map)
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 
@@ -130,7 +130,7 @@ class TestMeanIOU:
         dataset = single_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([1.0], self.name, {0: 'dog'})
+        expected = generate_expected_result([1.0], self.name, {0: dataset.labels[0]})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 
@@ -140,7 +140,7 @@ class TestMeanIOU:
         dataset = multi_class_dataset()
         dispatcher = MetricsExecutor(create_config(self.name), dataset)
         dispatcher.update_metrics_on_batch(range(len(annotations)), annotations, predictions)
-        expected = generate_expected_result([0.0, 0.0], self.name, {0: 'dog', 1: 'cat'})
+        expected = generate_expected_result([0.0, 0.0], self.name, {0: dataset.labels[0], 1: dataset.labels[1]})
         for _, evaluation_result in dispatcher.iterate_metrics(annotations, predictions):
             assert evaluation_result == expected
 


### PR DESCRIPTION
metrics should ignore classes where predictions do not exists. Result finalization skip only nan, inf values and treat zero as valid result while for these metrics it means that label should be ignored (icnet/unet trained on camvid do not have objects for unlabled class and it should not affect metric result)