### PR TITLE
downloader: check the size of the received file before checking the hash

### DIFF
--- a/models/public/face-recognition-resnet100-arcface/model.yml
+++ b/models/public/face-recognition-resnet100-arcface/model.yml
@@ -17,7 +17,7 @@ description: >-
 task_type: face_recognition
 files:
   - name: model-r100-arcface-ms1m-refine-v2.zip
-    size: 162345348
+    size: 243494890
     sha256: eab0e5bcca81c070f56ffb11a1c32d7b2e574a8bb94f32590e7b48b355c13d1f
     source: https://www.dropbox.com/s/tj96fsm6t6rq8ye/model-r100-arcface-ms1m-refine-v2.zip?dl=1
 postprocessing:


### PR DESCRIPTION
This has two benefits:

1. it makes sure file sizes are set correctly in the config files and therefore that we are reporting correct progress information;

2. if a download fails because the file on the remote server was replaced with an unrelated file, a size mismatch message will communicate more information than a hash mismatch message.

Also, break early if we receive more data than we expect. It's more efficient and it prevents a server from filling up the local file system by sending a very large (or even infinite) file.