### PR TITLE
Eradicate the remaining mentions of libcpu_extension

### DIFF
--- a/demos/python_demos/face_recognition_demo/README.md
+++ b/demos/python_demos/face_recognition_demo/README.md
@@ -179,7 +179,6 @@ python ./face_recognition_demo.py \
 -m_fd <path_to_model>/face-detection-retail-0004.xml \
 -m_lm <path_to_model>/landmarks-regression-retail-0009.xml \
 -m_reid <path_to_model>/face-reidentification-retail-0095.xml \
--l <path_to_cpu_extensions>/libcpu_extension_sse4.so \
 --verbose \
 -fg "/home/face_gallery"
 ```
@@ -194,7 +193,6 @@ python ./face_recognition_demo.py ^
 -m_fd <path_to_model>/face-detection-retail-0004.xml ^
 -m_lm <path_to_model>/landmarks-regression-retail-0009.xml ^
 -m_reid <path_to_model>/face-reidentification-retail-0095.xml ^
--l <path_to_cpu_extensions>/cpu_extension_avx2.dll ^
 --verbose ^
 -fg "C:/face_gallery"
 ```

--- a/demos/python_demos/image_retrieval_demo/README.md
+++ b/demos/python_demos/image_retrieval_demo/README.md
@@ -66,7 +66,6 @@ python image_retrieval_demo.py \
 -m /home/user/image-retrieval-0001.xml \
 -i /home/user/video.dav.mp4 \
 -g /home/user/list.txt \
--l /opt/intel/openvino/inference_engine/lib/intel64/libcpu_extension_avx512.so \
 --ground_truth text_label
 ```
 

--- a/demos/python_demos/instance_segmentation_demo/README.md
+++ b/demos/python_demos/instance_segmentation_demo/README.md
@@ -84,7 +84,6 @@ To run the demo, please provide paths to the model in the IR format, to a file w
 python3 instance_segmentation_demo/instance_segmentation_demo.py \
     -m <path_to_model>/instance-segmentation-security-0050.xml \
     --label instance_segmentation_demo/coco_labels.txt \
-    -l <openvino_root>/inference_engine/lib/intel64/libcpu_extension_avx2.so \
     --no_keep_aspect_ratio \
     -i 0 \
     --delay 1


### PR DESCRIPTION
It will no longer exist as a separate library in the next release of Inference Engine.