### PR TITLE
smart_classroom_demo: remove the enabled fields from detector configs

### DIFF
--- a/demos/smart_classroom_demo/include/action_detector.hpp
+++ b/demos/smart_classroom_demo/include/action_detector.hpp
@@ -115,10 +115,9 @@ class ActionDetection : public BaseCnnDetection {
 public:
     explicit ActionDetection(const ActionDetectorConfig& config);
 
-    DetectedActions results;
     void submitRequest() override;
     void enqueue(const cv::Mat &frame);
-    void fetchResults();
+    DetectedActions fetchResults();
 
 private:
     ActionDetectorConfig config_;
@@ -129,7 +128,6 @@ private:
     int enqueued_frames_ = 0;
     float width_ = 0;
     float height_ = 0;
-    bool results_fetched_ = false;
     bool new_network_ = false;
     std::vector<int> head_ranges_;
     std::vector<int> head_step_sizes_;
@@ -160,14 +158,13 @@ private:
     * @param add_conf Action conf buffer
     * @param priorboxes Priorboxes buffer
     * @param frame_size Size of input image (WxH)
-    * @param detections Detected objects
+    * @return Detected objects
     */
-    void GetDetections(const cv::Mat& loc,
-                       const cv::Mat& main_conf,
-                       const cv::Mat& priorboxes,
-                       const std::vector<cv::Mat>& add_conf,
-                       const cv::Size& frame_size,
-                       DetectedActions* detections) const;
+    DetectedActions GetDetections(const cv::Mat& loc,
+                                  const cv::Mat& main_conf,
+                                  const cv::Mat& priorboxes,
+                                  const std::vector<cv::Mat>& add_conf,
+                                  const cv::Size& frame_size) const;
 
      /**
     * @brief Translate input buffer to BBox

--- a/demos/smart_classroom_demo/include/action_detector.hpp
+++ b/demos/smart_classroom_demo/include/action_detector.hpp
@@ -59,8 +59,6 @@ struct ActionDetectorConfig : public CnnConfig {
                                   const std::string& path_to_weights)
         : CnnConfig(path_to_model, path_to_weights) {}
 
-    bool enabled{true};
-
     /** @brief Name of output blob with location info */
     std::string old_loc_blob_name{"mbox_loc1/out/conv/flat"};
     /** @brief Name of output blob with detection confidence info */
@@ -111,13 +109,17 @@ struct ActionDetectorConfig : public CnnConfig {
 };
 
 
-class ActionDetection : public BaseCnnDetection {
+class ActionDetection : public AsyncDetection<DetectedAction>, public BaseCnnDetection {
 public:
     explicit ActionDetection(const ActionDetectorConfig& config);
 
     void submitRequest() override;
-    void enqueue(const cv::Mat &frame);
-    DetectedActions fetchResults();
+    void enqueue(const cv::Mat &frame) override;
+    void wait() override { BaseCnnDetection::wait(); }
+    void printPerformanceCounts(const std::string &fullDeviceName) override {
+        BaseCnnDetection::printPerformanceCounts(fullDeviceName);
+    }
+    DetectedActions fetchResults() override;
 
 private:
     ActionDetectorConfig config_;

--- a/demos/smart_classroom_demo/include/detector.hpp
+++ b/demos/smart_classroom_demo/include/detector.hpp
@@ -50,15 +50,13 @@ private:
     int enqueued_frames_ = 0;
     float width_ = 0;
     float height_ = 0;
-    bool results_fetched_ = false;
 
 public:
     explicit FaceDetection(const DetectorConfig& config);
 
-    DetectedObjects results;
     void submitRequest() override;
     void enqueue(const cv::Mat &frame);
-    void fetchResults();
+    DetectedObjects fetchResults();
 };
 
 }  // namespace detection

--- a/demos/smart_classroom_demo/include/detector.hpp
+++ b/demos/smart_classroom_demo/include/detector.hpp
@@ -29,8 +29,6 @@ struct DetectorConfig : public CnnConfig {
                             const std::string& path_to_weights)
         : CnnConfig(path_to_model, path_to_weights) {}
 
-    bool enabled{true};
-
     float confidence_threshold{0.6f};
     float increase_scale_x{1.15f};
     float increase_scale_y{1.15f};
@@ -39,7 +37,7 @@ struct DetectorConfig : public CnnConfig {
     int input_w = 600;
 };
 
-class FaceDetection : public BaseCnnDetection {
+class FaceDetection : public AsyncDetection<DetectedObject>, public BaseCnnDetection {
 private:
     DetectorConfig config_;
     InferenceEngine::ExecutableNetwork net_;
@@ -55,8 +53,13 @@ public:
     explicit FaceDetection(const DetectorConfig& config);
 
     void submitRequest() override;
-    void enqueue(const cv::Mat &frame);
-    DetectedObjects fetchResults();
+    void enqueue(const cv::Mat &frame) override;
+    void wait() override { BaseCnnDetection::wait(); }
+    void printPerformanceCounts(const std::string &fullDeviceName) override {
+        BaseCnnDetection::printPerformanceCounts(fullDeviceName);
+    }
+
+    DetectedObjects fetchResults() override;
 };
 
 }  // namespace detection

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -856,8 +856,7 @@ int main(int argc, char* argv[]) {
                     }
 
                     action_detector.wait();
-                    action_detector.fetchResults();
-                    actions = action_detector.results;
+                    actions = action_detector.fetchResults();
 
                     if (!is_last_frame) {
                         prev_frame_path = cap.GetVideoPath();
@@ -911,12 +910,10 @@ int main(int argc, char* argv[]) {
                 }
             } else {
                 face_detector.wait();
-                face_detector.fetchResults();
-                faces = face_detector.results;
+                faces = face_detector.fetchResults();
 
                 action_detector.wait();
-                action_detector.fetchResults();
-                actions = action_detector.results;
+                actions = action_detector.fetchResults();
 
                 if (!is_last_frame) {
                     prev_frame_path = cap.GetVideoPath();

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -645,29 +645,37 @@ int main(int argc, char* argv[]) {
             loadedDevices.insert(device);
         }
 
-        // Load action detector
-        ActionDetectorConfig action_config(ad_model_path, ad_weights_path);
-        action_config.deviceName = FLAGS_d_act;
-        action_config.ie = ie;
-        action_config.is_async = true;
-        action_config.enabled = !ad_model_path.empty();
-        action_config.detection_confidence_threshold = static_cast<float>(FLAGS_t_ad);
-        action_config.action_confidence_threshold = static_cast<float>(FLAGS_t_ar);
-        action_config.num_action_classes = actions_map.size();
-        ActionDetection action_detector(action_config);
+        std::unique_ptr<AsyncDetection<DetectedAction>> action_detector;
+        if (!ad_model_path.empty()) {
+            // Load action detector
+            ActionDetectorConfig action_config(ad_model_path, ad_weights_path);
+            action_config.deviceName = FLAGS_d_act;
+            action_config.ie = ie;
+            action_config.is_async = true;
+            action_config.detection_confidence_threshold = static_cast<float>(FLAGS_t_ad);
+            action_config.action_confidence_threshold = static_cast<float>(FLAGS_t_ar);
+            action_config.num_action_classes = actions_map.size();
+            action_detector.reset(new ActionDetection(action_config));
+        } else {
+            action_detector.reset(new NullDetection<DetectedAction>);
+        }
 
-        // Load face detector
-        detection::DetectorConfig face_config(fd_model_path, fd_weights_path);
-        face_config.deviceName = FLAGS_d_fd;
-        face_config.ie = ie;
-        face_config.is_async = true;
-        face_config.enabled = !fd_model_path.empty();
-        face_config.confidence_threshold = static_cast<float>(FLAGS_t_fd);
-        face_config.input_h = FLAGS_inh_fd;
-        face_config.input_w = FLAGS_inw_fd;
-        face_config.increase_scale_x = static_cast<float>(FLAGS_exp_r_fd);
-        face_config.increase_scale_y = static_cast<float>(FLAGS_exp_r_fd);
-        detection::FaceDetection face_detector(face_config);
+        std::unique_ptr<AsyncDetection<detection::DetectedObject>> face_detector;
+        if (!fd_model_path.empty()) {
+            // Load face detector
+            detection::DetectorConfig face_config(fd_model_path, fd_weights_path);
+            face_config.deviceName = FLAGS_d_fd;
+            face_config.ie = ie;
+            face_config.is_async = true;
+            face_config.confidence_threshold = static_cast<float>(FLAGS_t_fd);
+            face_config.input_h = FLAGS_inh_fd;
+            face_config.input_w = FLAGS_inw_fd;
+            face_config.increase_scale_x = static_cast<float>(FLAGS_exp_r_fd);
+            face_config.increase_scale_y = static_cast<float>(FLAGS_exp_r_fd);
+            face_detector.reset(new detection::FaceDetection(face_config));
+        } else {
+            face_detector.reset(new NullDetection<detection::DetectedObject>);
+        }
 
         std::unique_ptr<FaceRecognizer> face_recognizer;
 
@@ -774,10 +782,10 @@ int main(int argc, char* argv[]) {
         }
 
         if (actions_type != TOP_K) {
-            action_detector.enqueue(frame);
-            action_detector.submitRequest();
-            face_detector.enqueue(frame);
-            face_detector.submitRequest();
+            action_detector->enqueue(frame);
+            action_detector->submitRequest();
+            face_detector->enqueue(frame);
+            face_detector->submitRequest();
         }
 
         prev_frame = frame.clone();
@@ -828,8 +836,8 @@ int main(int argc, char* argv[]) {
                 if ( (is_monitoring_enabled && key == SPACE_KEY) ||
                      (!is_monitoring_enabled && key != SPACE_KEY) ) {
                     if (key == SPACE_KEY) {
-                        action_detector.wait();
-                        action_detector.fetchResults();
+                        action_detector->wait();
+                        action_detector->fetchResults();
 
                         tracker_action.Reset();
                         top_k_obj_ids.clear();
@@ -851,17 +859,17 @@ int main(int argc, char* argv[]) {
                     if (key == SPACE_KEY) {
                         is_monitoring_enabled = true;
 
-                        action_detector.enqueue(prev_frame);
-                        action_detector.submitRequest();
+                        action_detector->enqueue(prev_frame);
+                        action_detector->submitRequest();
                     }
 
-                    action_detector.wait();
-                    actions = action_detector.fetchResults();
+                    action_detector->wait();
+                    actions = action_detector->fetchResults();
 
                     if (!is_last_frame) {
                         prev_frame_path = cap.GetVideoPath();
-                        action_detector.enqueue(frame);
-                        action_detector.submitRequest();
+                        action_detector->enqueue(frame);
+                        action_detector->submitRequest();
                     }
 
                     TrackedObjects tracked_action_objects;
@@ -909,18 +917,18 @@ int main(int argc, char* argv[]) {
                     }
                 }
             } else {
-                face_detector.wait();
-                faces = face_detector.fetchResults();
+                face_detector->wait();
+                faces = face_detector->fetchResults();
 
-                action_detector.wait();
-                actions = action_detector.fetchResults();
+                action_detector->wait();
+                actions = action_detector->fetchResults();
 
                 if (!is_last_frame) {
                     prev_frame_path = cap.GetVideoPath();
-                    face_detector.enqueue(frame);
-                    face_detector.submitRequest();
-                    action_detector.enqueue(frame);
-                    action_detector.submitRequest();
+                    face_detector->enqueue(frame);
+                    face_detector->submitRequest();
+                    action_detector->enqueue(frame);
+                    action_detector->submitRequest();
                 }
 
                 auto ids = face_recognizer->Recognize(prev_frame, faces);
@@ -985,7 +993,7 @@ int main(int argc, char* argv[]) {
                     for (const auto& action : tracked_actions) {
                         const auto& action_label = GetActionTextLabel(action.label, actions_map);
                         const auto& action_color = GetActionTextColor(action.label);
-                        const auto& text_label = face_config.enabled ? "" : action_label;
+                        const auto& text_label = fd_model_path.empty() ? action_label : "";
                         sc_visualizer.DrawObject(action.rect, text_label, action_color, white_color, true);
                         logger.AddPersonToFrame(action.rect, action_label, "");
                         logger.AddDetectionToFrame(action, work_num_frames);
@@ -1028,10 +1036,10 @@ int main(int argc, char* argv[]) {
         slog::info << "Frames processed: " << total_num_frames << slog::endl;
         if (FLAGS_pc) {
             std::map<std::string, std::string>  mapDevices = getMapFullDevicesNames(ie, devices);
-            face_detector.wait();
-            action_detector.wait();
-            action_detector.PrintPerformanceCounts(getFullDeviceName(mapDevices, FLAGS_d_act));
-            face_detector.PrintPerformanceCounts(getFullDeviceName(mapDevices, FLAGS_d_fd));
+            face_detector->wait();
+            action_detector->wait();
+            action_detector->printPerformanceCounts(getFullDeviceName(mapDevices, FLAGS_d_act));
+            face_detector->printPerformanceCounts(getFullDeviceName(mapDevices, FLAGS_d_fd));
             face_recognizer->PrintPerformanceCounts(
                 getFullDeviceName(mapDevices, FLAGS_d_lm),
                 getFullDeviceName(mapDevices, FLAGS_d_reid));

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -756,8 +756,6 @@ int main(int argc, char* argv[]) {
         Tracker tracker_action(tracker_action_params);
 
         cv::Mat frame, prev_frame;
-        DetectedActions actions;
-        detection::DetectedObjects faces;
 
         float work_time_ms = 0.f;
         float wait_time_ms = 0.f;
@@ -864,7 +862,7 @@ int main(int argc, char* argv[]) {
                     }
 
                     action_detector->wait();
-                    actions = action_detector->fetchResults();
+                    DetectedActions actions = action_detector->fetchResults();
 
                     if (!is_last_frame) {
                         prev_frame_path = cap.GetVideoPath();
@@ -918,10 +916,10 @@ int main(int argc, char* argv[]) {
                 }
             } else {
                 face_detector->wait();
-                faces = face_detector->fetchResults();
+                detection::DetectedObjects faces = face_detector->fetchResults();
 
                 action_detector->wait();
-                actions = action_detector->fetchResults();
+                DetectedActions actions = action_detector->fetchResults();
 
                 if (!is_last_frame) {
                     prev_frame_path = cap.GetVideoPath();

--- a/demos/smart_classroom_demo/src/detector.cpp
+++ b/demos/smart_classroom_demo/src/detector.cpp
@@ -50,8 +50,6 @@ cv::Rect IncreaseRect(const cv::Rect& r, float coeff_x,
 void FaceDetection::submitRequest() {
     if (!enqueued_frames_) return;
     enqueued_frames_ = 0;
-    results_fetched_ = false;
-    results.clear();
     BaseCnnDetection::submitRequest();
 }
 
@@ -134,11 +132,9 @@ FaceDetection::FaceDetection(const DetectorConfig& config) :
     }
 }
 
-void FaceDetection::fetchResults() {
-    if (!enabled()) return;
-    results.clear();
-    if (results_fetched_) return;
-    results_fetched_ = true;
+DetectedObjects FaceDetection::fetchResults() {
+    if (!enabled()) return {};
+    DetectedObjects results;
     const float *data = request->GetBlob(output_name_)->buffer().as<float *>();
 
     for (int det_id = 0; det_id < max_detections_count_; ++det_id) {
@@ -176,4 +172,6 @@ void FaceDetection::fetchResults() {
             results.emplace_back(object);
         }
     }
+
+    return results;
 }

--- a/demos/smart_classroom_demo/src/reid_gallery.cpp
+++ b/demos/smart_classroom_demo/src/reid_gallery.cpp
@@ -60,8 +60,7 @@ RegistrationStatus EmbeddingsGallery::RegisterIdentity(const std::string& identi
       detector.enqueue(image);
       detector.submitRequest();
       detector.wait();
-      detector.fetchResults();
-      detection::DetectedObjects faces = detector.results;
+      detection::DetectedObjects faces = detector.fetchResults();
       if (faces.size() == 0) {
         return RegistrationStatus::FAILURE_NOT_DETECTED;
       }


### PR DESCRIPTION
Instead, use the null object pattern to disable a detector when the corresponding model option is unspecified.

My original aim with this was to fix static analyzer warnings about the fields of `ActionDetection` not being initialized (which they weren't, when `enabled` was false). I think it's a good change in its own right, though, since it applies the Single Responsibility Principle by separating the "detection enabled" and "detection disabled" behavior into different classes.

