### PR TITLE
fix ref metrics representation (missed % sign)

### DIFF
--- a/models/intel/person-reidentification-retail-0103/description/person-reidentification-retail-0103.md
+++ b/models/intel/person-reidentification-retail-0103/description/person-reidentification-retail-0103.md
@@ -16,8 +16,8 @@ feature map outputs the embedding vector of 256 floats.
 
 | Metric                            | Value                                     |
 |-----------------------------------|-------------------------------------------|
-| GlobalMe-reID rank@1 accuracy     | 93.5                                      |
-| GlobalMe-reID mAP                 | 69.5                                      |
+| GlobalMe-reID rank@1 accuracy     | 93.5%                                     |
+| GlobalMe-reID mAP                 | 69.5%                                     |
 | Pose coverage                     | Standing upright, parallel to image plane |
 | Support of occluded pedestrians   | YES                                       |
 | Occlusion coverage                | <50%                                      |

--- a/models/intel/person-reidentification-retail-0107/description/person-reidentification-retail-0107.md
+++ b/models/intel/person-reidentification-retail-0107/description/person-reidentification-retail-0107.md
@@ -16,8 +16,8 @@ feature map outputs the embedding vector of 256 floats.
 
 | Metric                            | Value                                     |
 |-----------------------------------|-------------------------------------------|
-| GlobalMe-reID rank@1 accuracy     | 91.7                                      |
-| GlobalMe-reID mAP                 | 63.4                                      |
+| GlobalMe-reID rank@1 accuracy     | 91.7%                                     |
+| GlobalMe-reID mAP                 | 63.4%                                     |
 | Pose coverage                     | Standing upright, parallel to image plane |
 | Support of occluded pedestrians   | YES                                       |
 | Occlusion coverage                | <50%                                      |

--- a/models/intel/person-reidentification-retail-0200/description/person-reidentification-retail-0200.md
+++ b/models/intel/person-reidentification-retail-0200/description/person-reidentification-retail-0200.md
@@ -16,8 +16,8 @@ feature map outputs the embedding vector of 256 floats.
 
 | Metric                            | Value                                     |
 |-----------------------------------|-------------------------------------------|
-| GlobalMe-reID rank@1 accuracy     | 95.4                                      |
-| GlobalMe-reID mAP                 | 75.5                                      |
+| GlobalMe-reID rank@1 accuracy     | 95.4%                                     |
+| GlobalMe-reID mAP                 | 75.5%                                     |
 | Pose coverage                     | Standing upright, parallel to image plane |
 | Support of occluded pedestrians   | YES                                       |
 | Occlusion coverage                | <50%                                      |


### PR DESCRIPTION
fix missed '%' sign in ref metric representation