### PR TITLE
AC: update ONNX Runtime launcher for work with Execution Providers

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
@@ -2,9 +2,13 @@
 
 For enabling ONNX Runtime launcher you need to add `framework: onnx_runtime` in launchers section of your configuration file and provide following parameters:
 
-* `device` - specifies which device will be used for infer (`cpu`, `gpu` and so on).
+* `device` - specifies which device will be used for infer (`cpu`, `gpu` and so on). Optional, cpu used as default or can depend on used executable provider.
 * `model`- path to the network file in ONNX format.
 * `adapter` - approach how raw output will be converted to representation of dataset problem, some adapters can be specific to framework. You can find detailed instruction how to use adapters [here](../adapters/README.md).
+* `execution_providers` - list of execution providers for evaluation, e.g. [OpenVINO Execution Provider](https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/OpenVINO-ExecutionProvider.md). Default [`CPUExecutionProvider`] used. 
+
+**Note: execution providers available only with newest versions of ONNXRuntime, if your installed version does not support such API, please update or does not specify this field.**
+
 
 # Specifying model inputs in config.
 

--- a/tools/accuracy_checker/tests/test_onnx_launcher.py
+++ b/tools/accuracy_checker/tests/test_onnx_launcher.py
@@ -23,14 +23,25 @@ import numpy as np
 from accuracy_checker.launcher.launcher import create_launcher
 from accuracy_checker.config import ConfigError
 
+def old_onnxrunitme(models_dir):
+    import onnxruntime as rt
+    sess = rt.InferenceSession(str(models_dir / "samplenet.onnx"))
+    try:
+        sess.get_providers()
+        return False
+    except AttributeError:
+        return True
 
-def get_onnx_test_model(models_dir):
+def get_onnx_test_model(models_dir, device=None, ep=None):
     config = {
         "framework": "onnx_runtime",
         "model": str(models_dir / "samplenet.onnx"),
         "adapter": "classification",
-        "device": "cpu",
     }
+    if device is not None:
+        config['device'] = device
+    if ep is not None:
+        config['execution_providers'] = ep
     return create_launcher(config)
 
 
@@ -41,15 +52,26 @@ class TestONNXRuntimeLauncher:
         assert launcher.output_blob == 'fc3'
 
     def test_infer(self, data_dir, models_dir):
-        mx_test_model = get_onnx_test_model(models_dir)
-        _, _, h, w = mx_test_model.inputs['data']
+        onnx_test_model = get_onnx_test_model(models_dir)
+        _, _, h, w = onnx_test_model.inputs['data']
         img_raw = cv2.imread(str(data_dir / '1.jpg'))
         img_rgb = cv2.cvtColor(img_raw, cv2.COLOR_BGR2RGB)
         img_resized = cv2.resize(img_rgb, (w, h))
         input_blob = np.transpose([img_resized], (0, 3, 1, 2))
-        res = mx_test_model.predict([{'data': input_blob.astype(np.float32)}], [{}])
+        res = onnx_test_model.predict([{'data': input_blob.astype(np.float32)}], [{}])
 
         assert np.argmax(res[0]['fc3']) == 7
+
+    def test_infer_with_execution_provider(self, data_dir, models_dir):
+        if old_onnxrunitme(models_dir):
+            pytest.skip(reason="onnxruntime does not support EP")
+        onnx_test_model = get_onnx_test_model(models_dir, ep=['CPUExecutionProvider'])
+        _, _, h, w = onnx_test_model.inputs['data']
+        img_raw = cv2.imread(str(data_dir / '1.jpg'))
+        img_rgb = cv2.cvtColor(img_raw, cv2.COLOR_BGR2RGB)
+        img_resized = cv2.resize(img_rgb, (w, h))
+        input_blob = np.transpose([img_resized], (0, 3, 1, 2))
+        res = onnx_test_model.predict([{'data': input_blob.astype(np.float32)}], [{}])
 
 
 @pytest.mark.usefixtures('mock_path_exists')


### PR DESCRIPTION
new ONNX Runtime has ability of hardware acceleration with [Execution Providers API](https://github.com/microsoft/onnxruntime#high-performance). One of EP is [OpenVINO](https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/OpenVINO-ExecutionProvider.md), on my view, it is potentially important to be able evaluate ONNX models with this API.

old Backend API feautres stayed for backward compatibility.