### PR TITLE
Simplify post-processing in object_detection_demo_faster_rcnn

### DIFF
--- a/demos/object_detection_demo_faster_rcnn/detectionoutput.h
+++ b/demos/object_detection_demo_faster_rcnn/detectionoutput.h
@@ -34,19 +34,8 @@ public:
         try {
             IE_ASSERT(4 == image_dims.size());
 
-            _background_label_id = 0;
-            _top_k = 400;
-            _variance_encoded_in_target = true;
-            _keep_top_k = 200;
-            _nms_threshold = 0.3;
-            _confidence_threshold = -FLT_MAX;
-            _share_location = false;
-            _normalized = false;
             _image_height = image_dims[2];
             _image_width = image_dims[3];
-            _prior_size = 5;
-            _offset = 1;
-            _code_type = CodeType::CENTER_SIZE;
 
             IE_ASSERT(2 <=  prior_dims.size());
             int priors_size = prior_dims[prior_dims.size() - 2] * prior_dims[prior_dims.size() - 1];
@@ -138,22 +127,15 @@ public:
         const float *ppriors = prior_data;
 
         for (int n = 0; n < N; ++n) {
-            if (_share_location) {
-                const float *ploc = loc_data + n*4*_num_priors;
-                float *pboxes = decoded_bboxes_data + n*4*_num_priors;
-                float *psizes = bbox_sizes_data + n*_num_priors;
-                decodeBBoxes(ppriors, ploc, prior_variances, pboxes, psizes, num_priors_actual, n);
-            } else {
-                for (int c = 0; c < _num_loc_classes; ++c) {
-                    if (c == _background_label_id) {
-                        continue;
-                    }
-
-                    const float *ploc = loc_data + n*4*_num_loc_classes*_num_priors + c*4;
-                    float *pboxes = decoded_bboxes_data + n*4*_num_loc_classes*_num_priors + c*4*_num_priors;
-                    float *psizes = bbox_sizes_data + n*_num_loc_classes*_num_priors + c*_num_priors;
-                    decodeBBoxes(ppriors, ploc, prior_variances, pboxes, psizes, num_priors_actual, n);
+            for (int c = 0; c < _num_loc_classes; ++c) {
+                if (c == _background_label_id) {
+                    continue;
                 }
+
+                const float *ploc = loc_data + n*4*_num_loc_classes*_num_priors + c*4;
+                float *pboxes = decoded_bboxes_data + n*4*_num_loc_classes*_num_priors + c*4*_num_priors;
+                float *psizes = bbox_sizes_data + n*_num_loc_classes*_num_priors + c*_num_priors;
+                decodeBBoxes(ppriors, ploc, prior_variances, pboxes, psizes, num_priors_actual, n);
             }
         }
 
@@ -181,15 +163,8 @@ public:
                 int *pdetections = detections_data + n*_num_classes + c;
 
                 const float *pconf = reordered_conf_data + n*_num_classes*_num_priors + c*_num_priors;
-                const float *pboxes;
-                const float *psizes;
-                if (_share_location) {
-                    pboxes = decoded_bboxes_data + n*4*_num_priors;
-                    psizes = bbox_sizes_data + n*_num_priors;
-                } else {
-                    pboxes = decoded_bboxes_data + n*4*_num_classes*_num_priors + c*4*_num_priors;
-                    psizes = bbox_sizes_data + n*_num_classes*_num_priors + c*_num_priors;
-                }
+                const float *pboxes = decoded_bboxes_data + n*4*_num_classes*_num_priors + c*4*_num_priors;
+                const float *psizes = bbox_sizes_data + n*_num_classes*_num_priors + c*_num_priors;
 
                 nms(pconf, pboxes, psizes, pbuffer, pindices, *pdetections, num_priors_actual[n]);
             }
@@ -256,14 +231,10 @@ public:
                     dst_data[count * DETECTION_SIZE + 1] = static_cast<float>(c);
                     dst_data[count * DETECTION_SIZE + 2] = pconf[c*_num_priors + idx];
 
-                    float xmin = _share_location ? pboxes[idx*4 + 0] :
-                                 pboxes[c*4*_num_priors + idx*4 + 0];
-                    float ymin = _share_location ? pboxes[idx*4 + 1] :
-                                 pboxes[c*4*_num_priors + idx*4 + 1];
-                    float xmax = _share_location ? pboxes[idx*4 + 2] :
-                                 pboxes[c*4*_num_priors + idx*4 + 2];
-                    float ymax = _share_location ? pboxes[idx*4 + 3] :
-                                 pboxes[c*4*_num_priors + idx*4 + 3];
+                    float xmin = pboxes[c*4*_num_priors + idx*4 + 0];
+                    float ymin = pboxes[c*4*_num_priors + idx*4 + 1];
+                    float xmax = pboxes[c*4*_num_priors + idx*4 + 2];
+                    float ymax = pboxes[c*4*_num_priors + idx*4 + 3];
 
                     dst_data[count * DETECTION_SIZE + 3] = xmin;
                     dst_data[count * DETECTION_SIZE + 4] = ymin;
@@ -290,30 +261,20 @@ private:
 
 
     int _num_classes = 0;
-    int _background_label_id = 0;
-    int _top_k = 0;
-    int _variance_encoded_in_target = 0;
-    int _keep_top_k = 0;
-    int _code_type = 0;
-
-    bool _share_location = false;
+    const int _background_label_id = 0;
+    const int _top_k = 400;
+    const int _keep_top_k = 200;
 
     int _image_width = 0;
     int _image_height = 0;
-    int _prior_size = 4;
-    bool _normalized = true;
-    int _offset = 0;
+    const int _prior_size = 5;
+    const int _offset = 1;
 
-    float _nms_threshold = 0.0f;
-    float _confidence_threshold = 0.0f;
+    const float _nms_threshold = 0.3f;
+    const float _confidence_threshold = -FLT_MAX;
 
     int _num_loc_classes = 0;
     int _num_priors = 0;
-
-    enum CodeType {
-        CORNER = 1,
-        CENTER_SIZE = 2,
-    };
 
     void decodeBBoxes(const float *prior_data, const float *loc_data, const float *variance_data,
                       float *decoded_bboxes, float *decoded_bbox_sizes, int* num_priors_actual, int n);
@@ -387,14 +348,12 @@ void DetectionOutputPostProcessor::decodeBBoxes(const float *prior_data,
                                    int* num_priors_actual,
                                    int n) {
     num_priors_actual[n] = _num_priors;
-    if (!_normalized) {
-        int num = 0;
-        for (; num < _num_priors; ++num) {
-            float batch_id = prior_data[num * _prior_size + 0];
-            if (batch_id == -1.f) {
-                num_priors_actual[n] = num;
-                break;
-            }
+
+    for (int num = 0; num < _num_priors; ++num) {
+        float batch_id = prior_data[num * _prior_size + 0];
+        if (batch_id == -1.f) {
+            num_priors_actual[n] = num;
+            break;
         }
     }
 
@@ -414,54 +373,29 @@ void DetectionOutputPostProcessor::decodeBBoxes(const float *prior_data,
         float loc_xmax = loc_data[4*p*_num_loc_classes + 2];
         float loc_ymax = loc_data[4*p*_num_loc_classes + 3];
 
-        if (!_normalized) {
-            prior_xmin /= _image_width;
-            prior_ymin /= _image_height;
-            prior_xmax /= _image_width;
-            prior_ymax /= _image_height;
-        }
+        prior_xmin /= _image_width;
+        prior_ymin /= _image_height;
+        prior_xmax /= _image_width;
+        prior_ymax /= _image_height;
 
-        if (_code_type == CodeType::CORNER) {
-            if (_variance_encoded_in_target) {
-                // variance is encoded in target, we simply need to add the offset predictions.
-                new_xmin = prior_xmin + loc_xmin;
-                new_ymin = prior_ymin + loc_ymin;
-                new_xmax = prior_xmax + loc_xmax;
-                new_ymax = prior_ymax + loc_ymax;
-            } else {
-                new_xmin = prior_xmin + variance_data[p*4 + 0] * loc_xmin;
-                new_ymin = prior_ymin + variance_data[p*4 + 1] * loc_ymin;
-                new_xmax = prior_xmax + variance_data[p*4 + 2] * loc_xmax;
-                new_ymax = prior_ymax + variance_data[p*4 + 3] * loc_ymax;
-            }
-        } else if (_code_type == CodeType::CENTER_SIZE) {
-            float prior_width    =  prior_xmax - prior_xmin;
-            float prior_height   =  prior_ymax - prior_ymin;
-            float prior_center_x = (prior_xmin + prior_xmax) / 2.0f;
-            float prior_center_y = (prior_ymin + prior_ymax) / 2.0f;
+        float prior_width    =  prior_xmax - prior_xmin;
+        float prior_height   =  prior_ymax - prior_ymin;
+        float prior_center_x = (prior_xmin + prior_xmax) / 2.0f;
+        float prior_center_y = (prior_ymin + prior_ymax) / 2.0f;
 
-            float decode_bbox_center_x, decode_bbox_center_y;
-            float decode_bbox_width, decode_bbox_height;
+        float decode_bbox_center_x, decode_bbox_center_y;
+        float decode_bbox_width, decode_bbox_height;
 
-            if (_variance_encoded_in_target) {
-                // variance is encoded in target, we simply need to restore the offset predictions.
-                decode_bbox_center_x = loc_xmin * prior_width  + prior_center_x;
-                decode_bbox_center_y = loc_ymin * prior_height + prior_center_y;
-                decode_bbox_width  = std::exp(loc_xmax) * prior_width;
-                decode_bbox_height = std::exp(loc_ymax) * prior_height;
-            } else {
-                // variance is encoded in bbox, we need to scale the offset accordingly.
-                decode_bbox_center_x = variance_data[p*4 + 0] * loc_xmin * prior_width + prior_center_x;
-                decode_bbox_center_y = variance_data[p*4 + 1] * loc_ymin * prior_height + prior_center_y;
-                decode_bbox_width    = std::exp(variance_data[p*4 + 2] * loc_xmax) * prior_width;
-                decode_bbox_height   = std::exp(variance_data[p*4 + 3] * loc_ymax) * prior_height;
-            }
+        // variance is encoded in target, we simply need to restore the offset predictions.
+        decode_bbox_center_x = loc_xmin * prior_width  + prior_center_x;
+        decode_bbox_center_y = loc_ymin * prior_height + prior_center_y;
+        decode_bbox_width  = std::exp(loc_xmax) * prior_width;
+        decode_bbox_height = std::exp(loc_ymax) * prior_height;
 
-            new_xmin = decode_bbox_center_x - decode_bbox_width  / 2.0f;
-            new_ymin = decode_bbox_center_y - decode_bbox_height / 2.0f;
-            new_xmax = decode_bbox_center_x + decode_bbox_width  / 2.0f;
-            new_ymax = decode_bbox_center_y + decode_bbox_height / 2.0f;
-        }
+        new_xmin = decode_bbox_center_x - decode_bbox_width  / 2.0f;
+        new_ymin = decode_bbox_center_y - decode_bbox_height / 2.0f;
+        new_xmax = decode_bbox_center_x + decode_bbox_width  / 2.0f;
+        new_ymax = decode_bbox_center_y + decode_bbox_height / 2.0f;
 
         decoded_bboxes[p*4 + 0] = new_xmin;
         decoded_bboxes[p*4 + 1] = new_ymin;

--- a/demos/object_detection_demo_faster_rcnn/main.cpp
+++ b/demos/object_detection_demo_faster_rcnn/main.cpp
@@ -104,95 +104,9 @@ int main(int argc, char *argv[]) {
         /** Read network model **/
         CNNNetwork network = ie.ReadNetwork(FLAGS_m);
 
-        Precision precision = network.getPrecision();
         // -----------------------------------------------------------------------------------------------------
 
         // --------------------------- 3. Configure input & output ---------------------------------------------
-
-        // ------------------------------ Adding DetectionOutput -----------------------------------------------
-
-        /**
-         * The only meaningful difference between Faster-RCNN and SSD-like topologies is the interpretation
-         * of the output data. Faster-RCNN has 2 output layers which (the same format) are presented inside SSD.
-         *
-         * But SSD has an additional post-processing DetectionOutput layer that simplifies output filtering.
-         * So here we are adding 3 Reshapes and the DetectionOutput to the end of Faster-RCNN so it will return the
-         * same result as SSD and we can easily parse it.
-         */
-
-        std::string firstLayerName = network.getInputsInfo().begin()->first;
-
-        int inputWidth = network.getInputsInfo().begin()->second->getTensorDesc().getDims()[3];
-        int inputHeight = network.getInputsInfo().begin()->second->getTensorDesc().getDims()[2];
-
-        DataPtr bbox_pred_reshapeInPort = ((ICNNNetwork&)network).getData(FLAGS_bbox_name.c_str());
-        if (bbox_pred_reshapeInPort == nullptr) {
-            throw std::logic_error(std::string("Can't find output layer named ") + FLAGS_bbox_name);
-        }
-
-        SizeVector bbox_pred_reshapeOutDims = {
-            bbox_pred_reshapeInPort->getTensorDesc().getDims()[0] *
-            bbox_pred_reshapeInPort->getTensorDesc().getDims()[1], 1
-        };
-        DataPtr rois_reshapeInPort = ((ICNNNetwork&)network).getData(FLAGS_proposal_name.c_str());
-        if (rois_reshapeInPort == nullptr) {
-            throw std::logic_error(std::string("Can't find output layer named ") + FLAGS_proposal_name);
-        }
-
-        SizeVector rois_reshapeOutDims = {rois_reshapeInPort->getTensorDesc().getDims()[0] * rois_reshapeInPort->getTensorDesc().getDims()[1], 1};
-
-        DataPtr cls_prob_reshapeInPort = ((ICNNNetwork&)network).getData(FLAGS_prob_name.c_str());
-        if (cls_prob_reshapeInPort == nullptr) {
-            throw std::logic_error(std::string("Can't find output layer named ") + FLAGS_prob_name);
-        }
-
-        SizeVector cls_prob_reshapeOutDims = {cls_prob_reshapeInPort->getTensorDesc().getDims()[0] * cls_prob_reshapeInPort->getTensorDesc().getDims()[1], 1};
-
-        /*
-            Detection output
-        */
-
-        int normalized = 0;
-        int prior_size = normalized ? 4 : 5;
-        int num_priors = rois_reshapeOutDims[0] / prior_size;
-
-        // num_classes guessed from the output dims
-        if (bbox_pred_reshapeOutDims[0] % (num_priors * 4) != 0) {
-            throw std::logic_error("Can't guess number of classes. Something's wrong with output layers dims");
-        }
-        int num_classes = bbox_pred_reshapeOutDims[0] / (num_priors * 4);
-        slog::info << "num_classes guessed: " << num_classes << slog::endl;
-
-        LayerParams detectionOutParams;
-        detectionOutParams.name = "detection_out";
-        detectionOutParams.type = "DetectionOutput";
-        detectionOutParams.precision = precision;
-        CNNLayerPtr detectionOutLayer = CNNLayerPtr(new CNNLayer(detectionOutParams));
-        detectionOutLayer->params["background_label_id"] = "0";
-        detectionOutLayer->params["code_type"] = "caffe.PriorBoxParameter.CENTER_SIZE";
-        detectionOutLayer->params["eta"] = "1.0";
-        detectionOutLayer->params["input_height"] = std::to_string(inputHeight);
-        detectionOutLayer->params["input_width"] = std::to_string(inputWidth);
-        detectionOutLayer->params["keep_top_k"] = "200";
-        detectionOutLayer->params["nms_threshold"] = "0.3";
-        detectionOutLayer->params["normalized"] = std::to_string(normalized);
-        detectionOutLayer->params["num_classes"] = std::to_string(num_classes);
-        detectionOutLayer->params["share_location"] = "0";
-        detectionOutLayer->params["top_k"] = "400";
-        detectionOutLayer->params["variance_encoded_in_target"] = "1";
-        detectionOutLayer->params["visualize"] = "False";
-
-        detectionOutLayer->insData.push_back(bbox_pred_reshapeInPort);
-        detectionOutLayer->insData.push_back(cls_prob_reshapeInPort);
-        detectionOutLayer->insData.push_back(rois_reshapeInPort);
-
-        SizeVector detectionOutLayerOutDims = {1, 1, 200, 7};
-        DataPtr detectionOutLayerOutPort = DataPtr(new Data("detection_out", {precision, detectionOutLayerOutDims,
-                                                            TensorDesc::getLayoutByDims(detectionOutLayerOutDims)}));
-        detectionOutLayerOutPort->getCreatorLayer() = detectionOutLayer;
-        detectionOutLayer->outData.push_back(detectionOutLayerOutPort);
-
-        DetectionOutputPostProcessor detOutPostProcessor(detectionOutLayer.get());
 
         network.addOutput(FLAGS_bbox_name, 0);
         network.addOutput(FLAGS_prob_name, 0);
@@ -209,9 +123,6 @@ int main(int argc, char *argv[]) {
 
         std::string imageInputName, imInfoInputName;
 
-        InputInfo::Ptr inputInfo = inputsInfo.begin()->second;
-
-        SizeVector inputImageDims;
         /** Stores input image **/
 
         /** Iterating over all input blobs **/
@@ -243,8 +154,8 @@ int main(int argc, char *argv[]) {
 
         OutputsDataMap outputsInfo(network.getOutputsInfo());
 
-        const int maxProposalCount = detectionOutLayerOutDims[2];
-        const int objectSize = detectionOutLayerOutDims[3];
+        const size_t maxProposalCount = 200;
+        const size_t objectSize = 7;
 
         /** Set the precision of output data provided by the user, should be called before load of the network to the device **/
 
@@ -252,6 +163,23 @@ int main(int argc, char *argv[]) {
         outputsInfo[FLAGS_prob_name]->setPrecision(Precision::FP32);
         outputsInfo[FLAGS_proposal_name]->setPrecision(Precision::FP32);
         // -----------------------------------------------------------------------------------------------------
+
+        // ------------------------------ Adding DetectionOutput post-processor---------------------------------
+
+        /**
+         * The only meaningful difference between Faster-RCNN and SSD-like topologies is the interpretation
+         * of the output data. Faster-RCNN has 2 output layers which (the same format) are presented inside SSD.
+         *
+         * But SSD has an additional post-processing DetectionOutput layer that simplifies output filtering.
+         * So here we use a post-processor to convert the output of Faster-RCNN into the same format as SSD,
+         * so that we can easily parse it.
+         */
+
+        DetectionOutputPostProcessor detOutPostProcessor(
+            inputsInfo[imageInputName]->getTensorDesc().getDims(),
+            outputsInfo[FLAGS_bbox_name]->getTensorDesc().getDims(),
+            outputsInfo[FLAGS_prob_name]->getTensorDesc().getDims(),
+            outputsInfo[FLAGS_proposal_name]->getTensorDesc().getDims());
 
         // --------------------------- 4. Loading model to the device ------------------------------------------
         slog::info << "Loading model to the device" << slog::endl;
@@ -322,7 +250,7 @@ int main(int argc, char *argv[]) {
 
         std::vector<Blob::Ptr> detOutInBlobs = { bbox_output_blob, prob_output_blob, rois_output_blob };
 
-        Blob::Ptr output_blob = std::make_shared<TBlob<float>>(TensorDesc(Precision::FP32, detectionOutLayerOutDims, Layout::NCHW));
+        Blob::Ptr output_blob = std::make_shared<TBlob<float>>(TensorDesc(Precision::FP32, {1, 1, maxProposalCount, objectSize}, Layout::NCHW));
         output_blob->allocate();
         std::vector<Blob::Ptr> detOutOutBlobs = { output_blob };
 
@@ -331,7 +259,7 @@ int main(int argc, char *argv[]) {
         const float* detection = static_cast<PrecisionTrait<Precision::FP32>::value_type*>(output_blob->buffer());
 
         /* Each detection has image_id that denotes processed image */
-        for (int curProposal = 0; curProposal < maxProposalCount; curProposal++) {
+        for (size_t curProposal = 0; curProposal < maxProposalCount; curProposal++) {
             auto image_id = static_cast<int>(detection[curProposal * objectSize + 0]);
             if (image_id < 0) {
                 break;


### PR DESCRIPTION
Originally I set out to remove the usage of a soon-to-be deprecated `InferenceEngine::Data` constructor (see the first commit), but then I noticed that the code that constructor is used in is rather superfluous, so I ended up refactoring the demo to remove it entirely.

See the commit messages for more information.