### PR TITLE
Add a script that determines which CI jobs to run for a pull request

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,18 @@
 /demos/build_demos_msvc.bat omz.package=w
 /demos/tests/** -omz.package
 /tools/downloader/tests/** -omz.package
+
+/ci/requirements-ac.txt omz.ci.job-for-change.ac
+/ci/requirements-conversion.txt omz.ci.job-for-change.demos omz.ci.job-for-change.models
+/ci/requirements-demos.txt omz.ci.job-for-change.demos
+/ci/requirements-downloader.txt omz.ci.job-for-change.demos omz.ci.job-for-change.models
+
+/demos/** omz.ci.job-for-change.demos
+/demos/**/*.md -omz.ci.job-for-change.demos
+
+/models/** omz.ci.job-for-change.documentation
+/models/**/*.yml -omz.ci.job-for-change.documentation
+
+/tools/accuracy_checker/** omz.ci.job-for-change.ac
+/tools/downloader/** omz.ci.job-for-change.downloader
+/tools/**/*.md -omz.ci.job-for-change.ac -omz.ci.job-for-change.downloader

--- a/ci/get-jobs-for-changes.py
+++ b/ci/get-jobs-for-changes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A script that prints a JSON description of the CI jobs necessary to validate
+the changes made between a base commit and the current commit.
+
+The output format is a an object where each key is the identifier of the job
+and the corresponding value represents that job's parameters. The value
+is usually just "true" (which just means that the job should be run), but
+for the "models" job the value can be an array of names of models that should
+be validated.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+from pathlib import Path, PurePosixPath
+
+RE_ATTRIB_NAME = re.compile(r"omz\.ci\.job-for-change\.(.+)")
+
+def group_by_n(iterable, n):
+    return zip(*[iter(iterable)] * n)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('base_commit', metavar='COMMIT')
+    args = parser.parse_args()
+
+    git_diff_output = subprocess.check_output(
+        ["git", "diff", "--name-only", "-z", args.base_commit + "...HEAD"])
+    changed_files = list(map(PurePosixPath, git_diff_output.decode()[:-1].split("\0")))
+
+    models_dir = PurePosixPath("models")
+
+    jobs = {}
+
+    for changed_file in changed_files:
+        if models_dir in changed_file.parents and changed_file.name == "model.yml":
+            if Path(changed_file).exists(): # it might've been deleted in the branch
+                jobs.setdefault("models", []).append(changed_file.parent.name)
+
+    git_check_attr_output = subprocess.run(
+        ["git", "check-attr", "--stdin", "-z", "--all"],
+        input=git_diff_output, stdout=subprocess.PIPE, check=True).stdout
+
+    for path, attribute, value in group_by_n(git_check_attr_output.decode()[:-1].split("\0"), 3):
+        attribute_match = RE_ATTRIB_NAME.fullmatch(attribute)
+        if value != 'unset' and attribute_match:
+            jobs[attribute_match.group(1)] = True
+
+    json.dump(jobs, sys.stdout)
+    print()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently, this determination is done by a similar script in an internal repository used by the CI jobs. There are, however, a few advantages to having this script in the main repo:

* It's easier to effect project layout changes, since we can update the attributes and/or the script in the same PR in which we update the layout, thus avoiding periods where the project is desynchronized from the CI logic.

* Different branches can contain different versions of the script, which lets us configure CI logic per-branch without special-casing it in the CI scripts.

* We can use Git attributes to specify most of the job triggering policy, which lets us easily create fine-grained rules.

* It's more transparent to external users.

Admittedly, since the actual definitions of CI jobs are still in an internal repository, it'll still be necessary sometimes to synchronize changes to the main and CI repos. I hope to eventually move more of the CI logic to the main repository to rectify this.

There are five possible jobs that the script can request: "ac", "demos", "documentation", "downloader", and "models". We don't actually have separate "downloader" and "models" CI jobs (both types of changes are handled by the downloader job), but I think that:

a) it's more logical to report these types of changes separately; and 
b) we might eventually create a "models" job to separate the testing of models from the testing of the downloader itself.

[skip-ci] (This doesn't affect any jobs (yet), and I don't want to take up CI machines.)