### PR TITLE
models: remove the --input_symbol option

### DIFF
--- a/models/public/octave-densenet-121-0.125/model.yml
+++ b/models/public/octave-densenet-121-0.125/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a01_densenet-121_alpha-0.125/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a01_densenet-121_alpha-0.125/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/models/public/octave-resnet-101-0.125/model.yml
+++ b/models/public/octave-resnet-101-0.125/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a06_resnet-101_alpha-0.125/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a06_resnet-101_alpha-0.125/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/models/public/octave-resnet-200-0.125/model.yml
+++ b/models/public/octave-resnet-200-0.125/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a08_resnet-200_alpha-0.125/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a08_resnet-200_alpha-0.125/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/models/public/octave-resnet-26-0.25/model.yml
+++ b/models/public/octave-resnet-26-0.25/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a02_resnet-26_alpha-0.250/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a02_resnet-26_alpha-0.250/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/models/public/octave-resnet-50-0.125/model.yml
+++ b/models/public/octave-resnet-50-0.125/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a03_resnet-50_alpha-0.125/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a03_resnet-50_alpha-0.125/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/models/public/octave-resnext-101-0.25/model.yml
+++ b/models/public/octave-resnext-101-0.25/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a07_resnext-101_32x4d_alpha-0.250/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a07_resnext-101_32x4d_alpha-0.250/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/models/public/octave-resnext-50-0.25/model.yml
+++ b/models/public/octave-resnext-50-0.25/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a04_resnext-50_32x4d_alpha-0.250/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a04_resnext-50_32x4d_alpha-0.250/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE

--- a/models/public/octave-se-resnet-50-0.125/model.yml
+++ b/models/public/octave-se-resnet-50-0.125/model.yml
@@ -46,6 +46,5 @@ model_optimizer_args:
   - --input=data
   - --output=softmax
   - --input_model=$dl_dir/a05_se-resnet-50_alpha-0.125/checkpoint-0-0000.params
-  - --input_symbol=$dl_dir/a05_se-resnet-50_alpha-0.125/checkpoint-0-symbol.json
 framework: mxnet
 license: https://raw.githubusercontent.com/facebookresearch/OctConv/master/LICENSE


### PR DESCRIPTION
Model Optimizer ignores it unless `--nd_prefix_name` and `--pretrained_model_name` are also specified, and in the next MO release, specifying this option alone is an error.