### PR TITLE
demos/monitors: update strStream init

### DIFF
--- a/demos/common/monitors/presenter.cpp
+++ b/demos/common/monitors/presenter.cpp
@@ -37,7 +37,7 @@ Presenter::Presenter(std::set<MonitorType> enabledMonitors,
             graphPadding{std::max(1, static_cast<int>(graphSize.width * 0.05))},
             historySize{historySize},
             distributionCpuEnabled{false},
-            strStream{std::ostringstream(std::ios_base::app)} {
+            strStream{std::ios_base::app} {
     for (MonitorType monitor : enabledMonitors) {
         addRemoveMonitor(monitor);
     }


### PR DESCRIPTION
Enable build for old gcc which doesn't have `basic_ostringstream(basic_ostringstream&&)` constructor.
It also makes more sense to use `basic_ostringstream(ios_base::openmode mode)`.