### PR TITLE
AC: support yolo v2 TF

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/yolo.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/yolo.py
@@ -135,6 +135,8 @@ class YoloV2Adapter(Adapter):
         result = []
         for identifier, prediction in zip(identifiers, predictions):
             labels, scores, x_mins, y_mins, x_maxs, y_maxs = [], [], [], [], [], []
+            if len(np.shape(prediction)) == 3:
+                prediction = prediction.flatten()
             for y, x, n in np.ndindex((cells_y, cells_x, self.num)):
                 index = n * cells_y * cells_x + y * cells_x + x
 


### PR DESCRIPTION
in openvino YoloRegion layer is flatten with shape ([batch, 125х13х13]), in TF implementation it is 4 dim tensor with shape [batch, 125, 13, 13].
Adopt yolo_v2 adapter to work for both cases,