### PR TITLE
AC: support MO transformations config option

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/config/config_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_reader.py
@@ -433,6 +433,7 @@ class ConfigReader:
         additional_keys = [
             'model_optimizer', 'tf_custom_op_config_dir',
             'tf_obj_detection_api_pipeline_config_path',
+            'transformations_config_dir',
             'cpu_extensions_mode', 'vpu_log_level'
         ]
         arguments_dict = arguments if isinstance(arguments, dict) else vars(arguments)

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -200,7 +200,7 @@ class DLSDKLauncher(Launcher):
                 optional=True, is_directory=True, description="TF Custom Operation Config prefix."
             ),
             '_transformations_config_dir': PathField(
-                optional=True, is_directory=True, description="Transformation config for Model Optimizer"),
+                optional=True, is_directory=True, description="Transformation config prefix for Model Optimizer"),
             '_tf_obj_detection_api_pipeline_config_path': PathField(
                 optional=True, is_directory=False, description="TF Custom Operation Pipeline Config."),
             '_cpu_extensions_mode': StringField(optional=True, description="CPU extensions mode."),

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -197,8 +197,10 @@ class DLSDKLauncher(Launcher):
                 optional=True, is_directory=True, description="TF Object Detection API Config."
             ),
             '_tf_custom_op_config_dir': PathField(
-                optional=True, is_directory=True, description="TF Custom Operation Config."
+                optional=True, is_directory=True, description="TF Custom Operation Config prefix."
             ),
+            '_transformations_config_dir': PathField(
+                optional=True, is_directory=False, description="Transformation config for Model Optimizer"),
             '_tf_obj_detection_api_pipeline_config_path': PathField(
                 optional=True, is_directory=False, description="TF Custom Operation Pipeline Config."),
             '_cpu_extensions_mode': StringField(optional=True, description="CPU extensions mode."),
@@ -437,8 +439,12 @@ class DLSDKLauncher(Launcher):
             get_parameter_value_from_config(config, DLSDKLauncher.parameters(), 'mo_params'),
             get_parameter_value_from_config(config, DLSDKLauncher.parameters(), 'mo_flags'),
             get_parameter_value_from_config(config, DLSDKLauncher.parameters(), '_tf_custom_op_config_dir'),
-            get_parameter_value_from_config(config, DLSDKLauncher.parameters(),
-                                            '_tf_obj_detection_api_pipeline_config_path'),
+            get_parameter_value_from_config(
+                config, DLSDKLauncher.parameters(), '_tf_obj_detection_api_pipeline_config_path'
+            ),
+            get_parameter_value_from_config(
+                config, DLSDKLauncher.parameters(), '_transformations_config_dir'
+            ),
             should_log_cmd=should_log_mo_cmd
         )
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -200,7 +200,7 @@ class DLSDKLauncher(Launcher):
                 optional=True, is_directory=True, description="TF Custom Operation Config prefix."
             ),
             '_transformations_config_dir': PathField(
-                optional=True, is_directory=False, description="Transformation config for Model Optimizer"),
+                optional=True, is_directory=True, description="Transformation config for Model Optimizer"),
             '_tf_obj_detection_api_pipeline_config_path': PathField(
                 optional=True, is_directory=False, description="TF Custom Operation Pipeline Config."),
             '_cpu_extensions_mode': StringField(optional=True, description="CPU extensions mode."),

--- a/tools/accuracy_checker/accuracy_checker/launcher/model_conversion.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/model_conversion.py
@@ -209,7 +209,7 @@ def set_path_to_tf_custom_operation_configs(
 
 
 def set_path_to_transformation_configs(mo_params, framework, transformation_config_dir, mo_path):
-    transformation_config_path = mo_params.get('tensorflow_use_custom_operations_config')
+    transformation_config_path = mo_params.get('transformations_config')
     if not transformation_config_path:
         return mo_params
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/model_conversion.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/model_conversion.py
@@ -27,7 +27,9 @@ FrameworkParameters = namedtuple('FrameworkParameters', ['name', 'meta'])
 
 def convert_model(topology_name, model=None, weights=None, meta=None,
                   framework=FrameworkParameters('caffe', False), mo_search_paths=None, mo_params=None, mo_flags=None,
-                  tf_custom_op_config_dir=None, tf_object_detection_api_config_dir=None, should_log_cmd=False):
+                  tf_custom_op_config_dir=None, tf_object_detection_api_config_dir=None,
+                  transformations_config_dir=None,
+                  should_log_cmd=False):
     """
     Args:
         topology_name: name for converted model files.
@@ -38,8 +40,10 @@ def convert_model(topology_name, model=None, weights=None, meta=None,
         mo_search_paths: paths where ModelOptimizer may be found. If None only default paths is used.
         mo_params: value parameters for ModelOptimizer execution.
         mo_flags: flags parameters for ModelOptimizer execution.
-        tf_custom_op_config_dir: path to Tensor Flow custom operations directory.
+        tf_custom_op_config_dir: path to TensorFlow custom operations directory.
+        transformations_config_dir: path to Model Optimizer transformations extensions directory.
         tf_object_detection_api_config_dir: path to Tensor Flow directory with config for object detection API.
+        should_log_cmd: allows print out command line arguments for Model Downloader.
     Returns:
         paths to converted to IE IR model and weights.
     """
@@ -68,7 +72,9 @@ def convert_model(topology_name, model=None, weights=None, meta=None,
     mo_params['framework'] = framework.name
     mo_params.update(framework_specific_options.get(framework, {}))
 
-    set_path_to_custom_operation_configs(mo_params, framework, tf_custom_op_config_dir, model_optimizer_executable)
+    set_path_to_custom_operation_configs(
+        mo_params, framework, tf_custom_op_config_dir, transformations_config_dir, model_optimizer_executable
+    )
     set_path_to_object_detection_api_pipeline_config(mo_params, framework, tf_object_detection_api_config_dir)
     args = prepare_args(str(model_optimizer_executable), flag_options=mo_flags, value_options=mo_params)
 
@@ -162,6 +168,7 @@ def print_cmd(args, indent=0):
     if arr_to_print:
         print_info(indent_str + " ".join(arr_to_print))
 
+
 def exec_mo_binary(args, timeout=None, should_log_cmd=False):
     """
     Args:
@@ -177,24 +184,35 @@ def exec_mo_binary(args, timeout=None, should_log_cmd=False):
     return subprocess.run(args, check=False, timeout=timeout)
 
 
-def set_path_to_custom_operation_configs(mo_params, framework, tf_custom_op_config_dir, mo_path):
+def set_path_to_custom_operation_configs(
+        mo_params, framework, tf_custom_op_config_dir, transformations_config_dir, mo_path
+):
     if framework.name != 'tf':
         return mo_params
 
-    config_path = mo_params.get('tensorflow_use_custom_operations_config')
-    if not config_path:
+    tf_custom_op_config_path = mo_params.get('tensorflow_use_custom_operations_config')
+    transformations_config = mo_params.get('transformations_config')
+    if not tf_custom_op_config_path and not transformations_config:
         return mo_params
 
     if tf_custom_op_config_dir:
-        tf_custom_op_config_dir = Path(tf_custom_op_config_dir)
+        prefix_dir = Path(tf_custom_op_config_dir)
+    elif transformations_config_dir:
+        prefix_dir = Path(transformations_config_dir)
     else:
-        tf_custom_op_config_dir = Path('/').joinpath(*mo_path.parts[:-1]) / 'extensions' / 'front' / 'tf'
+        prefix_dir = Path('/').joinpath(*mo_path.parts[:-1]) / 'extensions' / 'front' / 'tf'
 
-    config_path = Path(config_path)
+    if tf_custom_op_config_path:
+        config_path = Path(tf_custom_op_config_path)
+        if not config_path.is_absolute():
+            config_path = prefix_dir / config_path
+            mo_params['tensorflow_use_custom_operations_config'] = str(get_path(config_path))
+        return mo_params
+
+    config_path = Path(transformations_config)
     if not config_path.is_absolute():
-        config_path = tf_custom_op_config_dir / config_path
-
-    mo_params['tensorflow_use_custom_operations_config'] = str(get_path(config_path))
+        config_path = prefix_dir / config_path
+        mo_params['transformations_config'] = str(get_path(config_path))
 
     return mo_params
 

--- a/tools/accuracy_checker/accuracy_checker/main.py
+++ b/tools/accuracy_checker/accuracy_checker/main.py
@@ -108,7 +108,15 @@ def build_arguments_parser():
     )
     parser.add_argument(
         '--tf_custom_op_config_dir',
-        help='path to directory with tensorflow custom operation configuration files for model optimizer',
+        help='path to directory with Model Optimizer transformation configuration files',
+        type=partial(get_path, is_directory=True),
+        # there is no default value because if user did not specify it we use specific location
+        # defined in model_conversion.py
+        required=False
+    )
+    parser.add_argument(
+        '--transformations_config_dir',
+        help='path to directory with Model Optimizer transformations configuration files',
         type=partial(get_path, is_directory=True),
         # there is no default value because if user did not specify it we use specific location
         # defined in model_conversion.py

--- a/tools/accuracy_checker/accuracy_checker/main.py
+++ b/tools/accuracy_checker/accuracy_checker/main.py
@@ -108,7 +108,7 @@ def build_arguments_parser():
     )
     parser.add_argument(
         '--tf_custom_op_config_dir',
-        help='path to directory with Model Optimizer transformation configuration files',
+        help='path to directory with tensorflow custom operation configuration files for model optimizer',
         type=partial(get_path, is_directory=True),
         # there is no default value because if user did not specify it we use specific location
         # defined in model_conversion.py

--- a/tools/accuracy_checker/tests/test_config_reader.py
+++ b/tools/accuracy_checker/tests/test_config_reader.py
@@ -88,7 +88,7 @@ class TestConfigReader:
             'bitstreams': Path('bitstreams/'),
             'definitions': None,
             'stored_predictions': None,
-            'tf_custom_op_config': None,
+            'tf_custom_op_config_dir': None,
             'tf_obj_detection_api_pipeline_config_path': None,
             'progress': 'bar',
             'target_framework': None,
@@ -97,7 +97,8 @@ class TestConfigReader:
             'target_tags': None,
             'cpu_extensions_mode': None,
             'aocl': None,
-            'deprecated_ir_v7': False
+            'deprecated_ir_v7': False,
+            'transformations_config_dir': None
         })
 
     def test_read_configs_without_global_config(self, mocker):
@@ -109,10 +110,10 @@ class TestConfigReader:
         empty_args = Namespace(**{
             'models': Path.cwd(), 'extensions': Path.cwd(), 'source': Path.cwd(), 'annotations': Path.cwd(),
             'converted_models': None, 'model_optimizer': None, 'bitstreams': Path.cwd(),
-            'definitions': None, 'config': None, 'stored_predictions': None, 'tf_custom_op_config': None,
+            'definitions': None, 'config': None, 'stored_predictions': None, 'tf_custom_op_config_dir': None,
             'progress': 'bar', 'target_framework': None, 'target_devices': None, 'log_file': None,
             'tf_obj_detection_api_pipeline_config_path': None, 'target_tags': None, 'cpu_extensions_mode': None,
-            'aocl': None, 'deprecated_ir_v7': False
+            'aocl': None, 'deprecated_ir_v7': False, 'transformations_config_dir': None
         })
         mocker.patch('accuracy_checker.utils.get_path', return_value=Path.cwd())
         mocker.patch('yaml.load', return_value=config)

--- a/tools/accuracy_checker/tests/test_dlsdk_launcher.py
+++ b/tools/accuracy_checker/tests/test_dlsdk_launcher.py
@@ -354,7 +354,7 @@ class TestDLSDKLauncher:
         mock.assert_called_once_with(
             'custom_model', '/path/to/source_models/custom_model', '/path/to/source_models/custom_weights', '',
             FrameworkParameters('caffe', False),
-            [], None, None, None, None, should_log_cmd=False
+            [], None, None, None, None, None, should_log_cmd=False
         )
 
     def test_model_converted_with_mo_params(self, mocker):
@@ -379,7 +379,7 @@ class TestDLSDKLauncher:
         mock.assert_called_once_with(
             'custom_model', '/path/to/source_models/custom_model', '/path/to/source_models/custom_weights', '',
             FrameworkParameters('caffe', False),
-            [], {'data_type': 'FP16'}, None, None, None, should_log_cmd=False
+            [], {'data_type': 'FP16'}, None, None, None, None, should_log_cmd=False
         )
 
     def test_model_converted_with_mo_flags(self, mocker):
@@ -405,7 +405,7 @@ class TestDLSDKLauncher:
         mock.assert_called_once_with(
             'custom_model', '/path/to/source_models/custom_model', '/path/to/source_models/custom_weights', '',
             FrameworkParameters('caffe', False),
-            [], None, ['reverse_input_channels'], None, None, should_log_cmd=False
+            [], None, ['reverse_input_channels'], None, None, None, should_log_cmd=False
         )
 
     def test_model_converted_to_output_dir_in_mo_params(self, mocker):
@@ -451,7 +451,7 @@ class TestDLSDKLauncher:
 
         mock.assert_called_once_with(
             'custom_model', '/path/to/source_models/custom_model', '', '',
-            FrameworkParameters('tf', False), [], None, None, None, None,
+            FrameworkParameters('tf', False), [], None, None, None, None, None,
             should_log_cmd=False
         )
 
@@ -473,7 +473,7 @@ class TestDLSDKLauncher:
 
         mock.assert_called_once_with(
             'custom_model', '', '', '/path/to/source_models/custom_model',
-            FrameworkParameters('tf', True), [], None, None, None, None,
+            FrameworkParameters('tf', True), [], None, None, None, None, None,
             should_log_cmd=False
         )
 
@@ -565,7 +565,6 @@ class TestDLSDKLauncher:
             '_models_prefix': '/path/to',
             'adapter': 'classification',
             'mo_params': {'tensorflow_object_detection_api_pipeline_config': 'operations.config'},
-            '_tf_custom_op_config_dir': 'config/dir',
             '_tf_obj_detection_api_pipeline_config_path': 'od_api'
         }
         mocker.patch('accuracy_checker.launcher.model_conversion.find_mo', return_value=Path('/path/ModelOptimizer'))
@@ -612,7 +611,7 @@ class TestDLSDKLauncher:
         DLSDKLauncher(config)
         prepare_args_patch.assert_called_once_with('/path/ModelOptimizer', flag_options=[], value_options=args)
 
-    def test_model_converted_from_tf_checkoint_with_default_path_to_custom_tf_config(self, mocker):
+    def test_model_converted_from_tf_checkpoint_with_default_path_to_custom_tf_config(self, mocker):
         config = {
             'framework': 'dlsdk',
             'tf_meta': '/path/to/source_models/custom_model',
@@ -638,7 +637,7 @@ class TestDLSDKLauncher:
         DLSDKLauncher(config)
         prepare_args_patch.assert_called_once_with('/path/ModelOptimizer', flag_options=[], value_options=args)
 
-    def test_model_converted_from_tf_checkoint_with_default_path_to_obj_detection_api_config(self, mocker):
+    def test_model_converted_from_tf_checkpoint_with_default_path_to_obj_detection_api_config(self, mocker):
         config = {
             'framework': 'dlsdk',
             'tf_meta': '/path/to/source_models/custom_model',
@@ -693,6 +692,59 @@ class TestDLSDKLauncher:
         DLSDKLauncher(config)
         prepare_args_patch.assert_called_once_with('/path/ModelOptimizer', flag_options=[], value_options=args)
 
+    def test_model_converted_from_tf_checkpoint_with_arg_path_to_transformations_config(self, mocker):
+        config = {
+            'framework': 'dlsdk',
+            'tf_meta': '/path/to/source_models/custom_model',
+            'device': 'cpu',
+            '_models_prefix': '/path/to',
+            'adapter': 'classification',
+            'mo_params': {'transformations_config': 'ssd_v2_support.json'},
+            '_transformations_config_dir': 'config/dir'
+        }
+        mocker.patch('accuracy_checker.launcher.model_conversion.find_mo', return_value=Path('/path/ModelOptimizer'))
+        prepare_args_patch = mocker.patch('accuracy_checker.launcher.model_conversion.prepare_args')
+
+        args = {
+            'input_meta_graph': '/path/to/source_models/custom_model',
+            'model_name': 'custom_model',
+            'framework': 'tf',
+            'transformations_config': 'config/dir/ssd_v2_support.json'
+        }
+
+        mocker.patch(
+            'accuracy_checker.launcher.model_conversion.exec_mo_binary',
+            return_value=subprocess.CompletedProcess(args, returncode=0)
+        )
+        DLSDKLauncher(config)
+        prepare_args_patch.assert_called_once_with('/path/ModelOptimizer', flag_options=[], value_options=args)
+
+    def test_model_converted_from_tf_checkpoint_with_default_path_to_transformations_config(self, mocker):
+        config = {
+            'framework': 'dlsdk',
+            'tf_meta': '/path/to/source_models/custom_model',
+            'device': 'cpu',
+            '_models_prefix': '/path/to',
+            'adapter': 'classification',
+            'mo_params': {'transformations_config': 'config.json'}
+        }
+        mocker.patch('accuracy_checker.launcher.model_conversion.find_mo', return_value=Path('/path/ModelOptimizer'))
+        prepare_args_patch = mocker.patch('accuracy_checker.launcher.model_conversion.prepare_args')
+
+        args = {
+            'input_meta_graph': '/path/to/source_models/custom_model',
+            'model_name': 'custom_model',
+            'framework': 'tf',
+            'transformations_config': '/path/extensions/front/tf/config.json'
+        }
+
+        mocker.patch(
+            'accuracy_checker.launcher.model_conversion.exec_mo_binary',
+            return_value=subprocess.CompletedProcess(args, returncode=0)
+        )
+        DLSDKLauncher(config)
+        prepare_args_patch.assert_called_once_with('/path/ModelOptimizer', flag_options=[], value_options=args)
+
     def test_model_converted_from_mxnet(self, mocker):
         mock = mocker.patch(
             'accuracy_checker.launcher.dlsdk_launcher.convert_model',
@@ -711,7 +763,7 @@ class TestDLSDKLauncher:
 
         mock.assert_called_once_with(
             'custom_weights', '', '/path/to/source_models/custom_weights', '',
-            FrameworkParameters('mxnet', False), [], None, None, None, None,
+            FrameworkParameters('mxnet', False), [], None, None, None, None, None,
             should_log_cmd=False
         )
 
@@ -733,7 +785,7 @@ class TestDLSDKLauncher:
 
         mock.assert_called_once_with(
             'custom_model', '/path/to/source_models/custom_model', '', '',
-            FrameworkParameters('onnx', False), [], None, None, None, None,
+            FrameworkParameters('onnx', False), [], None, None, None, None, None,
             should_log_cmd=False
         )
 
@@ -755,7 +807,7 @@ class TestDLSDKLauncher:
 
         mock.assert_called_once_with(
             'custom_model', '/path/to/source_models/custom_model', '', '',
-            FrameworkParameters('kaldi', False), [], None, None, None, None,
+            FrameworkParameters('kaldi', False), [], None, None, None, None, None,
             should_log_cmd=False
         )
 


### PR DESCRIPTION
`--tf_custom_operation_config` option in MO is deprecated in this release.  (now in the latest versions DLDT, it raises deprecation warning). MO team recommend to replace it with `--transformations_config` 

P.S. Probably it also should affect Model Downloader configs for some TF models.