### PR TITLE
downloader: add more supported precisions in preparation for the next release

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -324,8 +324,18 @@ describing a single model. Each such object has the following keys:
 
 * `precisions`: the list of precisions that the model has IR files for. For models downloaded
   in a format other than the Inference Engine IR format, these are the precisions that the model
-  converter can produce IR files in. Current possible values are `FP16`, `FP32`, `INT1`, `INT8`;
-  more might be added in the future.
+  converter can produce IR files in. Current possible values are:
+
+  * `FP16`
+  * `FP16-INT1`
+  * `FP16-INT8`
+  * `FP32`
+  * `FP32-INT1`
+  * `FP32-INT8`
+  * `INT1`
+  * `INT8`
+
+  Additional possible values might be added in the future.
 
 * `subdirectory`: the subdirectory of the output tree into which the downloaded or converted files
   will be placed by the downloader or the converter, respectively.

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -37,7 +37,11 @@ KNOWN_FRAMEWORKS = {
     'pytorch': 'pytorch_to_onnx.py',
     'tf': None,
 }
-KNOWN_PRECISIONS = {'FP16', 'FP32', 'INT1', 'INT8'}
+KNOWN_PRECISIONS = {
+    'FP16', 'FP16-INT1', 'FP16-INT8',
+    'FP32', 'FP32-INT1', 'FP32-INT8',
+    'INT1', 'INT8',
+}
 KNOWN_TASK_TYPES = {
     'action_recognition',
     'classification',


### PR DESCRIPTION
In the next release, there will be quantized models based on both FP32 and FP16, so additional precision IDs will be necessary to distinguish them.

We should be able to remove the old INT1/INT8 IDs in the future, but for now we still have models using them, so they have to stay.