### PR TITLE
Escape a special character in tools/downloader/README.md

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -48,7 +48,7 @@ When running the model downloader with Python 3.5.x on macOS, you may encounter
 an error similar to the following:
 
 > requests.exceptions.SSLError: [...] (Caused by SSLError(SSLError(1, '[SSL: TLSV1_ALERT_PROTOCOL_VERSION]
-tlsv1 alert protocol version (_ssl.c:719)'),))
+tlsv1 alert protocol version (\_ssl.c:719)'),))
 
 You can work around this by installing additional packages:
 


### PR DESCRIPTION
It being unescaped makes the GitHub syntax highlighter think the rest of the file is italicized, which is annoying. See:

https://github.com/opencv/open_model_zoo/blame/372c3b5d8/tools/downloader/README.md#L53