### PR TITLE
demos: remove useless comments from command line flags and help messages

### DIFF
--- a/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
+++ b/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
@@ -38,63 +38,36 @@ static const char no_show_processed_video[] = "Optional. No show processed video
 static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
 
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "cam", video_message);
 
-/// @brief Define parameter for vehicle detection  model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", person_vehicle_bike_detection_model_message);
 
-/// @brief Define parameter for vehicle attributes model file <br>
-/// It is a required parameter
 DEFINE_string(m_pa, "", person_attribs_model_message);
 
-/// @brief Define parameter for vehicle detection  model file <br>
-/// It is a required parameter
 DEFINE_string(m_reid, "", person_reid_model_message);
 
-/// @brief device the target device for vehicle detection infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// @brief device the target device for age gender detection on <br>
 DEFINE_string(d_pa, "CPU", target_device_message_person_attribs);
 
-/// @brief device the target device for head pose detection on <br>
 DEFINE_string(d_reid, "CPU", target_device_message_person_reid);
 
-/// @brief Enable per-layer performance report
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// @brief Flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// @brief Define probability threshold for person/vehicle/bike crossroad detections <br>
-/// It is an optional parameter
 DEFINE_double(t, 0.5, threshold_output_message);
 
-/// @brief Define probability threshold for person/vehicle/bike crossroad detections <br>
-/// It is an optional parameter
 DEFINE_double(t_reid, 0.7, threshold_output_message_person_reid);
 
-/// @brief Flag to disable processed video showing<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
-/// \brief Enables resizable input<br>
-/// It is an optional parameter
 DEFINE_bool(auto_resize, false, input_resizable_message);
 
 

--- a/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
+++ b/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
@@ -10,44 +10,31 @@
 #include <gflags/gflags.h>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Required. Path to a video or image file. Default value is \"cam\" to work with camera.";
-
 static const char person_vehicle_bike_detection_model_message[] = "Required. Path to the Person/Vehicle/Bike Detection Crossroad model (.xml) file.";
 static const char person_attribs_model_message[] = "Optional. Path to the Person Attributes Recognition Crossroad model (.xml) file.";
 static const char person_reid_model_message[] = "Optional. Path to the Person Reidentification Retail model (.xml) file.";
-
 static const char target_device_message[] = "Optional. Specify the target device for Person/Vehicle/Bike Detection. " \
                                             "The list of available devices is shown below. Default value is CPU. " \
                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The application looks for a suitable plugin for the specified device.";
-
 static const char target_device_message_person_attribs[] = "Optional. Specify the target device for Person Attributes Recognition. "\
                                                             "The list of available devices is shown below. Default value is CPU. " \
                                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                             "The application looks for a suitable plugin for the specified device.";
-
 static const char target_device_message_person_reid[] = "Optional. Specify the target device for Person Reidentification Retail. "\
                                                         "The list of available devices is shown below. Default value is CPU. " \
                                                         "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                         "The application looks for a suitable plugin for the specified device.";
-
 static const char performance_counter_message[] = "Optional. Enables per-layer performance statistics.";
-
 static const char custom_cldnn_message[] = "Optional. For clDNN (GPU)-targeted custom kernels, if any. "\
-"Absolute path to the xml file with the kernels desc.";
-
+                                           "Absolute path to the xml file with the kernels desc.";
 static const char custom_cpu_library_message[] = "Optional. For MKLDNN (CPU)-targeted custom layers, if any. " \
-"Absolute path to a shared library with the kernels impl.";
-
+                                                 "Absolute path to a shared library with the kernels impl.";
 static const char threshold_output_message[] = "Optional. Probability threshold for person/vehicle/bike crossroad detections.";
-
 static const char threshold_output_message_person_reid[] = "Optional. Cosine similarity threshold between two vectors for person reidentification.";
-
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
-
 static const char no_show_processed_video[] = "Optional. No show processed video.";
-
 static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
 
 

--- a/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
+++ b/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
@@ -39,35 +39,20 @@ static const char input_resizable_message[] = "Optional. Enables resizable input
 
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "cam", video_message);
-
 DEFINE_string(m, "", person_vehicle_bike_detection_model_message);
-
 DEFINE_string(m_pa, "", person_attribs_model_message);
-
 DEFINE_string(m_reid, "", person_reid_model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(d_pa, "CPU", target_device_message_person_attribs);
-
 DEFINE_string(d_reid, "CPU", target_device_message_person_reid);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_double(t, 0.5, threshold_output_message);
-
 DEFINE_double(t_reid, 0.7, threshold_output_message_person_reid);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
-
 DEFINE_bool(auto_resize, false, input_resizable_message);
 
 

--- a/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
+++ b/demos/crossroad_camera_demo/crossroad_camera_demo.hpp
@@ -9,59 +9,45 @@
 #include <vector>
 #include <gflags/gflags.h>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for images argument
 static const char video_message[] = "Required. Path to a video or image file. Default value is \"cam\" to work with camera.";
 
-/// @brief message for model argument
 static const char person_vehicle_bike_detection_model_message[] = "Required. Path to the Person/Vehicle/Bike Detection Crossroad model (.xml) file.";
 static const char person_attribs_model_message[] = "Optional. Path to the Person Attributes Recognition Crossroad model (.xml) file.";
 static const char person_reid_model_message[] = "Optional. Path to the Person Reidentification Retail model (.xml) file.";
 
-/// @brief message for assigning Person/Vehicle/Bike detection inference to device
 static const char target_device_message[] = "Optional. Specify the target device for Person/Vehicle/Bike Detection. " \
                                             "The list of available devices is shown below. Default value is CPU. " \
                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The application looks for a suitable plugin for the specified device.";
 
-/// @brief message for assigning Person attributes recognition inference to device
 static const char target_device_message_person_attribs[] = "Optional. Specify the target device for Person Attributes Recognition. "\
                                                             "The list of available devices is shown below. Default value is CPU. " \
                                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                             "The application looks for a suitable plugin for the specified device.";
 
-/// @brief message for assigning Person Reidentification retail inference to device
 static const char target_device_message_person_reid[] = "Optional. Specify the target device for Person Reidentification Retail. "\
                                                         "The list of available devices is shown below. Default value is CPU. " \
                                                         "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                         "The application looks for a suitable plugin for the specified device.";
 
-/// @brief message for performance counters
 static const char performance_counter_message[] = "Optional. Enables per-layer performance statistics.";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Optional. For clDNN (GPU)-targeted custom kernels, if any. "\
 "Absolute path to the xml file with the kernels desc.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Optional. For MKLDNN (CPU)-targeted custom layers, if any. " \
 "Absolute path to a shared library with the kernels impl.";
 
-/// @brief message for probability threshold argument for person/vehicle/bike crossroad detections
 static const char threshold_output_message[] = "Optional. Probability threshold for person/vehicle/bike crossroad detections.";
 
-/// @brief message for probability threshold argument for person/vehicle/bike crossroad detections
 static const char threshold_output_message_person_reid[] = "Optional. Cosine similarity threshold between two vectors for person reidentification.";
 
-/// @brief message raw output flag
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
 
-/// @brief message no show processed video
 static const char no_show_processed_video[] = "Optional. No show processed video.";
 
-/// @brief message resizable input flag
 static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
 
 

--- a/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
+++ b/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
@@ -17,43 +17,30 @@
 #endif
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Optional. Path to a video file. Default value is \"cam\" to work with camera.";
-
 static const char gaze_estimation_model_message[] = "Required. Path to an .xml file with a trained Gaze Estimation model.";
 static const char face_detection_model_message[] = "Required. Path to an .xml file with a trained Face Detection model.";
 static const char head_pose_model_message[] = "Required. Path to an .xml file with a trained Head Pose Estimation model.";
 static const char facial_landmarks_model_message[] = "Required. Path to an .xml file with a trained Facial Landmarks Estimation model.";
-
 static const char plugin_message[] = "Plugin name. For example, CPU. If this parameter is specified, " \
-"the demo will look for this plugin only.";
-
+                                     "the demo will look for this plugin only.";
 static const char target_device_message[] = "Optional. Target device for Gaze Estimation network (the list of available devices is shown below). " \
-"Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
-
+                                            "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                            "The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
 static const char target_device_message_fd[] = "Optional. Target device for Face Detection network (the list of available devices is shown below). " \
-"Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
-
+                                               "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                               "The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
 static const char target_device_message_hp[] = "Optional. Target device for Head Pose Estimation network (the list of available devices is shown below). " \
-"Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
-
+                                               "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                               "The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
 static const char target_device_message_lm[] = "Optional. Target device for Facial Landmarks Estimation network " \
-"(the list of available devices is shown below). Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for device specified. Default value is \"CPU\".";
-
+                                               "(the list of available devices is shown below). Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                               "The demo will look for a suitable plugin for device specified. Default value is \"CPU\".";
 static const char camera_resolution_message[] = "Optional. Set camera resolution in format WxH.";
-
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report.";
-
 static const char thresh_output_message[] = "Optional. Probability threshold for Face Detector. The default value is 0.5.";
-
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
-
 static const char fd_reshape_message[] = "Optional. Reshape Face Detector network so that its input resolution has the same aspect ratio as the input frame.";
-
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 /// \brief Define flag for showing help message<br>

--- a/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
+++ b/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
@@ -16,58 +16,44 @@
 #include <dirent.h>
 #endif
 
-/// @brief Message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief Message for images argument
 static const char video_message[] = "Optional. Path to a video file. Default value is \"cam\" to work with camera.";
 
-/// @brief message for model argument
 static const char gaze_estimation_model_message[] = "Required. Path to an .xml file with a trained Gaze Estimation model.";
 static const char face_detection_model_message[] = "Required. Path to an .xml file with a trained Face Detection model.";
 static const char head_pose_model_message[] = "Required. Path to an .xml file with a trained Head Pose Estimation model.";
 static const char facial_landmarks_model_message[] = "Required. Path to an .xml file with a trained Facial Landmarks Estimation model.";
 
-/// @brief Message for plugin argument
 static const char plugin_message[] = "Plugin name. For example, CPU. If this parameter is specified, " \
 "the demo will look for this plugin only.";
 
-/// @brief Message for assigning gaze calculation to device
 static const char target_device_message[] = "Optional. Target device for Gaze Estimation network (the list of available devices is shown below). " \
 "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
 
-/// @brief Message for assigning face detection calculation to device
 static const char target_device_message_fd[] = "Optional. Target device for Face Detection network (the list of available devices is shown below). " \
 "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
 
-/// @brief Message for assigning head pose calculation to device
 static const char target_device_message_hp[] = "Optional. Target device for Head Pose Estimation network (the list of available devices is shown below). " \
 "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
 
-/// @brief Message for assigning facial landmarks calculation to device
 static const char target_device_message_lm[] = "Optional. Target device for Facial Landmarks Estimation network " \
 "(the list of available devices is shown below). Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for device specified. Default value is \"CPU\".";
 
-/// @brief Message for assigning setting resolution of camera
 static const char camera_resolution_message[] = "Optional. Set camera resolution in format WxH.";
 
-/// @brief Message for performance counters
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report.";
 
-/// @brief Message for probability threshold argument
 static const char thresh_output_message[] = "Optional. Probability threshold for Face Detector. The default value is 0.5.";
 
-/// @brief Message raw output flag
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
 
-/// @brief Message for enabling Face Detector network reshape
 static const char fd_reshape_message[] = "Optional. Reshape Face Detector network so that its input resolution has the same aspect ratio as the input frame.";
 
-/// @brief Message do not show processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 /// \brief Define flag for showing help message<br>

--- a/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
+++ b/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
@@ -43,63 +43,36 @@ static const char raw_output_message[] = "Optional. Output inference results as 
 static const char fd_reshape_message[] = "Optional. Reshape Face Detector network so that its input resolution has the same aspect ratio as the input frame.";
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// \brief Define flag for showing help message<br>
 DEFINE_bool(h, false, help_message);
 
-/// \brief Define parameter for set image file<br>
-/// It is a required parameter
 DEFINE_string(i, "cam", video_message);
 
-/// \brief Define parameter for Gaze Estimation model file<br>
-/// It is a required parameter
 DEFINE_string(m, "", gaze_estimation_model_message);
 
-/// \brief Define parameter for Face Detection model file<br>
-/// It is a required parameter
 DEFINE_string(m_fd, "", face_detection_model_message);
 
-/// \brief Define parameter for Head Pose Estimation model file<br>
-/// It is a required parameter
 DEFINE_string(m_hp, "", head_pose_model_message);
 
-/// \brief Define parameter for Facial Landmarks Estimation model file<br>
-/// It is an optional parameter
 DEFINE_string(m_lm, "", facial_landmarks_model_message);
 
-/// \brief target device for Gaze Estimation network<br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// \brief Define parameter for target device for Face Detection network<br>
 DEFINE_string(d_fd, "CPU", target_device_message_fd);
 
-/// \brief Define parameter for target device for Head Pose Estimation network<br>
 DEFINE_string(d_hp, "CPU", target_device_message_hp);
 
-/// \brief Define parameter for target device for Facial Landmarks Estimation network<br>
 DEFINE_string(d_lm, "CPU", target_device_message_lm);
 
-/// \brief Define parameter camera resolution<br>
-/// It is an optional parameter
 DEFINE_string(res, "", camera_resolution_message);
 
-/// \brief Define parameter to enable face detector network reshape<br>
-/// It is an optional parameter
 DEFINE_bool(fd_reshape, false, fd_reshape_message);
 
-/// \brief Define parameter to enable per-layer performance report<br>
-/// It is an optional parameter
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// \brief Define a flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// \brief Define a parameter for probability threshold for detections<br>
-/// It is an optional parameter
 DEFINE_double(t, 0.5, thresh_output_message);
 
-/// \brief Define a flag to disable showing processed video<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
 /**

--- a/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
+++ b/demos/gaze_estimation_demo/gaze_estimation_demo.hpp
@@ -44,35 +44,20 @@ static const char fd_reshape_message[] = "Optional. Reshape Face Detector networ
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "cam", video_message);
-
 DEFINE_string(m, "", gaze_estimation_model_message);
-
 DEFINE_string(m_fd, "", face_detection_model_message);
-
 DEFINE_string(m_hp, "", head_pose_model_message);
-
 DEFINE_string(m_lm, "", facial_landmarks_model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(d_fd, "CPU", target_device_message_fd);
-
 DEFINE_string(d_hp, "CPU", target_device_message_hp);
-
 DEFINE_string(d_lm, "CPU", target_device_message_lm);
-
 DEFINE_string(res, "", camera_resolution_message);
-
 DEFINE_bool(fd_reshape, false, fd_reshape_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_double(t, 0.5, thresh_output_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
 
 /**

--- a/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
+++ b/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
@@ -18,31 +18,18 @@ static const char performance_counter_message[] = "Optional. Enable per-layer pe
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
 
-/// @brief Defines flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Defines parameter for setting video file <br>
-/// It is a required parameter
 DEFINE_string(i, "cam", video_message);
 
-/// @brief Defines parameter for human pose estimation model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", human_pose_estimation_model_message);
 
-/// @brief Defines parameter for the target device to infer on <br>
-/// It is an optional parameter
 DEFINE_string(d, "CPU", target_device_message);
 
-/// @brief Defines flag for per-layer performance report <br>
-/// It is an optional parameter
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief Defines flag for disabling processed video showing <br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
-/// @brief Defines flag to output raw results <br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
 /**

--- a/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
+++ b/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
@@ -8,20 +8,14 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Required. Path to a video. Default value is \"cam\" to work with camera.";
-
 static const char human_pose_estimation_model_message[] = "Required. Path to the Human Pose Estimation model (.xml) file.";
-
 static const char target_device_message[] = "Optional. Specify the target device for Human Pose Estimation "\
                                             "(the list of available devices is shown below). Default value is CPU. " \
                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The application looks for a suitable plugin for the specified device.";
-
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report.";
-
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
-
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
 
 /// @brief Defines flag for showing help message <br>

--- a/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
+++ b/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
@@ -19,17 +19,11 @@ static const char no_show_processed_video[] = "Optional. Do not show processed v
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "cam", video_message);
-
 DEFINE_string(m, "", human_pose_estimation_model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
-
 DEFINE_bool(r, false, raw_output_message);
 
 /**

--- a/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
+++ b/demos/human_pose_estimation_demo/include/human_pose_estimation_demo.hpp
@@ -7,28 +7,21 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief Message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief Message for video argument
 static const char video_message[] = "Required. Path to a video. Default value is \"cam\" to work with camera.";
 
-/// @brief Message for model argument
 static const char human_pose_estimation_model_message[] = "Required. Path to the Human Pose Estimation model (.xml) file.";
 
-/// @brief Message for assigning Human Pose Estimation inference to device
 static const char target_device_message[] = "Optional. Specify the target device for Human Pose Estimation "\
                                             "(the list of available devices is shown below). Default value is CPU. " \
                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The application looks for a suitable plugin for the specified device.";
 
-/// @brief Message for performance counter
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report.";
 
-/// @brief Message for not showing processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// @brief Message for raw output
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
 
 /// @brief Defines flag for showing help message <br>

--- a/demos/interactive_face_detection_demo/interactive_face_detection.hpp
+++ b/demos/interactive_face_detection_demo/interactive_face_detection.hpp
@@ -66,75 +66,40 @@ static const char no_smooth_output_message[] = "Optional. Do not smooth person a
 static const char no_show_emotion_bar_message[] = "Optional. Do not show emotion bar";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", input_video_message);
-
 DEFINE_string(o, "", output_video_message);
-
 DEFINE_string(m, "", face_detection_model_message);
-
 DEFINE_string(m_ag, "", age_gender_model_message);
-
 DEFINE_string(m_hp, "", head_pose_model_message);
-
 DEFINE_string(m_em, "", emotions_model_message);
-
 DEFINE_string(m_lm, "", facial_landmarks_model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(d_ag, "CPU", target_device_message_ag);
-
 DEFINE_string(d_hp, "CPU", target_device_message_hp);
-
 DEFINE_string(d_em, "CPU", target_device_message_em);
-
 DEFINE_string(d_lm, "CPU", target_device_message_lm);
-
 DEFINE_uint32(n_ag, 16, num_batch_ag_message);
-
 DEFINE_bool(dyn_ag, false, dyn_batch_ag_message);
-
 DEFINE_uint32(n_hp, 16, num_batch_hp_message);
-
 DEFINE_bool(dyn_hp, false, dyn_batch_hp_message);
-
 DEFINE_uint32(n_em, 16, num_batch_em_message);
-
 DEFINE_bool(dyn_em, false, dyn_batch_em_message);
-
 DEFINE_uint32(n_lm, 16, num_batch_em_message);
-
 DEFINE_bool(dyn_lm, false, dyn_batch_em_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_double(t, 0.5, thresh_output_message);
-
 DEFINE_double(bb_enlarge_coef, 1.2, bb_enlarge_coef_output_message);
-
 DEFINE_bool(no_wait, false, no_wait_for_keypress_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
-
 DEFINE_bool(async, false, async_message);
-
 DEFINE_double(dx_coef, 1, dx_coef_output_message);
-
 DEFINE_double(dy_coef, 1, dy_coef_output_message);
-
 DEFINE_double(fps, -1, fps_output_message);
-
 DEFINE_bool(loop_video, false, loop_video_output_message);
-
 DEFINE_bool(no_smooth, false, no_smooth_output_message);
-
 DEFINE_bool(no_show_emotion_bar, false, no_show_emotion_bar_message);
 
 

--- a/demos/interactive_face_detection_demo/interactive_face_detection.hpp
+++ b/demos/interactive_face_detection_demo/interactive_face_detection.hpp
@@ -11,90 +11,58 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message";
-
 static const char input_video_message[] = "Required. Path to a video file (specify \"cam\" to work with camera).";
-
 static const char output_video_message[] = "Optional. Path to an output video file.";
-
 static const char face_detection_model_message[] = "Required. Path to an .xml file with a trained Face Detection model.";
 static const char age_gender_model_message[] = "Optional. Path to an .xml file with a trained Age/Gender Recognition model.";
 static const char head_pose_model_message[] = "Optional. Path to an .xml file with a trained Head Pose Estimation model.";
 static const char emotions_model_message[] = "Optional. Path to an .xml file with a trained Emotions Recognition model.";
 static const char facial_landmarks_model_message[] = "Optional. Path to an .xml file with a trained Facial Landmarks Estimation model.";
-
 static const char plugin_message[] = "Plugin name. For example, CPU. If this parameter is specified, " \
-"the demo will look for this plugin only.";
-
+                                     "the demo will look for this plugin only.";
 static const char target_device_message[] = "Optional. Target device for Face Detection network (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device.";
-
+                                            "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                            "The demo will look for a suitable plugin for a specified device.";
 static const char target_device_message_ag[] = "Optional. Target device for Age/Gender Recognition network (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device.";
-
+                                               "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                               "The demo will look for a suitable plugin for a specified device.";
 static const char target_device_message_hp[] = "Optional. Target device for Head Pose Estimation network (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device.";
-
+                                               "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                               "The demo will look for a suitable plugin for a specified device.";
 static const char target_device_message_em[] = "Optional. Target device for Emotions Recognition network (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device.";
-
+                                               "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                               "The demo will look for a suitable plugin for a specified device.";
 static const char target_device_message_lm[] = "Optional. Target device for Facial Landmarks Estimation network " \
-"(the list of available devices is shown below). Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for device specified.";
-
+                                               "(the list of available devices is shown below). Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                               "The demo will look for a suitable plugin for device specified.";
 static const char num_batch_ag_message[] = "Optional. Number of maximum simultaneously processed faces for Age/Gender Recognition network " \
-"(by default, it is 16)";
-
+                                           "(by default, it is 16)";
 static const char num_batch_hp_message[] = "Optional. Number of maximum simultaneously processed faces for Head Pose Estimation network " \
-"(by default, it is 16)";
-
+                                           "(by default, it is 16)";
 static const char num_batch_em_message[] = "Optional. Number of maximum simultaneously processed faces for Emotions Recognition network " \
-"(by default, it is 16)";
-
+                                           "(by default, it is 16)";
 static const char num_batch_lm_message[] = "Optional. Number of maximum simultaneously processed faces for Facial Landmarks Estimation network " \
-"(by default, it is 16)";
-
+                                           "(by default, it is 16)";
 static const char dyn_batch_ag_message[] = "Optional. Enable dynamic batch size for Age/Gender Recognition network";
-
 static const char dyn_batch_hp_message[] = "Optional. Enable dynamic batch size for Head Pose Estimation network";
-
 static const char dyn_batch_em_message[] = "Optional. Enable dynamic batch size for Emotions Recognition network";
-
 static const char dyn_batch_lm_message[] = "Optional. Enable dynamic batch size for Facial Landmarks Estimation network";
-
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report";
-
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
-"Absolute path to an .xml file with the kernels description.";
-
+                                           "Absolute path to an .xml file with the kernels description.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
-"Absolute path to a shared library with the kernels implementation.";
-
+                                                 "Absolute path to a shared library with the kernels implementation.";
 static const char thresh_output_message[] = "Optional. Probability threshold for detections";
-
 static const char bb_enlarge_coef_output_message[] = "Optional. Coefficient to enlarge/reduce the size of the bounding box around the detected face";
-
 static const char raw_output_message[] = "Optional. Output inference results as raw values";
-
 static const char no_wait_for_keypress_message[] = "Optional. Do not wait for key press in the end.";
-
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
-
 static const char async_message[] = "Optional. Enable asynchronous mode";
-
 static const char dx_coef_output_message[] = "Optional. Coefficient to shift the bounding box around the detected face along the Ox axis";
-
 static const char dy_coef_output_message[] = "Optional. Coefficient to shift the bounding box around the detected face along the Oy axis";
-
 static const char fps_output_message[] = "Optional. Maximum FPS for playing video";
-
 static const char loop_video_output_message[] = "Optional. Enable playing video on a loop";
-
 static const char no_smooth_output_message[] = "Optional. Do not smooth person attributes";
-
 static const char no_show_emotion_bar_message[] = "Optional. Do not show emotion bar";
 
 /// \brief Define flag for showing help message<br>

--- a/demos/interactive_face_detection_demo/interactive_face_detection.hpp
+++ b/demos/interactive_face_detection_demo/interactive_face_detection.hpp
@@ -10,124 +10,91 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief Message for help argument
 static const char help_message[] = "Print a usage message";
 
-/// @brief Message for images argument
 static const char input_video_message[] = "Required. Path to a video file (specify \"cam\" to work with camera).";
 
-/// @brief Message for images argument
 static const char output_video_message[] = "Optional. Path to an output video file.";
 
-/// @brief message for model argument
 static const char face_detection_model_message[] = "Required. Path to an .xml file with a trained Face Detection model.";
 static const char age_gender_model_message[] = "Optional. Path to an .xml file with a trained Age/Gender Recognition model.";
 static const char head_pose_model_message[] = "Optional. Path to an .xml file with a trained Head Pose Estimation model.";
 static const char emotions_model_message[] = "Optional. Path to an .xml file with a trained Emotions Recognition model.";
 static const char facial_landmarks_model_message[] = "Optional. Path to an .xml file with a trained Facial Landmarks Estimation model.";
 
-/// @brief Message for plugin argument
 static const char plugin_message[] = "Plugin name. For example, CPU. If this parameter is specified, " \
 "the demo will look for this plugin only.";
 
-/// @brief Message for assigning face detection calculation to device
 static const char target_device_message[] = "Optional. Target device for Face Detection network (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device.";
 
-/// @brief Message for assigning age/gender calculation to device
 static const char target_device_message_ag[] = "Optional. Target device for Age/Gender Recognition network (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device.";
 
-/// @brief Message for assigning head pose calculation to device
 static const char target_device_message_hp[] = "Optional. Target device for Head Pose Estimation network (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device.";
 
-/// @brief Message for assigning emotions calculation to device
 static const char target_device_message_em[] = "Optional. Target device for Emotions Recognition network (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device.";
 
-/// @brief Message for assigning Facial Landmarks Estimation network to device
 static const char target_device_message_lm[] = "Optional. Target device for Facial Landmarks Estimation network " \
 "(the list of available devices is shown below). Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for device specified.";
 
-/// @brief Message for the maximum number of simultaneously processed faces for Age Gender network
 static const char num_batch_ag_message[] = "Optional. Number of maximum simultaneously processed faces for Age/Gender Recognition network " \
 "(by default, it is 16)";
 
-/// @brief Message for the maximum number of simultaneously processed faces for Head Pose network
 static const char num_batch_hp_message[] = "Optional. Number of maximum simultaneously processed faces for Head Pose Estimation network " \
 "(by default, it is 16)";
 
-/// @brief Message for the maximum number of simultaneously processed faces for Emotions network
 static const char num_batch_em_message[] = "Optional. Number of maximum simultaneously processed faces for Emotions Recognition network " \
 "(by default, it is 16)";
 
-/// @brief Message for the maximum number of simultaneously processed faces for Facial Landmarks Estimation network
 static const char num_batch_lm_message[] = "Optional. Number of maximum simultaneously processed faces for Facial Landmarks Estimation network " \
 "(by default, it is 16)";
 
-/// @brief Message for dynamic batching support for AgeGender net
 static const char dyn_batch_ag_message[] = "Optional. Enable dynamic batch size for Age/Gender Recognition network";
 
-/// @brief Message for dynamic batching support for HeadPose net
 static const char dyn_batch_hp_message[] = "Optional. Enable dynamic batch size for Head Pose Estimation network";
 
-/// @brief Message for dynamic batching support for Emotions net
 static const char dyn_batch_em_message[] = "Optional. Enable dynamic batch size for Emotions Recognition network";
 
-/// @brief Message for dynamic batching support for Facial Landmarks Estimation network
 static const char dyn_batch_lm_message[] = "Optional. Enable dynamic batch size for Facial Landmarks Estimation network";
 
-/// @brief Message for performance counters
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report";
 
-/// @brief Message for GPU custom kernels description
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
 "Absolute path to an .xml file with the kernels description.";
 
-/// @brief Message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
 "Absolute path to a shared library with the kernels implementation.";
 
-/// @brief Message for probability threshold argument
 static const char thresh_output_message[] = "Optional. Probability threshold for detections";
 
-/// @brief Message for face enlarge coefficient argument
 static const char bb_enlarge_coef_output_message[] = "Optional. Coefficient to enlarge/reduce the size of the bounding box around the detected face";
 
-/// @brief Message raw output flag
 static const char raw_output_message[] = "Optional. Output inference results as raw values";
 
-/// @brief Message do not wait for keypress after input stream completed
 static const char no_wait_for_keypress_message[] = "Optional. Do not wait for key press in the end.";
 
-/// @brief Message do not show processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// @brief Message for asynchronous mode
 static const char async_message[] = "Optional. Enable asynchronous mode";
 
-/// @brief Message for shifting coefficient by dx for detected faces
 static const char dx_coef_output_message[] = "Optional. Coefficient to shift the bounding box around the detected face along the Ox axis";
 
-/// @brief Message for shifting coefficient by dy for detected faces
 static const char dy_coef_output_message[] = "Optional. Coefficient to shift the bounding box around the detected face along the Oy axis";
 
-/// @brief Message for fps argument
 static const char fps_output_message[] = "Optional. Maximum FPS for playing video";
 
-/// @brief Message for looping video argument
 static const char loop_video_output_message[] = "Optional. Enable playing video on a loop";
 
-/// @brief Message for smooth argument
 static const char no_smooth_output_message[] = "Optional. Do not smooth person attributes";
 
-/// @brief Message for smooth argument
 static const char no_show_emotion_bar_message[] = "Optional. Do not show emotion bar";
 
 /// \brief Define flag for showing help message<br>

--- a/demos/interactive_face_detection_demo/interactive_face_detection.hpp
+++ b/demos/interactive_face_detection_demo/interactive_face_detection.hpp
@@ -65,133 +65,76 @@ static const char loop_video_output_message[] = "Optional. Enable playing video 
 static const char no_smooth_output_message[] = "Optional. Do not smooth person attributes";
 static const char no_show_emotion_bar_message[] = "Optional. Do not show emotion bar";
 
-/// \brief Define flag for showing help message<br>
 DEFINE_bool(h, false, help_message);
 
-/// \brief Define parameter for set image file<br>
-/// It is a required parameter
 DEFINE_string(i, "", input_video_message);
 
-/// \brief Define parameter for an output video file<br>
-/// It is an optional parameter
 DEFINE_string(o, "", output_video_message);
 
-/// \brief Define parameter for Face Detection model file<br>
-/// It is a required parameter
 DEFINE_string(m, "", face_detection_model_message);
 
-/// \brief Define parameter for Age Gender Recognition model file<br>
-/// It is a optional parameter
 DEFINE_string(m_ag, "", age_gender_model_message);
 
-/// \brief Define parameter for Head Pose Estimation model file<br>
-/// It is a optional parameter
 DEFINE_string(m_hp, "", head_pose_model_message);
 
-/// \brief Define parameter for Emotions Recognition model file<br>
-/// It is a optional parameter
 DEFINE_string(m_em, "", emotions_model_message);
 
-/// \brief Define parameter for Facial Landmarks Estimation model file<br>
-/// It is an optional parameter
 DEFINE_string(m_lm, "", facial_landmarks_model_message);
 
-/// \brief target device for Face Detection network<br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// \brief Define parameter for target device for Age/Gender Recognition network<br>
 DEFINE_string(d_ag, "CPU", target_device_message_ag);
 
-/// \brief Define parameter for target device for Head Pose Estimation network<br>
 DEFINE_string(d_hp, "CPU", target_device_message_hp);
 
-/// \brief Define parameter for target device for Emotions Recognition network<br>
 DEFINE_string(d_em, "CPU", target_device_message_em);
 
-/// \brief Define parameter for target device for Facial Landmarks Estimation network<br>
 DEFINE_string(d_lm, "CPU", target_device_message_lm);
 
-/// \brief Define parameter for maximum batch size for Age/Gender Recognition network<br>
 DEFINE_uint32(n_ag, 16, num_batch_ag_message);
 
-/// \brief Define parameter to enable dynamic batch size for Age/Gender Recognition network<br>
 DEFINE_bool(dyn_ag, false, dyn_batch_ag_message);
 
-/// \brief Define parameter for maximum batch size for Head Pose Estimation network<br>
 DEFINE_uint32(n_hp, 16, num_batch_hp_message);
 
-/// \brief Define parameter to enable dynamic batch size for Head Pose Estimation network<br>
 DEFINE_bool(dyn_hp, false, dyn_batch_hp_message);
 
-/// \brief Define parameter for maximum batch size for Emotions Recognition network<br>
 DEFINE_uint32(n_em, 16, num_batch_em_message);
 
-/// \brief Define parameter to enable dynamic batch size for Emotions Recognition network<br>
 DEFINE_bool(dyn_em, false, dyn_batch_em_message);
 
-/// \brief Define parameter for maximum batch size for Facial Landmarks Estimation network<br>
 DEFINE_uint32(n_lm, 16, num_batch_em_message);
 
-/// \brief Define parameter to enable dynamic batch size for Facial Landmarks Estimation network<br>
 DEFINE_bool(dyn_lm, false, dyn_batch_em_message);
 
-/// \brief Define parameter to enable per-layer performance report<br>
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief Define parameter for GPU custom kernels path<br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Define parameter for absolute path to CPU library with user layers<br>
-/// It is an optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// \brief Define a flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// \brief Define a parameter for probability threshold for detections<br>
-/// It is an optional parameter
 DEFINE_double(t, 0.5, thresh_output_message);
 
-/// \brief Define a parameter to enlarge the bounding box around the detected face for more robust operation of face analytics networks<br>
-/// It is an optional parameter
 DEFINE_double(bb_enlarge_coef, 1.2, bb_enlarge_coef_output_message);
 
-/// \brief Define a flag to disable keypress exit<br>
-/// It is an optional parameter
 DEFINE_bool(no_wait, false, no_wait_for_keypress_message);
 
-/// \brief Define a flag to disable showing processed video<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
-/// \brief Define a flag to enable aynchronous execution<br>
-/// It is an optional parameter
 DEFINE_bool(async, false, async_message);
 
-/// \brief Define a parameter to shift face bounding box by Ox for more robust operation of face analytics networks<br>
-/// It is an optional parameter
 DEFINE_double(dx_coef, 1, dx_coef_output_message);
 
-/// \brief Define a parameter to shift face bounding box by Oy for more robust operation of face analytics networks<br>
-/// It is an optional parameter
 DEFINE_double(dy_coef, 1, dy_coef_output_message);
 
-/// \brief Define a parameter to play video with defined fps<br>
-/// It is an optional parameter
 DEFINE_double(fps, -1, fps_output_message);
 
-/// \brief Define a flag to loop video<br>
-/// It is an optional parameter
 DEFINE_bool(loop_video, false, loop_video_output_message);
 
-/// \brief Define a flag to disable smoothing person attributes<br>
-/// It is an optional parameter
 DEFINE_bool(no_smooth, false, no_smooth_output_message);
 
-/// \brief Define a flag to disable showing emotion bar<br>
-/// It is an optional parameter
 DEFINE_bool(no_show_emotion_bar, false, no_show_emotion_bar_message);
 
 

--- a/demos/mask_rcnn_demo/mask_rcnn_demo.h
+++ b/demos/mask_rcnn_demo/mask_rcnn_demo.h
@@ -23,19 +23,12 @@ static const char detection_output_layer_name_message[] = "Optional. The name of
 static const char masks_layer_name_message[] = "Optional. The name of masks layer. Default value is \"masks\"";
 
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", image_message);
-
 DEFINE_string(m, "", model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(detection_output_name, "detection_output", detection_output_layer_name_message);
-
 DEFINE_string(masks_name, "masks", masks_layer_name_message);
 
 /**

--- a/demos/mask_rcnn_demo/mask_rcnn_demo.h
+++ b/demos/mask_rcnn_demo/mask_rcnn_demo.h
@@ -22,32 +22,20 @@ static const char custom_cpu_library_message[] = "Required for CPU custom layers
 static const char detection_output_layer_name_message[] = "Optional. The name of detection output layer. Default value is \"detection_output\"";
 static const char masks_layer_name_message[] = "Optional. The name of masks layer. Default value is \"masks\"";
 
-/// @brief Define parameter for clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "", image_message);
 
-/// @brief Define parameter for set model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", model_message);
 
-/// @brief device the target device to infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// @brief Custom Detection Output layer name
 DEFINE_string(detection_output_name, "detection_output", detection_output_layer_name_message);
 
-/// @brief Custom layer name producing masks
 DEFINE_string(masks_name, "masks", masks_layer_name_message);
 
 /**

--- a/demos/mask_rcnn_demo/mask_rcnn_demo.h
+++ b/demos/mask_rcnn_demo/mask_rcnn_demo.h
@@ -10,23 +10,16 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char image_message[] = "Required. Path to an .bmp image.";
-
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";\
-
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
-"Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device (CPU by default)";
-
+                                            "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                            "The demo will look for a suitable plugin for a specified device (CPU by default)";
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
-"Absolute path to the .xml file with the kernels descriptions.";
-
+                                           "Absolute path to the .xml file with the kernels descriptions.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
-"Absolute path to a shared library with the kernels implementations.";
-
+                                                 "Absolute path to a shared library with the kernels implementations.";
 static const char detection_output_layer_name_message[] = "Optional. The name of detection output layer. Default value is \"detection_output\"";
-
 static const char masks_layer_name_message[] = "Optional. The name of masks layer. Default value is \"masks\"";
 
 /// @brief Define parameter for clDNN custom kernels path <br>

--- a/demos/mask_rcnn_demo/mask_rcnn_demo.h
+++ b/demos/mask_rcnn_demo/mask_rcnn_demo.h
@@ -9,32 +9,24 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for images argument
 static const char image_message[] = "Required. Path to an .bmp image.";
 
-/// @brief message for model argument
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";\
 
-/// @brief message for assigning cnn calculation to device
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
 "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device (CPU by default)";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
 "Absolute path to the .xml file with the kernels descriptions.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
 "Absolute path to a shared library with the kernels implementations.";
 
-/// @brief message for detection output layer name argument
 static const char detection_output_layer_name_message[] = "Optional. The name of detection output layer. Default value is \"detection_output\"";
 
-/// @brief message for masks layer name argument
 static const char masks_layer_name_message[] = "Optional. The name of masks layer. Default value is \"masks\"";
 
 /// @brief Define parameter for clDNN custom kernels path <br>

--- a/demos/multi_channel/common/multichannel_params.hpp
+++ b/demos/multi_channel/common/multichannel_params.hpp
@@ -8,59 +8,42 @@
 #include <vector>
 #include <gflags/gflags.h>
 
-/// @brief Message for help argument
 static const char help_message[] = "Print a usage message";
 
-/// @brief Message for model argument
 static const char model_path_message[] = "Required. Path to an .xml file with a trained model.";
 
-/// @brief Message for assigning face detection calculation to a device
 static const char target_device_message[] = "Optional. Specify the target device for a network (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo looks for a suitable plugin for a specified device.";
 
-/// @brief Message for performance counters
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report";
 
-/// @brief Message for GPU custom kernels descriptions
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
 "Absolute path to an .xml file with the kernels descriptions";
 
-/// @brief Message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
 "Absolute path to a shared library with the kernels implementations";
 
-/// @brief Message for not showing a processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// @brief Message for the number of camera inputs
 static const char num_cameras[] = "Optional. Maximum number of processed camera inputs (web cameras)";
 
-/// @brief Message for batch size
 static const char batch_size[] = "Optional. Batch size for processing (the number of frames processed per infer request)";
 
-/// @brief Message for the number of infer requests
 static const char num_infer_requests[] = "Optional. Number of infer requests";
 
-/// @brief Message for inputs queue size
 static const char input_queue_size[] = "Optional. Frame queue size for input channels";
 
-/// @brief Message for FPS measurement sampling period
 static const char fps_sampling_period[] = "Optional. FPS measurement sampling period between timepoints in msec";
 
-/// @brief Message for the number of sampling periods
 static const char num_sampling_periods[] = "Optional. Number of sampling periods";
 
-/// @brief Message for enabling statistics output
 static const char show_statistics[] = "Optional. Enable statistics report";
 
-/// @brief Message for enabling channel duplication
 static const char duplication_channel_number[] = "Optional. Enable and specify the number of channels additionally copied from real sources";
 
-/// @brief Message for enabling real input FPS
 static const char real_input_fps[] = "Optional. Disable input frames caching, for maximum throughput pipeline";
 
-/// @brief Message for enabling input video
 static const char input_video[] = "Optional. Specify full path to input video files";
 
 /// \brief Define a flag for showing help message <br>

--- a/demos/multi_channel/common/multichannel_params.hpp
+++ b/demos/multi_channel/common/multichannel_params.hpp
@@ -31,35 +31,19 @@ static const char real_input_fps[] = "Optional. Disable input frames caching, fo
 static const char input_video[] = "Optional. Specify full path to input video files";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(m, "", model_path_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
-
 DEFINE_uint32(nc, 0, num_cameras);
-
 DEFINE_uint32(bs, 1, batch_size);
-
 DEFINE_uint32(nireq, 5, num_infer_requests);
-
 DEFINE_uint32(n_iqs, 5, input_queue_size);
-
 DEFINE_uint32(fps_sp, 1000, fps_sampling_period);
-
 DEFINE_uint32(n_sp, 10, num_sampling_periods);
-
 DEFINE_bool(show_stats, false, show_statistics);
-
 DEFINE_uint32(duplicate_num, 0, duplication_channel_number);
-
 DEFINE_bool(real_input_fps, false, real_input_fps);
-
 DEFINE_string(i, "", input_video);

--- a/demos/multi_channel/common/multichannel_params.hpp
+++ b/demos/multi_channel/common/multichannel_params.hpp
@@ -30,67 +30,36 @@ static const char duplication_channel_number[] = "Optional. Enable and specify t
 static const char real_input_fps[] = "Optional. Disable input frames caching, for maximum throughput pipeline";
 static const char input_video[] = "Optional. Specify full path to input video files";
 
-/// \brief Define a flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// \brief Define a parameter for a model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", model_path_message);
 
-/// \brief Define a target device parameter for a model <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// \brief Define a flag to enable per-layer performance report <br>
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief GPU custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// \brief Flag to disable showing processed video<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
-/// \brief Flag to specify the number of expected input channels<br>
-/// It is an optional parameter
 DEFINE_uint32(nc, 0, num_cameras);
 
-/// \brief Flag to specify batch size<br>
-/// It is an optional parameter
 DEFINE_uint32(bs, 1, batch_size);
 
-/// \brief Flag to specify the number of infer requests<br>
-/// It is an optional parameter
 DEFINE_uint32(nireq, 5, num_infer_requests);
 
-/// \brief Flag to specify the number of expected input channels<br>
-/// It is an optional parameter
 DEFINE_uint32(n_iqs, 5, input_queue_size);
 
-/// \brief Flag to specify FPS measurement sampling period<br>
-/// It is an optional parameter
 DEFINE_uint32(fps_sp, 1000, fps_sampling_period);
 
-/// \brief Flag to specify the number of sampling periods<br>
-/// It is an optional parameter
 DEFINE_uint32(n_sp, 10, num_sampling_periods);
 
-/// \brief Flag to enable statisics output<br>
-/// It is an optional parameter
 DEFINE_bool(show_stats, false, show_statistics);
 
-/// \brief Flag to enable and specify the number of channels additionally copied from real sources<br>
-/// It is an optional parameter
 DEFINE_uint32(duplicate_num, 0, duplication_channel_number);
 
-/// \brief Flag to enable real input FPS<br>
-/// It is an optional parameter
 DEFINE_bool(real_input_fps, false, real_input_fps);
 
-/// \brief Define parameter for input video files <br>
-/// It is a optional parameter
 DEFINE_string(i, "", input_video);

--- a/demos/multi_channel/common/multichannel_params.hpp
+++ b/demos/multi_channel/common/multichannel_params.hpp
@@ -9,41 +9,25 @@
 #include <gflags/gflags.h>
 
 static const char help_message[] = "Print a usage message";
-
 static const char model_path_message[] = "Required. Path to an .xml file with a trained model.";
-
 static const char target_device_message[] = "Optional. Specify the target device for a network (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo looks for a suitable plugin for a specified device.";
-
+                                            "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                            "The demo looks for a suitable plugin for a specified device.";
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report";
-
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
-"Absolute path to an .xml file with the kernels descriptions";
-
+                                           "Absolute path to an .xml file with the kernels descriptions";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
-"Absolute path to a shared library with the kernels implementations";
-
+                                                 "Absolute path to a shared library with the kernels implementations";
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
-
 static const char num_cameras[] = "Optional. Maximum number of processed camera inputs (web cameras)";
-
 static const char batch_size[] = "Optional. Batch size for processing (the number of frames processed per infer request)";
-
 static const char num_infer_requests[] = "Optional. Number of infer requests";
-
 static const char input_queue_size[] = "Optional. Frame queue size for input channels";
-
 static const char fps_sampling_period[] = "Optional. FPS measurement sampling period between timepoints in msec";
-
 static const char num_sampling_periods[] = "Optional. Number of sampling periods";
-
 static const char show_statistics[] = "Optional. Enable statistics report";
-
 static const char duplication_channel_number[] = "Optional. Enable and specify the number of channels additionally copied from real sources";
-
 static const char real_input_fps[] = "Optional. Disable input frames caching, for maximum throughput pipeline";
-
 static const char input_video[] = "Optional. Specify full path to input video files";
 
 /// \brief Define a flag for showing help message <br>

--- a/demos/multi_channel/face_detection_demo/multichannel_face_detection_params.hpp
+++ b/demos/multi_channel/face_detection_demo/multichannel_face_detection_params.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <gflags/gflags.h>
 
-/// @brief message for probability threshold argument
 static const char thresh_output_message[] = "Optional. Probability threshold for detections";
 
 /// \brief Flag to output raw scoring results<br>

--- a/demos/multi_channel/face_detection_demo/multichannel_face_detection_params.hpp
+++ b/demos/multi_channel/face_detection_demo/multichannel_face_detection_params.hpp
@@ -10,6 +10,4 @@
 
 static const char thresh_output_message[] = "Optional. Probability threshold for detections";
 
-/// \brief Flag to output raw scoring results<br>
-/// It is an optional parameter. Ignored for human-pose-estimation
 DEFINE_double(t, 0.5, thresh_output_message);

--- a/demos/multi_channel/object_detection_demo_yolov3/multichannel_object_detection_demo_yolov3_params.hpp
+++ b/demos/multi_channel/object_detection_demo_yolov3/multichannel_object_detection_demo_yolov3_params.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <gflags/gflags.h>
 
-/// @brief message for probability threshold argument
 static const char thresh_output_message[] = "Optional. Probability threshold for detections";
 
 /// \brief Flag to output raw scoring results<br>

--- a/demos/multi_channel/object_detection_demo_yolov3/multichannel_object_detection_demo_yolov3_params.hpp
+++ b/demos/multi_channel/object_detection_demo_yolov3/multichannel_object_detection_demo_yolov3_params.hpp
@@ -10,6 +10,4 @@
 
 static const char thresh_output_message[] = "Optional. Probability threshold for detections";
 
-/// \brief Flag to output raw scoring results<br>
-/// It is an optional parameter. Ignored for human-pose-estimation
 DEFINE_double(t, 0.5, thresh_output_message);

--- a/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
+++ b/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
@@ -29,36 +29,22 @@ static const char proposal_layer_name_message[] = "Optional. The name of output 
 static const char prob_layer_name_message[] = "Optional. The name of output probability layer. Default value is \"cls_prob\"";
 static const char plugin_message[] = "Optional. Enables messages from a plugin";
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "", image_message);
 
-/// @brief Define parameter for set model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", model_message);
 
-/// @brief device the target device to infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// @brief Define parameter for clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// @brief Custom bbox layer name
 DEFINE_string(bbox_name, "bbox_pred", bbox_layer_name_message);
-/// @brief Custom proposal layer name
 DEFINE_string(proposal_name, "proposal", proposal_layer_name_message);
-/// @brief Custom prob layer name
 DEFINE_string(prob_name, "cls_prob", prob_layer_name_message);
 
-/// @brief Enable plugin messages
 DEFINE_bool(p_msg, false, plugin_message);
 
 /**

--- a/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
+++ b/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
@@ -30,21 +30,14 @@ static const char prob_layer_name_message[] = "Optional. The name of output prob
 static const char plugin_message[] = "Optional. Enables messages from a plugin";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", image_message);
-
 DEFINE_string(m, "", model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_string(bbox_name, "bbox_pred", bbox_layer_name_message);
 DEFINE_string(proposal_name, "proposal", proposal_layer_name_message);
 DEFINE_string(prob_name, "cls_prob", prob_layer_name_message);
-
 DEFINE_bool(p_msg, false, plugin_message);
 
 /**

--- a/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
+++ b/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
@@ -15,25 +15,18 @@
 #include <chrono>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char image_message[] = "Required. Path to a .bmp image.";
-
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";
-
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device.";
-
+                                            "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                            "The demo will look for a suitable plugin for a specified device.";
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
-"Absolute path to the .xml file with the kernels descriptions.";
-
+                                           "Absolute path to the .xml file with the kernels descriptions.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
-"Absolute path to a shared library with the kernels implementations.";
-
+                                                 "Absolute path to a shared library with the kernels implementations.";
 static const char bbox_layer_name_message[] = "Optional. The name of output box prediction layer. Default value is \"bbox_pred\"";
 static const char proposal_layer_name_message[] = "Optional. The name of output proposal layer. Default value is \"proposal\"";
 static const char prob_layer_name_message[] = "Optional. The name of output probability layer. Default value is \"cls_prob\"";
-
 static const char plugin_message[] = "Optional. Enables messages from a plugin";
 
 /// @brief Define flag for showing help message <br>

--- a/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
+++ b/demos/object_detection_demo_faster_rcnn/object_detection_demo_faster_rcnn.h
@@ -14,36 +14,26 @@
 #include <limits>
 #include <chrono>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for images argument
 static const char image_message[] = "Required. Path to a .bmp image.";
 
-/// @brief message for model argument
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";
 
-/// @brief message for assigning cnn calculation to device
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device.";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
 "Absolute path to the .xml file with the kernels descriptions.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
 "Absolute path to a shared library with the kernels implementations.";
 
-/// @brief message for bbox layer name argument
 static const char bbox_layer_name_message[] = "Optional. The name of output box prediction layer. Default value is \"bbox_pred\"";
-/// @brief message for proposal layer name argument
 static const char proposal_layer_name_message[] = "Optional. The name of output proposal layer. Default value is \"proposal\"";
-/// @brief message for prob layer name argument
 static const char prob_layer_name_message[] = "Optional. The name of output probability layer. Default value is \"cls_prob\"";
 
-/// @brief message for plugin messages
 static const char plugin_message[] = "Optional. Enables messages from a plugin";
 
 /// @brief Define flag for showing help message <br>

--- a/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
+++ b/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
@@ -11,28 +11,19 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Required. Path to a video file (specify \"cam\" to work with camera).";
-
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";
-
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device.";
-
+                                            "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                            "The demo will look for a suitable plugin for a specified device.";
 static const char performance_counter_message[] = "Optional. Enables per-layer performance report.";
-
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
-"Absolute path to the .xml file with the kernel descriptions.";
-
+                                           "Absolute path to the .xml file with the kernel descriptions.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
-"Absolute path to a shared library with the kernel implementations.";
-
+                                                 "Absolute path to a shared library with the kernel implementations.";
 static const char thresh_output_message[] = "Optional. Probability threshold for detections.";
 static const char raw_output_message[] = "Optional. Inference results as raw values.";
-
 static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
-
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 /// \brief Define flag for showing help message <br>

--- a/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
+++ b/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
@@ -26,45 +26,26 @@ static const char raw_output_message[] = "Optional. Inference results as raw val
 static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// \brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// \brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "", video_message);
 
-/// \brief Define parameter for set model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", model_message);
 
-/// \brief device the target device to infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// \brief Enable per-layer performance report
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// \brief Flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// \brief Flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_double(t, 0.5, thresh_output_message);
 
-/// \brief Enables resizable input<br>
-/// It is an optional parameter
 DEFINE_bool(auto_resize, false, input_resizable_message);
 
-/// \brief Define a flag to disable showing processed video<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
 /**

--- a/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
+++ b/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
@@ -10,40 +10,29 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for images argument
 static const char video_message[] = "Required. Path to a video file (specify \"cam\" to work with camera).";
 
-/// @brief message for model argument
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";
 
-/// @brief message for assigning cnn calculation to device
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device.";
 
-/// @brief message for performance counters
 static const char performance_counter_message[] = "Optional. Enables per-layer performance report.";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
 "Absolute path to the .xml file with the kernel descriptions.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
 "Absolute path to a shared library with the kernel implementations.";
 
-/// @brief message for probability threshold argument
 static const char thresh_output_message[] = "Optional. Probability threshold for detections.";
-/// @brief message raw output flag
 static const char raw_output_message[] = "Optional. Inference results as raw values.";
 
-/// @brief message resizable input flag
 static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
 
-/// @brief Message do not show processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 /// \brief Define flag for showing help message <br>

--- a/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
+++ b/demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.hpp
@@ -27,25 +27,15 @@ static const char input_resizable_message[] = "Optional. Enables resizable input
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", video_message);
-
 DEFINE_string(m, "", model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_double(t, 0.5, thresh_output_message);
-
 DEFINE_bool(auto_resize, false, input_resizable_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
 
 /**

--- a/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
+++ b/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
@@ -11,30 +11,19 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Required. Path to a video file (specify \"cam\" to work with camera).";
-
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";
-
 static const char target_device_message[] = "Optional. Specify a target device to infer on (the list of available devices is shown below). " \
-"Default value is CPU. The demo will look for a suitable plugin for the specified device";
-
+                                            "Default value is CPU. The demo will look for a suitable plugin for the specified device";
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report.";
-
 static const char custom_cldnn_message[] = "Optional. Required for GPU custom kernels. "\
-"Absolute path to the .xml file with the kernels description.";
-
+                                           "Absolute path to the .xml file with the kernels description.";
 static const char custom_cpu_library_message[] = "Optional. Required for CPU custom layers. " \
-"Absolute path to a shared library with the layers implementation.";
-
+                                                 "Absolute path to a shared library with the layers implementation.";
 static const char thresh_output_message[] = "Optional. Probability threshold for detections.";
-
 static const char iou_thresh_output_message[] = "Optional. Filtering intersection over union threshold for overlapping boxes.";
-
 static const char raw_output_message[] = "Optional. Output inference results raw values showing.";
-
 static const char input_resizable_message[] = "Optional. Enable resizable input with support of ROI crop and auto resize.";
-
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 /// \brief Defines flag for showing help message <br>

--- a/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
+++ b/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
@@ -27,27 +27,16 @@ static const char input_resizable_message[] = "Optional. Enable resizable input 
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", video_message);
-
 DEFINE_string(m, "", model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_double(t, 0.5, thresh_output_message);
-
 DEFINE_double(iou_t, 0.4, iou_thresh_output_message);
-
 DEFINE_bool(auto_resize, false, input_resizable_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
 
 /**

--- a/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
+++ b/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
@@ -26,49 +26,28 @@ static const char raw_output_message[] = "Optional. Output inference results raw
 static const char input_resizable_message[] = "Optional. Enable resizable input with support of ROI crop and auto resize.";
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// \brief Defines flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// \brief Define parameter for set video file of reading from camera <br>
-/// It is a required parameter
 DEFINE_string(i, "", video_message);
 
-/// \brief Defines parameter for setting path to a model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", model_message);
 
-/// \brief Defines the target device to infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// \brief Enables per-layer performance report
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief Defines GPU custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Defines absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// \brief Defines flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// \brief Defines value of confidence threshold <br>
-/// It is an optional parameter
 DEFINE_double(t, 0.5, thresh_output_message);
 
-/// \brief Defines value of intersection over union threshold<br>
-/// It is an optional parameter
 DEFINE_double(iou_t, 0.4, iou_thresh_output_message);
 
-/// \brief Enables resizable input<br>
-/// It is an optional parameter
 DEFINE_bool(auto_resize, false, input_resizable_message);
 
-/// \brief Define a flag to disable showing processed video<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
 /**

--- a/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
+++ b/demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.hpp
@@ -10,43 +10,31 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief Message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief Message for images argument
 static const char video_message[] = "Required. Path to a video file (specify \"cam\" to work with camera).";
 
-/// @brief Message for model argument
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";
 
-/// @brief Message for assigning cnn calculation to device
 static const char target_device_message[] = "Optional. Specify a target device to infer on (the list of available devices is shown below). " \
 "Default value is CPU. The demo will look for a suitable plugin for the specified device";
 
-/// @brief Message for performance counters
 static const char performance_counter_message[] = "Optional. Enable per-layer performance report.";
 
-/// @brief Message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Optional. Required for GPU custom kernels. "\
 "Absolute path to the .xml file with the kernels description.";
 
-/// @brief Message for user library argument
 static const char custom_cpu_library_message[] = "Optional. Required for CPU custom layers. " \
 "Absolute path to a shared library with the layers implementation.";
 
-/// @brief Message for probability threshold argument
 static const char thresh_output_message[] = "Optional. Probability threshold for detections.";
 
-/// @brief Message for probability threshold argument
 static const char iou_thresh_output_message[] = "Optional. Filtering intersection over union threshold for overlapping boxes.";
 
-/// @brief Message raw output flag
 static const char raw_output_message[] = "Optional. Output inference results raw values showing.";
 
-/// @brief Message resizable input flag
 static const char input_resizable_message[] = "Optional. Enable resizable input with support of ROI crop and auto resize.";
 
-/// @brief Message do not show processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
 /// \brief Defines flag for showing help message <br>

--- a/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
+++ b/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
@@ -10,40 +10,28 @@
 #include <gflags/gflags.h>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Required. Video sequence to process.";
-
 static const char pedestrian_detection_model_message[] = "Required. Path to the Pedestrian Detection Retail model (.xml) file.";
 static const char pedestrian_reid_model_message[] = "Required. Path to the Pedestrian Reidentification Retail model (.xml) file.";
-
 static const char target_device_detection_message[] = "Optional. Specify the target device for pedestrian detection "\
                                                       "(the list of available devices is shown below). Default value is CPU. " \
                                                       "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin.";
-
 static const char target_device_reid_message[] = "Optional. Specify the target device for pedestrian reidentification "\
                                                  "(the list of available devices is shown below). Default value is CPU. " \
                                                  "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin.";
-
 static const char performance_counter_message[] = "Optional. Enable per-layer performance statistics.";
-
 static const char custom_cldnn_message[] = "Optional. For GPU custom kernels, if any. "\
                                             "Absolute path to the .xml file with the kernels description.";
-
 static const char custom_cpu_library_message[] = "Optional. For CPU custom layers, if any. "\
                                                   "Absolute path to a shared library with the kernels implementation.";
-
 static const char raw_output_message[] = "Optional. Output pedestrian tracking results in a raw format "\
                                           "(compatible with MOTChallenge format).";
-
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
-
 static const char delay_message[] = "Optional. Delay between frames used for visualization. "\
                                      "If negative, the visualization is turned off (like with the option 'no_show'). "\
                                      "If zero, the visualization is made frame-by-frame.";
-
 static const char output_log_message[] = "Optional. The file name to write output log file with results of pedestrian tracking. "\
                                           "The format of the log file is compatible with MOTChallenge format.";
-
 static const char first_frame_message[] = "Optional. The index of the first frame of video sequence to process. "
                                            "This has effect only if it is positive. The actual first frame captured "
                                            "depends on cv::VideoCapture implementation and may have slightly different "

--- a/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
+++ b/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
@@ -9,59 +9,45 @@
 #include <vector>
 #include <gflags/gflags.h>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for images argument
 static const char video_message[] = "Required. Video sequence to process.";
 
-/// @brief message for model arguments
 static const char pedestrian_detection_model_message[] = "Required. Path to the Pedestrian Detection Retail model (.xml) file.";
 static const char pedestrian_reid_model_message[] = "Required. Path to the Pedestrian Reidentification Retail model (.xml) file.";
 
-/// @brief message for assigning Pedestrian detection inference to device
 static const char target_device_detection_message[] = "Optional. Specify the target device for pedestrian detection "\
                                                       "(the list of available devices is shown below). Default value is CPU. " \
                                                       "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin.";
 
-/// @brief message for assigning Pedestrian Reidentification retail inference to device
 static const char target_device_reid_message[] = "Optional. Specify the target device for pedestrian reidentification "\
                                                  "(the list of available devices is shown below). Default value is CPU. " \
                                                  "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin.";
 
-/// @brief message for performance counters
 static const char performance_counter_message[] = "Optional. Enable per-layer performance statistics.";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Optional. For GPU custom kernels, if any. "\
                                             "Absolute path to the .xml file with the kernels description.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Optional. For CPU custom layers, if any. "\
                                                   "Absolute path to a shared library with the kernels implementation.";
 
-/// @brief message raw output flag
 static const char raw_output_message[] = "Optional. Output pedestrian tracking results in a raw format "\
                                           "(compatible with MOTChallenge format).";
 
-/// @brief message no show processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// @brief message for delay between frames
 static const char delay_message[] = "Optional. Delay between frames used for visualization. "\
                                      "If negative, the visualization is turned off (like with the option 'no_show'). "\
                                      "If zero, the visualization is made frame-by-frame.";
 
-/// @brief message for output log
 static const char output_log_message[] = "Optional. The file name to write output log file with results of pedestrian tracking. "\
                                           "The format of the log file is compatible with MOTChallenge format.";
 
-/// @brief message for the first frame
 static const char first_frame_message[] = "Optional. The index of the first frame of video sequence to process. "
                                            "This has effect only if it is positive. The actual first frame captured "
                                            "depends on cv::VideoCapture implementation and may have slightly different "
                                            "number.";
-/// @brief message for the last frame
 static const char last_frame_message[] = "Optional. The index of the last frame of video sequence to process. "\
                                           "This has effect only if it is positive.";
 

--- a/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
+++ b/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
@@ -41,33 +41,19 @@ static const char last_frame_message[] = "Optional. The index of the last frame 
 
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", video_message);
-
 DEFINE_string(m_det, "", pedestrian_detection_model_message);
-
 DEFINE_string(m_reid, "", pedestrian_reid_model_message);
-
 DEFINE_string(d_det, "CPU", target_device_detection_message);
-
 DEFINE_string(d_reid, "CPU", target_device_reid_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
-
 DEFINE_int32(delay, 3, delay_message);
-
 DEFINE_string(out, "", output_log_message);
-
 DEFINE_int32(first, -1, first_frame_message);
-
 DEFINE_int32(last, -1, last_frame_message);
 
 

--- a/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
+++ b/demos/pedestrian_tracker_demo/include/pedestrian_tracker_demo.hpp
@@ -40,60 +40,34 @@ static const char last_frame_message[] = "Optional. The index of the last frame 
                                           "This has effect only if it is positive.";
 
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "", video_message);
 
-/// @brief Define parameter for pedestrian detection model file <br>
-/// It is a required parameter
 DEFINE_string(m_det, "", pedestrian_detection_model_message);
 
-/// @brief Define parameter for pedestrian reidentification model file <br>
-/// It is a required parameter
 DEFINE_string(m_reid, "", pedestrian_reid_model_message);
 
-/// @brief device the target device for pedestrian detection infer on <br>
 DEFINE_string(d_det, "CPU", target_device_detection_message);
 
-/// @brief device the target device for pedestrian reidentification infer on <br>
 DEFINE_string(d_reid, "CPU", target_device_reid_message);
 
-/// @brief Enable per-layer performance report
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// \brief Flag to output pedestrian tracking results in raw format<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// @brief Flag to disable processed video showing<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
-/// @brief Define delay for visualization <br>
-/// It is an optional parameter
 DEFINE_int32(delay, 3, delay_message);
 
-/// @brief Define output log path to store tracking results <br>
-/// It is an optional parameter
 DEFINE_string(out, "", output_log_message);
 
-/// @brief Define the first frame to process <br>
-/// It is an optional parameter
 DEFINE_int32(first, -1, first_frame_message);
 
-/// @brief Define the last frame to process <br>
-/// It is an optional parameter
 DEFINE_int32(last, -1, last_frame_message);
 
 

--- a/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
+++ b/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
@@ -10,73 +10,49 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Required for video or image files input. Path to video or image files.";
-
 static const char detection_model_message[] = "Required. Path to the Vehicle and License Plate Detection model .xml file.";
 static const char vehicle_attribs_model_message[] = "Optional. Path to the Vehicle Attributes model .xml file.";
 static const char lpr_model_message[] = "Optional. Path to the License Plate Recognition model .xml file.";
-
 static const char target_device_message[] = "Optional. Specify the target device for Vehicle Detection "\
                                             "(the list of available devices is shown below). Default value is CPU. " \
                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The application looks for a suitable plugin for the specified device.";
-
 static const char target_device_message_vehicle_attribs[] = "Optional. Specify the target device for Vehicle Attributes "\
                                                             "(the list of available devices is shown below). Default value is CPU. " \
                                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                             "The application looks for a suitable plugin for the specified device.";
-
 static const char target_device_message_lpr[] = "Optional. Specify the target device for License Plate Recognition "\
                                                 "(the list of available devices is shown below). Default value is CPU. " \
                                                 "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                 "The application looks for a suitable plugin for the specified device.";
-
 static const char performance_counter_message[] = "Optional. Enables per-layer performance statistics.";
-
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
-
 static const char thresh_output_message[] = "Optional. Probability threshold for vehicle and license plate detections.";
-
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
-"Absolute path to an .xml file with the kernels description.";
-
+                                           "Absolute path to an .xml file with the kernels description.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
-"Absolute path to a shared library with the kernels implementation.";
-
+                                                 "Absolute path to a shared library with the kernels implementation.";
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
-
 static const char input_resizable_message[] = "Optional. Enable resizable input with support of ROI crop and auto resize.";
-
 static const char ninfer_request_message[] = "Optional. Number of infer requests. 0 sets the number of infer requests equal to the number of inputs.";
-
 static const char num_cameras[] = "Required for web camera input. Maximum number of processed camera inputs (web cameras).";
-
 static const char fpga_device_ids_message[] = "Optional. Specify FPGA device IDs (0,1,n).";
-
 static const char loop_video_output_message[] = "Optional. Enable playing video on a loop.";
-
 static const char input_queue_size[] = "Optional. Number of allocated frames. It is a multiplier of the number of inputs.";
-
 static const char ninputs_message[] = "Optional. Specify the number of channels generated from provided inputs (with -i and -nc keys). "\
-"For example, if only one camera is provided, but -ni is set to 2, the demo will process frames as if they are captured from two cameras. "\
-"0 sets the number of input channels equal to the number of provided inputs.";
-
+                                      "For example, if only one camera is provided, but -ni is set to 2, the demo will process frames as if they are captured from two cameras. "\
+                                      "0 sets the number of input channels equal to the number of provided inputs.";
 static const char fps[] = "Optional. Set the playback speed not faster than the specified FPS. 0 removes the upper bound.";
-
 static const char worker_threads[] = "Optional. Set the number of threads including the main thread a Worker class will use.";
-
 static const char display_resolution_message[] = "Optional. Specify the maximum output window resolution.";
-
 static const char use_tag_scheduler_message[] = "Required for HDDL plugin only. "
                                                 "If not set, the performance on Intel(R) Movidius(TM) X VPUs will not be optimal. "
                                                 "Running each network on a set of Intel(R) Movidius(TM) X VPUs with a specific tag. "
                                                 "You must specify the number of VPUs for each network in the hddl_service.config file. "
                                                 "Refer to the corresponding README file for more information.";
-
 static const char infer_num_threads_message[] = "Optional. Number of threads to use for inference on the CPU "
                                                 "(including HETERO and MULTI cases).";
-
 static const char infer_num_streams_message[] = "Optional. Number of streams to use for inference on the CPU or/and GPU in throughput mode "
                                                 "(for HETERO and MULTI device cases use format <device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)";
 

--- a/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
+++ b/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
@@ -9,99 +9,74 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for enabling input video
 static const char video_message[] = "Required for video or image files input. Path to video or image files.";
 
-/// @brief message for model argument
 static const char detection_model_message[] = "Required. Path to the Vehicle and License Plate Detection model .xml file.";
 static const char vehicle_attribs_model_message[] = "Optional. Path to the Vehicle Attributes model .xml file.";
 static const char lpr_model_message[] = "Optional. Path to the License Plate Recognition model .xml file.";
 
-/// @brief message for assigning vehicle detection inference to device
 static const char target_device_message[] = "Optional. Specify the target device for Vehicle Detection "\
                                             "(the list of available devices is shown below). Default value is CPU. " \
                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The application looks for a suitable plugin for the specified device.";
 
-/// @brief message for assigning vehicle attributes to device
 static const char target_device_message_vehicle_attribs[] = "Optional. Specify the target device for Vehicle Attributes "\
                                                             "(the list of available devices is shown below). Default value is CPU. " \
                                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                             "The application looks for a suitable plugin for the specified device.";
 
-/// @brief message for assigning LPR inference to device
 static const char target_device_message_lpr[] = "Optional. Specify the target device for License Plate Recognition "\
                                                 "(the list of available devices is shown below). Default value is CPU. " \
                                                 "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                 "The application looks for a suitable plugin for the specified device.";
 
-/// @brief message for performance counters
 static const char performance_counter_message[] = "Optional. Enables per-layer performance statistics.";
 
-/// @brief message raw output flag
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
 
-/// @brief message for probability threshold argument
 static const char thresh_output_message[] = "Optional. Probability threshold for vehicle and license plate detections.";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
 "Absolute path to an .xml file with the kernels description.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
 "Absolute path to a shared library with the kernels implementation.";
 
-/// @brief message no show processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// @brief message resizable input flag
 static const char input_resizable_message[] = "Optional. Enable resizable input with support of ROI crop and auto resize.";
 
-/// @brief message for number of infer requests
 static const char ninfer_request_message[] = "Optional. Number of infer requests. 0 sets the number of infer requests equal to the number of inputs.";
 
-/// @brief message for number of camera inputs
 static const char num_cameras[] = "Required for web camera input. Maximum number of processed camera inputs (web cameras).";
 
-/// @brief message for FPGA device IDs
 static const char fpga_device_ids_message[] = "Optional. Specify FPGA device IDs (0,1,n).";
 
-/// @brief Message for looping video argument
 static const char loop_video_output_message[] = "Optional. Enable playing video on a loop.";
 
-/// @brief message for inputs queue size
 static const char input_queue_size[] = "Optional. Number of allocated frames. It is a multiplier of the number of inputs.";
 
-/// @brief message for enabling channel duplication
 static const char ninputs_message[] = "Optional. Specify the number of channels generated from provided inputs (with -i and -nc keys). "\
 "For example, if only one camera is provided, but -ni is set to 2, the demo will process frames as if they are captured from two cameras. "\
 "0 sets the number of input channels equal to the number of provided inputs.";
 
-/// @brief message for setting playing fps
 static const char fps[] = "Optional. Set the playback speed not faster than the specified FPS. 0 removes the upper bound.";
 
-/// @brief message for setting the number of threads in Worker
 static const char worker_threads[] = "Optional. Set the number of threads including the main thread a Worker class will use.";
 
-/// @brief Message for display resolution argument
 static const char display_resolution_message[] = "Optional. Specify the maximum output window resolution.";
 
-/// @brief Message for using tag scheduler
 static const char use_tag_scheduler_message[] = "Required for HDDL plugin only. "
                                                 "If not set, the performance on Intel(R) Movidius(TM) X VPUs will not be optimal. "
                                                 "Running each network on a set of Intel(R) Movidius(TM) X VPUs with a specific tag. "
                                                 "You must specify the number of VPUs for each network in the hddl_service.config file. "
                                                 "Refer to the corresponding README file for more information.";
 
-/// @brief message for #threads for CPU inference
 static const char infer_num_threads_message[] = "Optional. Number of threads to use for inference on the CPU "
                                                 "(including HETERO and MULTI cases).";
 
-/// @brief message for #streams for CPU inference
 static const char infer_num_streams_message[] = "Optional. Number of streams to use for inference on the CPU or/and GPU in throughput mode "
                                                 "(for HETERO and MULTI device cases use format <device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)";
 

--- a/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
+++ b/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
@@ -57,57 +57,31 @@ static const char infer_num_streams_message[] = "Optional. Number of streams to 
                                                 "(for HETERO and MULTI device cases use format <device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", video_message);
-
 DEFINE_string(m, "", detection_model_message);
-
 DEFINE_string(m_va, "", vehicle_attribs_model_message);
-
 DEFINE_string(m_lpr, "", lpr_model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(d_va, "CPU", target_device_message_vehicle_attribs);
-
 DEFINE_string(d_lpr, "CPU", target_device_message_lpr);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_double(t, 0.5, thresh_output_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
-
 DEFINE_bool(auto_resize, false, input_resizable_message);
-
 DEFINE_uint32(nireq, 0, ninfer_request_message);
-
 DEFINE_uint32(nc, 0, num_cameras);
-
 DEFINE_string(fpga_device_ids, "", fpga_device_ids_message);
-
 DEFINE_bool(loop_video, false, loop_video_output_message);
-
 DEFINE_uint32(n_iqs, 3, input_queue_size);
-
 DEFINE_uint32(ni, 0, ninputs_message);
-
 DEFINE_uint32(fps, 0, fps);
-
 DEFINE_uint32(n_wt, 1, worker_threads);
-
 DEFINE_string(display_resolution, "1920x1080", display_resolution_message);
-
 DEFINE_bool(tag, false, use_tag_scheduler_message);
-
 DEFINE_uint32(nthreads, 0, infer_num_threads_message);
-
 DEFINE_string(nstreams, "", infer_num_streams_message);
 
 /**

--- a/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
+++ b/demos/security_barrier_camera_demo/security_barrier_camera_demo.hpp
@@ -56,105 +56,58 @@ static const char infer_num_threads_message[] = "Optional. Number of threads to 
 static const char infer_num_streams_message[] = "Optional. Number of streams to use for inference on the CPU or/and GPU in throughput mode "
                                                 "(for HETERO and MULTI device cases use format <device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)";
 
-/// \brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// \brief Define parameter for input video files <br>
-/// It is a optional parameter
 DEFINE_string(i, "", video_message);
 
-/// \brief Define parameter for vehicle detection  model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", detection_model_message);
 
-/// \brief Define parameter for vehicle attributes model file <br>
-/// It is a required parameter
 DEFINE_string(m_va, "", vehicle_attribs_model_message);
 
-/// \brief Define parameter for vehicle detection  model file <br>
-/// It is a required parameter
 DEFINE_string(m_lpr, "", lpr_model_message);
 
-/// \brief device the target device for vehicle detection infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// \brief device the target device for age gender detection on <br>
 DEFINE_string(d_va, "CPU", target_device_message_vehicle_attribs);
 
-/// \brief device the target device for head pose detection on <br>
 DEFINE_string(d_lpr, "CPU", target_device_message_lpr);
 
-/// \brief enable per-layer performance report <br>
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// \brief Flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// \brief Flag to output raw scoring results<br>
-/// It is an optional parameter
 DEFINE_double(t, 0.5, thresh_output_message);
 
-/// @brief clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// \brief Flag to disable processed video showing<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
-/// \brief Enables resizable input<br>
-/// It is an optional parameter
 DEFINE_bool(auto_resize, false, input_resizable_message);
 
-/// \brief Flag to specify number of infer requests<br>
-/// It is an optional parameter
 DEFINE_uint32(nireq, 0, ninfer_request_message);
 
-/// \brief Flag to specify number of expected input channels<br>
-/// It is an optional parameter
 DEFINE_uint32(nc, 0, num_cameras);
 
-/// \brief Flag to specify FPGA device IDs
-/// It is an optional parameter
 DEFINE_string(fpga_device_ids, "", fpga_device_ids_message);
 
-/// \brief Define a flag to loop video<br>
-/// It is an optional parameter
 DEFINE_bool(loop_video, false, loop_video_output_message);
 
-/// \brief Flag to specify number of allocated frames. It is a multiplyir of inputs number.<br>
-/// It is an optional parameter
 DEFINE_uint32(n_iqs, 3, input_queue_size);
 
-/// \brief Flag to specify number of input channels. It will multiply channels by reusing provided ones if there is lack of inputs<br>
-/// It is an optional parameter
 DEFINE_uint32(ni, 0, ninputs_message);
 
-/// \brief Define parameter for playing FPS <br>
-/// It is a optional parameter
 DEFINE_uint32(fps, 0, fps);
 
-/// \brief Define parameter for the number of threads including the main theread a Worker will use<br>
-/// It is a optional parameter
 DEFINE_uint32(n_wt, 1, worker_threads);
 
-/// \brief Flag to specify the maximum output window resolution<br>
-/// It is an optional parameter
 DEFINE_string(display_resolution, "1920x1080", display_resolution_message);
 
-/// \brief Message for using tag scheduler<br>
-/// It is a optional parameter
 DEFINE_bool(tag, false, use_tag_scheduler_message);
 
-/// @brief Number of threads to use for inference on the CPU in throughput mode (also affects Hetero cases)
 DEFINE_uint32(nthreads, 0, infer_num_threads_message);
 
-/// @brief Number of streams to use for inference on the CPU (also affects Hetero cases)
 DEFINE_string(nstreams, "", infer_num_streams_message);
 
 /**

--- a/demos/segmentation_demo/segmentation_demo.h
+++ b/demos/segmentation_demo/segmentation_demo.h
@@ -19,8 +19,7 @@ static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
                                            "Absolute path to the .xml file with the kernels descriptions.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
                                                  "Absolute path to a shared library with the kernels implementations.";
-
-static constexpr char config_message[] = "Path to the configuration file. Default value: \"config\".";
+static const char config_message[] = "Path to the configuration file. Default value: \"config\".";
 
 DEFINE_string(c, "", custom_cldnn_message);
 DEFINE_string(l, "", custom_cpu_library_message);

--- a/demos/segmentation_demo/segmentation_demo.h
+++ b/demos/segmentation_demo/segmentation_demo.h
@@ -22,29 +22,18 @@ static const char custom_cpu_library_message[] = "Required for CPU custom layers
 
 static constexpr char config_message[] = "Path to the configuration file. Default value: \"config\".";
 
-/// @brief Define parameter for clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "", image_message);
 
-/// @brief Define parameter for set model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", model_message);
 
-/// @brief device the target device to infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// @brief Define path to plugin config
 DEFINE_string(config, "", config_message);
 
 

--- a/demos/segmentation_demo/segmentation_demo.h
+++ b/demos/segmentation_demo/segmentation_demo.h
@@ -9,29 +9,22 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for images argument
 static const char image_message[] = "Required. Path to an .bmp image.";
 
-/// @brief message for model argument
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";\
 
-/// @brief message for assigning cnn calculation to device
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
 "The demo will look for a suitable plugin for a specified device.";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
 "Absolute path to the .xml file with the kernels descriptions.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
 "Absolute path to a shared library with the kernels implementations.";
 
-/// @brief message for config argument
 static constexpr char config_message[] = "Path to the configuration file. Default value: \"config\".";
 
 /// @brief Define parameter for clDNN custom kernels path <br>

--- a/demos/segmentation_demo/segmentation_demo.h
+++ b/demos/segmentation_demo/segmentation_demo.h
@@ -10,20 +10,15 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char image_message[] = "Required. Path to an .bmp image.";
-
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";\
-
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
-"Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
-"The demo will look for a suitable plugin for a specified device.";
-
+                                            "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
+                                            "The demo will look for a suitable plugin for a specified device.";
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
-"Absolute path to the .xml file with the kernels descriptions.";
-
+                                           "Absolute path to the .xml file with the kernels descriptions.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
-"Absolute path to a shared library with the kernels implementations.";
+                                                 "Absolute path to a shared library with the kernels implementations.";
 
 static constexpr char config_message[] = "Path to the configuration file. Default value: \"config\".";
 

--- a/demos/segmentation_demo/segmentation_demo.h
+++ b/demos/segmentation_demo/segmentation_demo.h
@@ -23,17 +23,11 @@ static const char custom_cpu_library_message[] = "Required for CPU custom layers
 static constexpr char config_message[] = "Path to the configuration file. Default value: \"config\".";
 
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", image_message);
-
 DEFINE_string(m, "", model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(config, "", config_message);
 
 

--- a/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
+++ b/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
@@ -9,133 +9,96 @@
 #include <vector>
 #include <gflags/gflags.h>
 
-/// @brief Message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief Message for images argument
 static const char video_message[] = "Required. Path to a video or image file. Default value is \"cam\" to work with camera.";
 
-/// @brief Message for model argument
 static const char person_action_detection_model_message[] = "Required. Path to the Person/Action Detection Retail model (.xml) file.";
 static const char face_detection_model_message[] = "Required. Path to the Face Detection Retail model (.xml) file.";
 static const char facial_landmarks_model_message[] = "Required. Path to the Facial Landmarks Regression Retail model (.xml) file.";
 static const char face_reid_model_message[] = "Required. Path to the Face Reidentification Retail model (.xml) file.";
 
-/// @brief Message for assigning Person/Action detection inference to device
 static const char target_device_message_action_detection[] = "Optional. Specify the target device for Person/Action Detection Retail "\
                                                              "(the list of available devices is shown below).Default value is CPU. " \
                                                              "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                              "The application looks for a suitable plugin for the specified device.";
 
-/// @brief Message for assigning Face Detection inference to device
 static const char target_device_message_face_detection[] = "Optional. Specify the target device for Face Detection Retail "\
                                                            "(the list of available devices is shown below).Default value is CPU. " \
                                                            "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                            "The application looks for a suitable plugin for the specified device.";
 
-/// @brief Message for assigning Landmarks Regression retail inference to device
 static const char target_device_message_landmarks_regression[] = "Optional. Specify the target device for Landmarks Regression Retail "\
                                                                  "(the list of available devices is shown below).Default value is CPU. " \
                                                                  "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                                  "The application looks for a suitable plugin for the specified device.";
 
-/// @brief Message for assigning Face Reidentification retail inference to device
 static const char target_device_message_face_reid[] = "Optional. Specify the target device for Face Reidentification Retail "\
                                                       "(the list of available devices is shown below).Default value is CPU. " \
                                                       "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                       "The application looks for a suitable plugin for the specified device.";
 
-/// @brief Message for greedy reid matching
 static const char greedy_reid_matching_message[] = "Optional. Use faster greedy matching algorithm in face reid.";
 
-/// @brief Message for performance counters
 static const char performance_counter_message[] = "Optional. Enables per-layer performance statistics.";
 
-/// @brief Message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Optional. For GPU custom kernels, if any. "\
 "Absolute path to an .xml file with the kernels description.";
 
-/// @brief Message for user library argument
 static const char custom_cpu_library_message[] = "Optional. For CPU custom layers, if any. " \
 "Absolute path to a shared library with the kernels implementation.";
 
-/// @brief Message for probability threshold argument for face detections
 static const char face_threshold_output_message[] = "Optional. Probability threshold for face detections.";
 
-/// @brief Message for probability threshold argument for person/action detection
 static const char person_threshold_output_message[] = "Optional. Probability threshold for person/action detection.";
 
-// @brief Message for probability threshold argument for action recognition
 static const char action_threshold_output_message[] = "Optional. Probability threshold for action recognition.";
 
-/// @brief Message for cosine distance threshold for face reidentification
 static const char threshold_output_message_face_reid[] = "Optional. Cosine distance threshold between two vectors for face reidentification.";
 
-/// @brief Message for faces gallery path
 static const char reid_gallery_path_message[] = "Optional. Path to a faces gallery in .json format.";
 
-/// @brief Message for output video path
 static const char output_video_message[] = "Optional. File to write output video with visualization to.";
 
-/// @brief Message action statistics output flag
 static const char act_stat_output_message[] = "Optional. Output file name to save per-person action statistics in.";
 
-/// @brief Message raw output flag
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
 
-/// @brief Message no show processed video
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
 
-/// @brief Message input image height for face detector
 static const char input_image_height_output_message[] = "Optional. Input image height for face detector.";
 
-/// @brief Message input image width for face detector
 static const char input_image_width_output_message[] = "Optional. Input image width for face detector.";
 
-/// @brief Message expand ratio for bbox
 static const char expand_ratio_output_message[] = "Optional. Expand ratio for bbox before face recognition.";
 
-/// @brief Message last frame number to handle
 static const char last_frame_message[] = "Optional. Last frame number to handle in demo. If negative, handle all input video.";
 
-/// @brief Message teacher id
 static const char teacher_id_message[] = "Optional. ID of a teacher. You must also set a faces gallery parameter (-fg) to use it.";
 
-/// @brief Message min action duration
 static const char min_action_duration_message[] = "Optional. Minimum action duration in seconds.";
 
-/// @brief Message same action time delta
 static const char same_action_time_delta_message[] = "Optional. Maximum time difference between actions in seconds.";
 
-/// @brief Message student actions
 static const char student_actions_message[] = "Optional. List of student actions separated by a comma.";
 
-/// @brief Message student actions for top-k mode
 static const char top_actions_message[] = "Optional. List of student actions (for top-k mode) separated by a comma.";
 
-/// @brief Message teacher actions
 static const char teacher_actions_message[] = "Optional. List of teacher actions separated by a comma.";
 
-/// @brief Message for target action name for top-k mode
 static const char target_action_name_message[] = "Optional. Target action name.";
 
-/// @brief Message for number of target actions
 static const char target_actions_num_message[] = "Optional. Number of first K students. If this parameter is positive,"\
 "the demo detects first K persons with the action, pointed by the parameter 'top_id'";
 
-/// @brief Message crop gallery
 static const char crop_gallery_message[] = "Optional. Crop images during faces gallery creation.";
 
-/// @brief Message for probability threshold argument for face detections during database registration.
 static const char face_threshold_registration_output_message[] = "Optional. Probability threshold for face detections during database registration.";
 
-/// @brief Message for minumum input size for faces database registration.
 static const char min_size_fr_reg_output_message[] = "Optional. Minimum input size for faces during database registration.";
 
-/// @brief Message action statistics output flag
 static const char act_det_output_message[] = "Optional. Output file name to save per-person action detections in.";
 
-/// @brief Message for number of frames for action tracker
 static const char tracker_smooth_size_message[] = "Optional. Number of frames to smooth actions.";
 
 /// @brief Define flag for showing help message <br>

--- a/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
+++ b/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
@@ -65,157 +65,84 @@ static const char min_size_fr_reg_output_message[] = "Optional. Minimum input si
 static const char act_det_output_message[] = "Optional. Output file name to save per-person action detections in.";
 static const char tracker_smooth_size_message[] = "Optional. Number of frames to smooth actions.";
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "cam", video_message);
 
-/// @brief Define parameter for person/action detection model file <br>
-/// It is a required parameter
 DEFINE_string(m_act, "", person_action_detection_model_message);
 
-/// @brief Define parameter for face detection model file <br>
-/// It is a required parameter
 DEFINE_string(m_fd, "", face_detection_model_message);
 
-/// @brief Define parameter for facial landmarks model file <br>
-/// It is a required parameter
 DEFINE_string(m_lm, "", facial_landmarks_model_message);
 
-/// @brief Define parameter for face reidentification model file <br>
-/// It is a required parameter
 DEFINE_string(m_reid, "", face_reid_model_message);
 
-/// @brief device the target device for person/action detection infer on <br>
 DEFINE_string(d_act, "CPU", target_device_message_action_detection);
 
-/// @brief device the target device for face detection on <br>
 DEFINE_string(d_fd, "CPU", target_device_message_face_detection);
 
-/// @brief device the target device for facial landnmarks regression infer on <br>
 DEFINE_string(d_lm, "CPU", target_device_message_landmarks_regression);
 
-/// @brief device the target device for face reidentification infer on <br>
 DEFINE_string(d_reid, "CPU", target_device_message_face_reid);
 
-/// @brief Use greedy matching algorithm in face reid
 DEFINE_bool(greedy_reid_matching, false, greedy_reid_matching_message);
 
-/// @brief Enable per-layer performance report
 DEFINE_bool(pc, false, performance_counter_message);
 
-/// @brief clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// @brief Output file name to save per-person action statistics in.
-/// It is an optional parameter
 DEFINE_string(ad, "", act_stat_output_message);
 
-/// @brief Flag to output raw pipeline results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
-/// @brief Define probability threshold for person/action detection <br>
-/// It is an optional parameter
 DEFINE_double(t_ad, 0.3, person_threshold_output_message);
 
-/// @brief Define probability threshold for action recognition <br>
-/// It is an optional parameter
 DEFINE_double(t_ar, 0.75, action_threshold_output_message);
 
-/// @brief Define probability threshold for face detections <br>
-/// It is an optional parameter
 DEFINE_double(t_fd, 0.6, face_threshold_output_message);
 
-/// @brief Define cosine distance threshold for face reid <br>
-/// It is an optional parameter
 DEFINE_double(t_reid, 0.7, threshold_output_message_face_reid);
 
-/// @brief Path to a faces gallery for reid <br>
-/// It is a optional parameter
 DEFINE_string(fg, "", reid_gallery_path_message);
 
-/// @brief File to write output video with visualization to.
-/// It is a optional parameter
 DEFINE_string(out_v, "", output_video_message);
 
-/// @brief Flag to disable processed video showing<br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_processed_video);
 
-/// @brief Input image height for face detector<br>
-/// It is an optional parameter
 DEFINE_int32(inh_fd, 600, input_image_height_output_message);
 
-/// @brief Input image width for face detector<br>
-/// It is an optional parameter
 DEFINE_int32(inw_fd, 600, input_image_width_output_message);
 
-/// @brief Expand ratio for bbox before face recognition<br>
-/// It is an optional parameter
 DEFINE_double(exp_r_fd, 1.15, face_threshold_output_message);
 
-/// @brief Input image height for face detector<br>
-/// It is an optional parameter
 DEFINE_int32(last_frame, -1, last_frame_message);
 
-/// @brief Label of teacher<br>
-/// It is an optional parameter
 DEFINE_string(teacher_id, "", teacher_id_message);
 
-/// @brief Min action duration<br>
-/// It is an optional parameter
 DEFINE_double(min_ad, 1.0, min_action_duration_message);
 
-/// @brief Same action time delta<br>
-/// It is an optional parameter
 DEFINE_double(d_ad, 1.0, same_action_time_delta_message);
 
-/// @brief Labels of student actions<br>
-/// It is an optional parameter
 DEFINE_string(student_ac, "sitting,standing,raising_hand", student_actions_message);
 
-/// @brief Labels of student actions for top-k mode<br>
-/// It is an optional parameter
 DEFINE_string(top_ac, "sitting,raising_hand", top_actions_message);
 
-/// @brief Labels of teacher actions<br>
-/// It is an optional parameter
 DEFINE_string(teacher_ac, "standing,writing,demonstrating", teacher_actions_message);
 
-/// @brief Define target action name for top-k mode <br>
-/// It is an optional parameter
 DEFINE_string(top_id, "raising_hand", target_action_name_message);
 
-/// @brief Define maximal number of target actions <br>
-/// It is an optional parameter
 DEFINE_int32(a_top, -1, target_actions_num_message);
 
-/// @brief Flag to enable image cropping during database creation<br>
-/// It is an optional parameter
 DEFINE_bool(crop_gallery, false, crop_gallery_message);
 
-/// @brief Define probability threshold for face detections during registration<br>
-/// It is an optional parameter
 DEFINE_double(t_reg_fd, 0.9, face_threshold_registration_output_message);
 
-/// @brief Minimum input image width & heigh for sucessful face registration<br>
-/// It is an optional parameter
 DEFINE_int32(min_size_fr, 128, min_size_fr_reg_output_message);
 
-/// @brief Output file name to save per-person action detections in.
-/// It is an optional parameter
 DEFINE_string(al, "", act_det_output_message);
 
-/// @brief Number of frames to smooth actions<br>
-/// It is an optional parameter
 DEFINE_int32(ss_t, -1, tracker_smooth_size_message);
 
 /**

--- a/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
+++ b/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
@@ -66,83 +66,44 @@ static const char act_det_output_message[] = "Optional. Output file name to save
 static const char tracker_smooth_size_message[] = "Optional. Number of frames to smooth actions.";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "cam", video_message);
-
 DEFINE_string(m_act, "", person_action_detection_model_message);
-
 DEFINE_string(m_fd, "", face_detection_model_message);
-
 DEFINE_string(m_lm, "", facial_landmarks_model_message);
-
 DEFINE_string(m_reid, "", face_reid_model_message);
-
 DEFINE_string(d_act, "CPU", target_device_message_action_detection);
-
 DEFINE_string(d_fd, "CPU", target_device_message_face_detection);
-
 DEFINE_string(d_lm, "CPU", target_device_message_landmarks_regression);
-
 DEFINE_string(d_reid, "CPU", target_device_message_face_reid);
-
 DEFINE_bool(greedy_reid_matching, false, greedy_reid_matching_message);
-
 DEFINE_bool(pc, false, performance_counter_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_string(ad, "", act_stat_output_message);
-
 DEFINE_bool(r, false, raw_output_message);
-
 DEFINE_double(t_ad, 0.3, person_threshold_output_message);
-
 DEFINE_double(t_ar, 0.75, action_threshold_output_message);
-
 DEFINE_double(t_fd, 0.6, face_threshold_output_message);
-
 DEFINE_double(t_reid, 0.7, threshold_output_message_face_reid);
-
 DEFINE_string(fg, "", reid_gallery_path_message);
-
 DEFINE_string(out_v, "", output_video_message);
-
 DEFINE_bool(no_show, false, no_show_processed_video);
-
 DEFINE_int32(inh_fd, 600, input_image_height_output_message);
-
 DEFINE_int32(inw_fd, 600, input_image_width_output_message);
-
 DEFINE_double(exp_r_fd, 1.15, face_threshold_output_message);
-
 DEFINE_int32(last_frame, -1, last_frame_message);
-
 DEFINE_string(teacher_id, "", teacher_id_message);
-
 DEFINE_double(min_ad, 1.0, min_action_duration_message);
-
 DEFINE_double(d_ad, 1.0, same_action_time_delta_message);
-
 DEFINE_string(student_ac, "sitting,standing,raising_hand", student_actions_message);
-
 DEFINE_string(top_ac, "sitting,raising_hand", top_actions_message);
-
 DEFINE_string(teacher_ac, "standing,writing,demonstrating", teacher_actions_message);
-
 DEFINE_string(top_id, "raising_hand", target_action_name_message);
-
 DEFINE_int32(a_top, -1, target_actions_num_message);
-
 DEFINE_bool(crop_gallery, false, crop_gallery_message);
-
 DEFINE_double(t_reg_fd, 0.9, face_threshold_registration_output_message);
-
 DEFINE_int32(min_size_fr, 128, min_size_fr_reg_output_message);
-
 DEFINE_string(al, "", act_det_output_message);
-
 DEFINE_int32(ss_t, -1, tracker_smooth_size_message);
 
 /**

--- a/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
+++ b/demos/smart_classroom_demo/include/smart_classroom_demo.hpp
@@ -10,95 +10,59 @@
 #include <gflags/gflags.h>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char video_message[] = "Required. Path to a video or image file. Default value is \"cam\" to work with camera.";
-
 static const char person_action_detection_model_message[] = "Required. Path to the Person/Action Detection Retail model (.xml) file.";
 static const char face_detection_model_message[] = "Required. Path to the Face Detection Retail model (.xml) file.";
 static const char facial_landmarks_model_message[] = "Required. Path to the Facial Landmarks Regression Retail model (.xml) file.";
 static const char face_reid_model_message[] = "Required. Path to the Face Reidentification Retail model (.xml) file.";
-
 static const char target_device_message_action_detection[] = "Optional. Specify the target device for Person/Action Detection Retail "\
                                                              "(the list of available devices is shown below).Default value is CPU. " \
                                                              "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                              "The application looks for a suitable plugin for the specified device.";
-
 static const char target_device_message_face_detection[] = "Optional. Specify the target device for Face Detection Retail "\
                                                            "(the list of available devices is shown below).Default value is CPU. " \
                                                            "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                            "The application looks for a suitable plugin for the specified device.";
-
 static const char target_device_message_landmarks_regression[] = "Optional. Specify the target device for Landmarks Regression Retail "\
                                                                  "(the list of available devices is shown below).Default value is CPU. " \
                                                                  "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                                  "The application looks for a suitable plugin for the specified device.";
-
 static const char target_device_message_face_reid[] = "Optional. Specify the target device for Face Reidentification Retail "\
                                                       "(the list of available devices is shown below).Default value is CPU. " \
                                                       "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                                       "The application looks for a suitable plugin for the specified device.";
-
 static const char greedy_reid_matching_message[] = "Optional. Use faster greedy matching algorithm in face reid.";
-
 static const char performance_counter_message[] = "Optional. Enables per-layer performance statistics.";
-
 static const char custom_cldnn_message[] = "Optional. For GPU custom kernels, if any. "\
-"Absolute path to an .xml file with the kernels description.";
-
+                                           "Absolute path to an .xml file with the kernels description.";
 static const char custom_cpu_library_message[] = "Optional. For CPU custom layers, if any. " \
-"Absolute path to a shared library with the kernels implementation.";
-
+                                                 "Absolute path to a shared library with the kernels implementation.";
 static const char face_threshold_output_message[] = "Optional. Probability threshold for face detections.";
-
 static const char person_threshold_output_message[] = "Optional. Probability threshold for person/action detection.";
-
 static const char action_threshold_output_message[] = "Optional. Probability threshold for action recognition.";
-
 static const char threshold_output_message_face_reid[] = "Optional. Cosine distance threshold between two vectors for face reidentification.";
-
 static const char reid_gallery_path_message[] = "Optional. Path to a faces gallery in .json format.";
-
 static const char output_video_message[] = "Optional. File to write output video with visualization to.";
-
 static const char act_stat_output_message[] = "Optional. Output file name to save per-person action statistics in.";
-
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
-
 static const char no_show_processed_video[] = "Optional. Do not show processed video.";
-
 static const char input_image_height_output_message[] = "Optional. Input image height for face detector.";
-
 static const char input_image_width_output_message[] = "Optional. Input image width for face detector.";
-
 static const char expand_ratio_output_message[] = "Optional. Expand ratio for bbox before face recognition.";
-
 static const char last_frame_message[] = "Optional. Last frame number to handle in demo. If negative, handle all input video.";
-
 static const char teacher_id_message[] = "Optional. ID of a teacher. You must also set a faces gallery parameter (-fg) to use it.";
-
 static const char min_action_duration_message[] = "Optional. Minimum action duration in seconds.";
-
 static const char same_action_time_delta_message[] = "Optional. Maximum time difference between actions in seconds.";
-
 static const char student_actions_message[] = "Optional. List of student actions separated by a comma.";
-
 static const char top_actions_message[] = "Optional. List of student actions (for top-k mode) separated by a comma.";
-
 static const char teacher_actions_message[] = "Optional. List of teacher actions separated by a comma.";
-
 static const char target_action_name_message[] = "Optional. Target action name.";
-
 static const char target_actions_num_message[] = "Optional. Number of first K students. If this parameter is positive,"\
-"the demo detects first K persons with the action, pointed by the parameter 'top_id'";
-
+                                                 "the demo detects first K persons with the action, pointed by the parameter 'top_id'";
 static const char crop_gallery_message[] = "Optional. Crop images during faces gallery creation.";
-
 static const char face_threshold_registration_output_message[] = "Optional. Probability threshold for face detections during database registration.";
-
 static const char min_size_fr_reg_output_message[] = "Optional. Minimum input size for faces during database registration.";
-
 static const char act_det_output_message[] = "Optional. Output file name to save per-person action detections in.";
-
 static const char tracker_smooth_size_message[] = "Optional. Number of frames to smooth actions.";
 
 /// @brief Define flag for showing help message <br>

--- a/demos/super_resolution_demo/super_resolution_demo.h
+++ b/demos/super_resolution_demo/super_resolution_demo.h
@@ -9,33 +9,25 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// @brief message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief message for images argument
 static const char image_message[] = "Required. Path to an image.";
 
-/// @brief message for model argument
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";\
 
-/// @brief message for plugin argument
 static const char plugin_message[] = "Plugin name. For example MKLDNNPlugin. If this parameter is pointed, " \
 "the demo will look for this plugin only";
 
-/// @brief message for assigning cnn calculation to device
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
                                             "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The demo will look for a suitable plugin for the specified device.";
 
-/// @brief message for user library argument
 static const char custom_cpu_library_message[] = "Required for CPU custom layers." \
                                                  "Absolute path to a shared library with the kernels implementations.";
 
-/// @brief message for clDNN custom kernels desc
 static const char custom_cldnn_message[] = "Required for GPU custom kernels."\
                                             "Absolute path to the xml file with the kernels descriptions.";
 
-/// @brief message for show argument
 static const char show_processed_images[] = "Optional. Show processed images. Default value is false.";
 
 

--- a/demos/super_resolution_demo/super_resolution_demo.h
+++ b/demos/super_resolution_demo/super_resolution_demo.h
@@ -25,17 +25,11 @@ static const char show_processed_images[] = "Optional. Show processed images. De
 
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", image_message);
-
 DEFINE_string(m, "", model_message);
-
 DEFINE_string(d, "CPU", target_device_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_string(c, "", custom_cldnn_message);
-
 DEFINE_bool(show, false, show_processed_images);
 
 /**

--- a/demos/super_resolution_demo/super_resolution_demo.h
+++ b/demos/super_resolution_demo/super_resolution_demo.h
@@ -24,30 +24,18 @@ static const char custom_cldnn_message[] = "Required for GPU custom kernels."\
 static const char show_processed_images[] = "Optional. Show processed images. Default value is false.";
 
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for set image file <br>
-/// It is a required parameter
 DEFINE_string(i, "", image_message);
 
-/// @brief Define parameter for set model file <br>
-/// It is a required parameter
 DEFINE_string(m, "", model_message);
 
-/// @brief device the target device to infer on <br>
 DEFINE_string(d, "CPU", target_device_message);
 
-/// @brief Absolute path to CPU library with user layers <br>
-/// It is a required parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// @brief Define parameter for clDNN custom kernels path <br>
-/// Default is ./lib
 DEFINE_string(c, "", custom_cldnn_message);
 
-/// @brief Flag to show processed images<br>
-/// It is an optional parameter
 DEFINE_bool(show, false, show_processed_images);
 
 /**

--- a/demos/super_resolution_demo/super_resolution_demo.h
+++ b/demos/super_resolution_demo/super_resolution_demo.h
@@ -10,24 +10,17 @@
 #include <iostream>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char image_message[] = "Required. Path to an image.";
-
 static const char model_message[] = "Required. Path to an .xml file with a trained model.";\
-
 static const char plugin_message[] = "Plugin name. For example MKLDNNPlugin. If this parameter is pointed, " \
-"the demo will look for this plugin only";
-
+                                     "the demo will look for this plugin only";
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). " \
                                             "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. " \
                                             "The demo will look for a suitable plugin for the specified device.";
-
 static const char custom_cpu_library_message[] = "Required for CPU custom layers." \
                                                  "Absolute path to a shared library with the kernels implementations.";
-
 static const char custom_cldnn_message[] = "Required for GPU custom kernels."\
                                             "Absolute path to the xml file with the kernels descriptions.";
-
 static const char show_processed_images[] = "Optional. Show processed images. Default value is false.";
 
 

--- a/demos/text_detection_demo/text_detection_demo.hpp
+++ b/demos/text_detection_demo/text_detection_demo.hpp
@@ -44,41 +44,23 @@ static const char input_data_type_message[] = "Required. Input data type: \"imag
                                               "\"webcam\" (for a webcamera device). By default, it is \"image\".";
 
 DEFINE_bool(h, false, help_message);
-
 DEFINE_string(i, "", input_message);
-
 DEFINE_string(m_td, "", text_detection_model_message);
-
 DEFINE_string(m_tr, "", text_recognition_model_message);
-
 DEFINE_string(m_tr_ss, "0123456789abcdefghijklmnopqrstuvwxyz", text_recognition_model_symbols_set_message);
-
 DEFINE_bool(cc, false, text_central_image_crop_message);
-
 DEFINE_int32(w_td, 1280, image_width_for_text_detection_model_message);
-
 DEFINE_int32(h_td, 768, image_height_for_text_detection_model_message);
-
 DEFINE_double(thr, 0.2, text_recognition_threshold_message);
-
 DEFINE_double(cls_pixel_thr, 0.8, pixel_classification_threshold_message);
-
 DEFINE_double(link_pixel_thr, 0.8, pixel_linkage_threshold_message);
-
 DEFINE_int32(max_rect_num, -1, text_max_rectangles_number_message);
-
 DEFINE_string(dt, "", input_data_type_message);
-
 DEFINE_string(d_td, "CPU", text_detection_target_device_message);
-
 DEFINE_string(d_tr, "CPU", text_recognition_target_device_message);
-
 DEFINE_string(l, "", custom_cpu_library_message);
-
 DEFINE_string(c, "", custom_gpu_library_message);
-
 DEFINE_bool(no_show, false, no_show_message);
-
 DEFINE_bool(r, false, raw_output_message);
 
 /**

--- a/demos/text_detection_demo/text_detection_demo.hpp
+++ b/demos/text_detection_demo/text_detection_demo.hpp
@@ -43,77 +43,42 @@ static const char input_data_type_message[] = "Required. Input data type: \"imag
                                               "\"video\" (for a saved video), "
                                               "\"webcam\" (for a webcamera device). By default, it is \"image\".";
 
-/// @brief Define flag for showing help message <br>
 DEFINE_bool(h, false, help_message);
 
-/// @brief Define parameter for setting input path <br>
-/// It is a required parameter
 DEFINE_string(i, "", input_message);
 
-/// @brief Define parameter for text detection model file <br>
-/// It is a required parameter
 DEFINE_string(m_td, "", text_detection_model_message);
 
-/// @brief Define parameter for text recognition model file <br>
-/// It is a required parameter
 DEFINE_string(m_tr, "", text_recognition_model_message);
 
-/// @brief Define parameter for text recognition model symbols set <br>
-/// It is a optional parameter
 DEFINE_string(m_tr_ss, "0123456789abcdefghijklmnopqrstuvwxyz", text_recognition_model_symbols_set_message);
 
-/// @brief Define parameter for central image crop. <br>
-/// It is a optional parameter
 DEFINE_bool(cc, false, text_central_image_crop_message);
 
-/// @brief Define parameter for input image width for text detection model <br>
-/// It is a optional parameter
 DEFINE_int32(w_td, 1280, image_width_for_text_detection_model_message);
 
-/// @brief Define parameter for input image height for text detection model <br>
-/// It is a optional parameter
 DEFINE_int32(h_td, 768, image_height_for_text_detection_model_message);
 
-/// @brief Define parameter for text recognition threshold <br>
-/// It is a optional parameter
 DEFINE_double(thr, 0.2, text_recognition_threshold_message);
 
-/// @brief Define parameter for pixel classification threshold <br>
-/// It is a optional parameter
 DEFINE_double(cls_pixel_thr, 0.8, pixel_classification_threshold_message);
 
-/// @brief Define parameter for pixel linking threshold <br>
-/// It is a optional parameter
 DEFINE_double(link_pixel_thr, 0.8, pixel_linkage_threshold_message);
 
-/// @brief Define parameter for maximum number of rectangles to recognize. If it is negative number of rectangles to recognize is not limited. <br>
-/// It is a optional parameter
 DEFINE_int32(max_rect_num, -1, text_max_rectangles_number_message);
 
-/// @brief Define parameter for input data type ("image", "list", "video", "webcam"). <br>
-/// It is a required parameter
 DEFINE_string(dt, "", input_data_type_message);
 
-/// @brief Define the target device for text detection model to infer on <br>
 DEFINE_string(d_td, "CPU", text_detection_target_device_message);
 
-/// @brief Define the target device for text recognition model to infer on <br>
 DEFINE_string(d_tr, "CPU", text_recognition_target_device_message);
 
-/// @brief Define parameter for asolute path to a shared library with the CPU kernels implementation for custom layers. <br>
-/// It is a optional parameter
 DEFINE_string(l, "", custom_cpu_library_message);
 
-/// @brief Define parameter for asolute path to the GPU kernels implementation for custom layers. <br>
-/// It is a optional parameter
 DEFINE_string(c, "", custom_gpu_library_message);
 
-/// @brief Define a flag to not show detected text on image frame. By default, it is false. <br>
-/// It is an optional parameter
 DEFINE_bool(no_show, false, no_show_message);
 
-/// @brief Flag to output raw pipeline results<br>
-/// It is an optional parameter
 DEFINE_bool(r, false, raw_output_message);
 
 /**

--- a/demos/text_detection_demo/text_detection_demo.hpp
+++ b/demos/text_detection_demo/text_detection_demo.hpp
@@ -9,72 +9,53 @@
 #include <vector>
 #include <gflags/gflags.h>
 
-/// @brief Message for help argument
 static const char help_message[] = "Print a usage message.";
 
-/// @brief Message for input path argument
 static const char input_message[] = "Required. Path to an image or video file, to a text file with paths to images, "
                                     "or to a webcamera device node (for example, /dev/video0).";
 
-/// @brief Message for text detection model argument
 static const char text_detection_model_message[] = "Required. Path to the Text Detection model (.xml) file.";
 
-/// @brief Message for text recognition model argument
 static const char text_recognition_model_message[] = "Required. Path to the Text Recognition model (.xml) file.";
 
-/// @brief Message for text recognition model symbols set argument
 static const char text_recognition_model_symbols_set_message[] = "Optional. Symbol set for the Text Recognition model.";
 
-/// @brief Message for central image crop argument
 static const char text_central_image_crop_message[] = "Optional. If it is set, then in case of absence of the Text Detector, "
                                                       "the Text Reconition model takes a central image crop as an input, but not full frame.";
 
-/// @brief Message for input image width for text detection model argument
 static const char image_width_for_text_detection_model_message[] = "Optional. Input image width for Text Detection model.";
 
-/// @brief Message for input image height for text detection model argument
 static const char image_height_for_text_detection_model_message[] = "Optional. Input image height for Text Detection model.";
 
-/// @brief Message for text recognition threshold argument
 static const char text_recognition_threshold_message[] = "Optional. Specify a recognition confidence threshold. Text detection candidates with "
                                                          "text recognition confidence below specified threshold are rejected.";
 
-/// @brief Message for pixel classification threshold argument
 static const char pixel_classification_threshold_message[] = "Optional. Specify a confidence threshold for pixel classification. "
                                                              "Pixels with classification confidence below specified threshold are rejected.";
 
-/// @brief Message for pixel linkage threshold argument
 static const char pixel_linkage_threshold_message[] = "Optional. Specify a confidence threshold for pixel linkage. "
                                                       "Pixels with linkage confidence below specified threshold are not linked.";
 
-/// @brief Message for max rectangles number argument
 static const char text_max_rectangles_number_message[] = "Optional. Maximum number of rectangles to recognize. "
                                                          "If it is negative, number of rectangles to recognize is not limited.";
 
-/// @brief Message for text detection target device argument
 static const char text_detection_target_device_message[] = "Optional. Specify the target device for the Text Detection model to infer on "
                                                            "(the list of available devices is shown below). "
                                                            "The demo will look for a suitable plugin for a specified device. By default, it is CPU.";
 
-/// @brief Message for text recognition target device argument
 static const char text_recognition_target_device_message[] = "Optional. Specify the target device for the Text Recognition model to infer on "
                                                              "(the list of available devices is shown below). "
                                                              "The demo will look for a suitable plugin for a specified device. By default, it is CPU.";
 
-/// @brief Message for user library argument
 static const char custom_cpu_library_message[] = "Optional. Absolute path to a shared library with the CPU kernels implementation "
                                                  "for custom layers.";
 
-/// @brief Message for user library argument
 static const char custom_gpu_library_message[] = "Optional. Absolute path to the GPU kernels implementation for custom layers.";
 
-/// @brief Message for user no_show argument
 static const char no_show_message[] = "Optional. If it is true, then detected text will not be shown on image frame. By default, it is false.";
 
-/// @brief Message raw output flag
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
 
-/// @brief Message for input data type argument
 static const char input_data_type_message[] = "Required. Input data type: \"image\" (for a single image), "
                                               "\"list\" (for a text file where images paths are listed), "
                                               "\"video\" (for a saved video), "

--- a/demos/text_detection_demo/text_detection_demo.hpp
+++ b/demos/text_detection_demo/text_detection_demo.hpp
@@ -10,52 +10,34 @@
 #include <gflags/gflags.h>
 
 static const char help_message[] = "Print a usage message.";
-
 static const char input_message[] = "Required. Path to an image or video file, to a text file with paths to images, "
                                     "or to a webcamera device node (for example, /dev/video0).";
-
 static const char text_detection_model_message[] = "Required. Path to the Text Detection model (.xml) file.";
-
 static const char text_recognition_model_message[] = "Required. Path to the Text Recognition model (.xml) file.";
-
 static const char text_recognition_model_symbols_set_message[] = "Optional. Symbol set for the Text Recognition model.";
-
 static const char text_central_image_crop_message[] = "Optional. If it is set, then in case of absence of the Text Detector, "
                                                       "the Text Reconition model takes a central image crop as an input, but not full frame.";
-
 static const char image_width_for_text_detection_model_message[] = "Optional. Input image width for Text Detection model.";
-
 static const char image_height_for_text_detection_model_message[] = "Optional. Input image height for Text Detection model.";
-
 static const char text_recognition_threshold_message[] = "Optional. Specify a recognition confidence threshold. Text detection candidates with "
                                                          "text recognition confidence below specified threshold are rejected.";
-
 static const char pixel_classification_threshold_message[] = "Optional. Specify a confidence threshold for pixel classification. "
                                                              "Pixels with classification confidence below specified threshold are rejected.";
-
 static const char pixel_linkage_threshold_message[] = "Optional. Specify a confidence threshold for pixel linkage. "
                                                       "Pixels with linkage confidence below specified threshold are not linked.";
-
 static const char text_max_rectangles_number_message[] = "Optional. Maximum number of rectangles to recognize. "
                                                          "If it is negative, number of rectangles to recognize is not limited.";
-
 static const char text_detection_target_device_message[] = "Optional. Specify the target device for the Text Detection model to infer on "
                                                            "(the list of available devices is shown below). "
                                                            "The demo will look for a suitable plugin for a specified device. By default, it is CPU.";
-
 static const char text_recognition_target_device_message[] = "Optional. Specify the target device for the Text Recognition model to infer on "
                                                              "(the list of available devices is shown below). "
                                                              "The demo will look for a suitable plugin for a specified device. By default, it is CPU.";
-
 static const char custom_cpu_library_message[] = "Optional. Absolute path to a shared library with the CPU kernels implementation "
                                                  "for custom layers.";
-
 static const char custom_gpu_library_message[] = "Optional. Absolute path to the GPU kernels implementation for custom layers.";
-
 static const char no_show_message[] = "Optional. If it is true, then detected text will not be shown on image frame. By default, it is false.";
-
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
-
 static const char input_data_type_message[] = "Required. Input data type: \"image\" (for a single image), "
                                               "\"list\" (for a text file where images paths are listed), "
                                               "\"video\" (for a saved video), "


### PR DESCRIPTION
They take up space and carry no information that isn't already present in the help messages themselves.