### PR TITLE
Remove the Jenkins link from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # [OpenVINO™ Toolkit](https://01.org/openvinotoolkit) - Open Model Zoo repository
-[![Build Status](http://134.191.240.124/buildStatus/icon?job=omz/2018/trigger)](http://134.191.240.124/job/omz/job/2018/job/trigger/)
 [![Stable release](https://img.shields.io/badge/version-2019_R4-green.svg)](https://github.com/opencv/open_model_zoo/releases/tag/2019_R4)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/open_model_zoo/community)
 [![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE)


### PR DESCRIPTION
There are a few reasons why:

1. It's broken.
2. I don't want to maintain links to different Jenkins jobs in different branches.
3. I'm thinking of removing the nightly trigger job and having the individual task jobs trigger themselves, so there won't even be anything to link to.