### PR TITLE
AC: support Yolo v3 with mask parameter in output

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -39,6 +39,7 @@ AccuracyChecker supports following set of adapters:
     - `tiny_yolo_v3` - `[10.0, 14.0, 23.0, 27.0, 37.0, 58.0, 81.0, 82.0, 135.0, 169.0, 344.0, 319.0]`
   * `coords` - number of bbox coordinates (default 4).
   * `num` - num parameter from DarkNet configuration file (default 3).
+  * `anchor_mask` - mask for used anchors for each output layer (Optional, if not provided default way for selecting anchors will be used.)
   * `threshold` - minimal objectness score value for valid detections (default 0.001).
   * `input_width` and `input_height` - network input width and height correspondingly (default 416).
   * `outputs` - the list of output layers names (optional), if specified there should be exactly 3 output layers provided.


### PR DESCRIPTION
same yolo v3 models has parameter `mask` for selection anchors for specific output layer.
yolo v3 demo is able to handle this case correctly because it check layer parameters and process using OpenVINO specifically approach.
Unforutnately, accuracy checker detections processing is framework agnostic. It is the reason why we need to put this parameter explicitly in the config.