### PR TITLE
AC configs: adopt to new layout

### DIFF
--- a/tools/accuracy_checker/configs/age-gender-recognition-retail-0013.yml
+++ b/tools/accuracy_checker/configs/age-gender-recognition-retail-0013.yml
@@ -22,6 +22,16 @@ models:
           gender_out: prob
           age_out: age_conv3
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.xml
+        weights: intel/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.bin
+        adapter:
+          type: age_gender
+          gender_out: prob
+          age_out: age_conv3
+
     datasets:
       - name: age_gender
 

--- a/tools/accuracy_checker/configs/emotions-recognition-retail-0003.yml
+++ b/tools/accuracy_checker/configs/emotions-recognition-retail-0003.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.xml
-        weights: intel/emotions-recognition-retail-0003/INT8/emotions-recognition-retail-0003.bin
+          - FP32-INT8
+        model:   intel/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.xml
+        weights: intel/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.bin
         adapter: classification
 
     datasets:

--- a/tools/accuracy_checker/configs/face-detection-adas-0001.yml
+++ b/tools/accuracy_checker/configs/face-detection-adas-0001.yml
@@ -18,10 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        device: CPU
-        model:   intel/face-detection-adas-0001/INT8/face-detection-adas-0001.xml
-        weights: intel/face-detection-adas-0001//INT8/face-detection-adas-0001.bin
+          - FP32-INT8
+        model:   intel/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.xml
+        weights: intel/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/face-detection-adas-binary-0001.yml
+++ b/tools/accuracy_checker/configs/face-detection-adas-binary-0001.yml
@@ -4,10 +4,9 @@ models:
     launchers:
       - framework: dlsdk
         tags:
-          - INT1
-        device: CPU
-        model:   intel/face-detection-adas-binary-0001/INT1/face-detection-adas-binary-0001.xml
-        weights: intel/face-detection-adas-binary-0001/INT1/face-detection-adas-binary-0001.bin
+          - FP32-INT1
+        model:   intel/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.xml
+        weights: intel/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/face-detection-retail-0004.yml
+++ b/tools/accuracy_checker/configs/face-detection-retail-0004.yml
@@ -18,10 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        device: CPU
-        model:   intel/face-detection-retail-0004/INT8/face-detection-retail-0004.xml
-        weights: intel/face-detection-retail-0004/INT8/face-detection-retail-0004.bin
+          - FP32-INT8
+        model:   intel/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.xml
+        weights: intel/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/face-detection-retail-0005.yml
+++ b/tools/accuracy_checker/configs/face-detection-retail-0005.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/face-detection-retail-0005/INT8/face-detection-retail-0005.xml
-        weights: intel/face-detection-retail-0005/INT8/face-detection-retail-0005.bin
+          - FP32-INT8
+        model:   intel/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.xml
+        weights: intel/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/face-detection-retail-0044.yml
+++ b/tools/accuracy_checker/configs/face-detection-retail-0044.yml
@@ -3,7 +3,6 @@ models:
 
     launchers:
       - framework: caffe
-        device: CPU
         model:   public/face-detection-retail-0044/face-detection-retail-0044.prototxt
         weights: public/face-detection-retail-0044/face-detection-retail-0044.caffemodel
         adapter: ssd
@@ -21,11 +20,6 @@ models:
         model:   public/face-detection-retail-0044/FP16/face-detection-retail-0044.xml
         weights: public/face-detection-retail-0044/FP16/face-detection-retail-0044.bin
         adapter: ssd
-        mo_params:
-          data_type: FP16
-          input_shape: "[1,3,300,300]"
-          input: data
-          output: detection_out
 
     datasets:
       - name: wider

--- a/tools/accuracy_checker/configs/face-recognition-resnet100-arcface.yml
+++ b/tools/accuracy_checker/configs/face-recognition-resnet100-arcface.yml
@@ -10,7 +10,6 @@ models:
             type: INPUT
             shape: 3, 112, 112
 
-
     datasets:
       - name: lfw
 

--- a/tools/accuracy_checker/configs/face-recognition-resnet34-arcface.yml
+++ b/tools/accuracy_checker/configs/face-recognition-resnet34-arcface.yml
@@ -10,7 +10,6 @@ models:
             type: INPUT
             shape: 3, 112, 112
 
-
     datasets:
       - name: lfw
 

--- a/tools/accuracy_checker/configs/face-recognition-resnet50-arcface.yml
+++ b/tools/accuracy_checker/configs/face-recognition-resnet50-arcface.yml
@@ -33,7 +33,6 @@ models:
         weights: public/face-recognition-resnet50-arcface//FP32/face-recognition-resnet50-arcface.bin
         adapter: reid
 
-
       - framework: dlsdk
         tags:
           - FP16

--- a/tools/accuracy_checker/configs/face-reidentification-retail-0095.yml
+++ b/tools/accuracy_checker/configs/face-reidentification-retail-0095.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
         adapter: reid
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.xml
+        weights: intel/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.bin
+        adapter: reid
+
     datasets:
       - name: lfw
 

--- a/tools/accuracy_checker/configs/facial-landmarks-35-adas-0002.yml
+++ b/tools/accuracy_checker/configs/facial-landmarks-35-adas-0002.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
         adapter: landmarks_regression
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.xml
+        weights: intel/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.bin
+        adapter: landmarks_regression
+
     datasets:
       - name: facial_landmarks_35
 

--- a/tools/accuracy_checker/configs/gaze-estimation-adas-0002.yml
+++ b/tools/accuracy_checker/configs/gaze-estimation-adas-0002.yml
@@ -39,9 +39,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/gaze-estimation-adas-0002/INT8/gaze-estimation-adas-0002.xml
-        weights: intel/gaze-estimation-adas-0002/INT8/gaze-estimation-adas-0002.bin
+          - FP32-INT8
+        model:   intel/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.xml
+        weights: intel/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.bin
         inputs:
           - name: left_eye_image
             type: INPUT

--- a/tools/accuracy_checker/configs/gaze-estimation-adas-0002.yml
+++ b/tools/accuracy_checker/configs/gaze-estimation-adas-0002.yml
@@ -2,7 +2,6 @@ models:
   - name: gaze-estimation-adas-0002
 
     launchers:
-
       - framework: dlsdk
         tags:
           - FP32

--- a/tools/accuracy_checker/configs/googlenet-v3-pytorch.yml
+++ b/tools/accuracy_checker/configs/googlenet-v3-pytorch.yml
@@ -30,7 +30,6 @@ models:
 
             # Using accuracy metric, achieved result of public model - 77.45% and 93.56% (top 1 and top 5 respectively)
 
-
   - name: googlenet-v3-pytorch
 
     # list of launchers

--- a/tools/accuracy_checker/configs/handwritten-score-recognition-0003.yml
+++ b/tools/accuracy_checker/configs/handwritten-score-recognition-0003.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
         adapter: beam_search_decoder
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.xml
+        weights: intel/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.bin
+        adapter: beam_search_decoder
+
     datasets:
       - name: handwritten_score_recognition
 

--- a/tools/accuracy_checker/configs/head-pose-estimation-adas-0001.yml
+++ b/tools/accuracy_checker/configs/head-pose-estimation-adas-0001.yml
@@ -24,6 +24,17 @@ models:
           angle_pitch: angle_p_fc
           angle_roll: angle_r_fc
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.xml
+        weights: intel/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.bin
+        adapter:
+          type: head_pose
+          angle_yaw: angle_y_fc
+          angle_pitch: angle_p_fc
+          angle_roll: angle_r_fc
+
     datasets:
       - name: head_pose
 

--- a/tools/accuracy_checker/configs/human-pose-estimation-0001.yml
+++ b/tools/accuracy_checker/configs/human-pose-estimation-0001.yml
@@ -26,10 +26,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        device: CPU
-        model:   intel/human-pose-estimation-0001/INT8/human-pose-estimation-0001.xml
-        weights: intel/human-pose-estimation-0001/INT8/human-pose-estimation-0001.bin
+          - FP32-INT8
+        model:   intel/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.xml
+        weights: intel/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.bin
         allow_reshape_input: True
         adapter:
           type: human_pose_estimation

--- a/tools/accuracy_checker/configs/image-retrieval-0001.yml
+++ b/tools/accuracy_checker/configs/image-retrieval-0001.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/image-retrieval-0001/FP16/image-retrieval-0001.bin
         adapter: reid
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/image-retrieval-0001/FP32-INT8/image-retrieval-0001.xml
+        weights: intel/image-retrieval-0001/FP32-INT8/image-retrieval-0001.bin
+        adapter: reid
+
     datasets:
       - name: image_retrieval
 

--- a/tools/accuracy_checker/configs/landmarks-regression-retail-0009.yml
+++ b/tools/accuracy_checker/configs/landmarks-regression-retail-0009.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
         adapter: landmarks_regression
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.xml
+        weights: intel/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.bin
+        adapter: landmarks_regression
+
     datasets:
       - name: vgg2face
 

--- a/tools/accuracy_checker/configs/license-plate-recognition-barrier-0001.yml
+++ b/tools/accuracy_checker/configs/license-plate-recognition-barrier-0001.yml
@@ -26,9 +26,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/license-plate-recognition-barrier-0001/INT8/license-plate-recognition-barrier-0001.xml
-        weights: intel/license-plate-recognition-barrier-0001/INT8/license-plate-recognition-barrier-0001.bin
+          - FP32-INT8
+        model:   intel/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.xml
+        weights: intel/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.bin
         adapter: lpr
         inputs:
           - name: seq_ind

--- a/tools/accuracy_checker/configs/pedestrian-and-vehicle-detector-adas-0001.yml
+++ b/tools/accuracy_checker/configs/pedestrian-and-vehicle-detector-adas-0001.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.xml
-        weights: intel/pedestrian-and-vehicle-detector-adas-0001/INT8/pedestrian-and-vehicle-detector-adas-0001.bin
+          - FP32-INT8
+        model:   intel/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
+        weights: intel/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/pedestrian-detection-adas-0002.yml
+++ b/tools/accuracy_checker/configs/pedestrian-detection-adas-0002.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.xml
-        weights: intel/pedestrian-detection-adas-0002/INT8/pedestrian-detection-adas-0002.bin
+          - FP32-INT8
+        model:   intel/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.xml
+        weights: intel/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/pedestrian-detection-adas-binary-0001.yml
+++ b/tools/accuracy_checker/configs/pedestrian-detection-adas-binary-0001.yml
@@ -4,9 +4,9 @@ models:
     launchers:
       - framework: dlsdk
         tags:
-          - INT1
-        model:   intel/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.xml
-        weights: intel/pedestrian-detection-adas-binary-0001/INT1/pedestrian-detection-adas-binary-0001.bin
+          - FP32-INT1
+        model:   intel/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.xml
+        weights: intel/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/person-attributes-recognition-crossroad-0230.yml
+++ b/tools/accuracy_checker/configs/person-attributes-recognition-crossroad-0230.yml
@@ -20,6 +20,16 @@ models:
           type: person_attributes
           attributes_recognition_out: "453"
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.xml
+        weights: intel/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.bin
+        adapter:
+          type: person_attributes
+          attributes_recognition_out: "453"
+
+
     datasets:
       - name: person_8_attributes
 

--- a/tools/accuracy_checker/configs/person-detection-action-recognition-0005.yml
+++ b/tools/accuracy_checker/configs/person-detection-action-recognition-0005.yml
@@ -38,9 +38,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-detection-action-recognition-0005/INT8/person-detection-action-recognition-0005.xml
-        weights: intel/person-detection-action-recognition-0005/INT8/person-detection-action-recognition-0005.bin
+          - FP32-INT8
+        model:   intel/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.xml
+        weights: intel/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.bin
         adapter:
           type: action_detection
           priorbox_out: mbox/priorbox

--- a/tools/accuracy_checker/configs/person-detection-action-recognition-0006.yml
+++ b/tools/accuracy_checker/configs/person-detection-action-recognition-0006.yml
@@ -53,9 +53,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-detection-action-recognition-0006/INT8/person-detection-action-recognition-0006.xml
-        weights: intel/person-detection-action-recognition-0006/INT8/person-detection-action-recognition-0006.bin
+          - FP32-INT8
+        model:   intel/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.xml
+        weights: intel/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.bin
         adapter:
           type: action_detection
           multihead_net: True

--- a/tools/accuracy_checker/configs/person-detection-action-recognition-teacher-0002.yml
+++ b/tools/accuracy_checker/configs/person-detection-action-recognition-teacher-0002.yml
@@ -36,6 +36,23 @@ models:
           action_confidence_threshold: 0.75
           action_scale: 3
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.xml
+        weights: intel/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.bin
+        adapter:
+          type: action_detection
+          priorbox_out: mbox/priorbox
+          loc_out: mbox_loc1/out/conv/flat
+          main_conf_out: mbox_main_conf/out/conv/flat/softmax/flat
+          add_conf_out_prefix: out/anchor
+          add_conf_out_count: 4
+          num_action_classes: 3
+          detection_threshold: 0.4
+          action_confidence_threshold: 0.75
+          action_scale: 3
+
     datasets:
       - name: action_detection_dataset_teacher
 

--- a/tools/accuracy_checker/configs/person-detection-raisinghand-recognition-0001.yml
+++ b/tools/accuracy_checker/configs/person-detection-raisinghand-recognition-0001.yml
@@ -36,6 +36,23 @@ models:
           action_confidence_threshold: 0.75
           action_scale: 3
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.xml
+        weights: intel/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.bin
+        adapter:
+          type: action_detection
+          priorbox_out: mbox/priorbox
+          loc_out: mbox_loc1/out/conv/flat
+          main_conf_out: mbox_main_conf/out/conv/flat/softmax/flat
+          add_conf_out_prefix: out/anchor
+          add_conf_out_count: 4
+          num_action_classes: 2
+          detection_threshold: 0.4
+          action_confidence_threshold: 0.75
+          action_scale: 3
+
     datasets:
       - name: action_detection_dataset_raising_hand
 

--- a/tools/accuracy_checker/configs/person-detection-retail-0002.yml
+++ b/tools/accuracy_checker/configs/person-detection-retail-0002.yml
@@ -24,6 +24,18 @@ models:
             type: CONST_INPUT
             value: [[544, 992, 0, 0, 0, 0]]
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/person-detection-retail-0002/FP32-INT8/person-detection-retail-0002.xml
+        weights: intel/person-detection-retail-0002/FP32-INT8/person-detection-retail-0002.bin
+        adapter: ssd
+        inputs:
+          - name: im_info
+            type: CONST_INPUT
+            value: [[544, 992, 0, 0, 0, 0]]
+
+
     datasets:
       - name: person_detection
 

--- a/tools/accuracy_checker/configs/person-detection-retail-0013.yml
+++ b/tools/accuracy_checker/configs/person-detection-retail-0013.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-detection-retail-0013/INT8/person-detection-retail-0013.xml
-        weights: intel/person-detection-retail-0013/INT8/person-detection-retail-0013.bin
+          - FP32-INT8
+        model:   intel/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.xml
+        weights: intel/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0031.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0031.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-reidentification-retail-0031/INT8/person-reidentification-retail-0031.xml
-        weights: intel/person-reidentification-retail-0031/INT8/person-reidentification-retail-0031.bin
+          - FP32-INT8
+        model:   intel/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.xml
+        weights: intel/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.bin
         adapter: reid
 
     datasets:

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0103.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0103.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-reidentification-retail-0103/INT8/person-reidentification-retail-0103.xml
-        weights: intel/person-reidentification-retail-0103/INT8/person-reidentification-retail-0103.bin
+          - FP32-INT8
+        model:   intel/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.xml
+        weights: intel/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.bin
         adapter: reid
 
     datasets:

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0107.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0107.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-reidentification-retail-0107/INT8/person-reidentification-retail-0107.xml
-        weights: intel/person-reidentification-retail-0107/INT8/person-reidentification-retail-0107.bin
+          - FP32-INT8
+        model:   intel/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.xml
+        weights: intel/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.bin
         adapter: reid
 
     datasets:

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0200.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0200.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-reidentification-retail-0200/INT8/person-reidentification-retail-0200.xml
-        weights: intel/person-reidentification-retail-0200/INT8/person-reidentification-retail-0200.bin
+          - FP32-INT8
+        model:   intel/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.xml
+        weights: intel/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.bin
         adapter: reid
 
     datasets:

--- a/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-0078.yml
+++ b/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-0078.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/person-vehicle-bike-detection-crossroad-0078/INT8/person-vehicle-bike-detection-crossroad-0078.xml
-        weights: intel/person-vehicle-bike-detection-crossroad-0078/INT8/person-vehicle-bike-detection-crossroad-0078.bin
+          - FP32-INT8
+        model:   intel/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.xml
+        weights: intel/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-1016.yml
+++ b/tools/accuracy_checker/configs/person-vehicle-bike-detection-crossroad-1016.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
         adapter: ssd
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.xml
+        weights: intel/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.bin
+        adapter: ssd
+
     datasets:
       - name: crossroad_dataset_1016
 

--- a/tools/accuracy_checker/configs/product-detection-0001.yml
+++ b/tools/accuracy_checker/configs/product-detection-0001.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/product-detection-0001/INT8/product-detection-0001.xml
-        weights: intel/product-detection-0001/INT8/product-detection-0001.bin
+          - FP32-INT8
+        model:   intel/product-detection-0001/FP32-INT8/product-detection-0001.xml
+        weights: intel/product-detection-0001/FP32-INT8/product-detection-0001.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/resnet18-xnor-binary-onnx-0001.yml
+++ b/tools/accuracy_checker/configs/resnet18-xnor-binary-onnx-0001.yml
@@ -1,0 +1,43 @@
+models:
+  - name: resnet18-xnor-binary-onnx-0001
+
+    launchers:
+      - framework: dlsdk
+        tags:
+          - FP32-INT1
+        model:   resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
+        weights: resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
+        adapter: classification
+      - framework: dlsdk
+        tags:
+          - FP16-INT1
+        model:   resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
+        weights: resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
+        adapter: classification
+
+    datasets:
+      - name: imagenet_1000_classes
+        data_source: ImageNet
+        annotation: imagenet1000.pickle
+        reader: pillow_imread
+
+        preprocessing:
+        - type: resize
+          size: 256
+          aspect_ratio_scale: greater
+          use_pillow: True
+          interpolation: BILINEAR
+        - type: crop
+          size: 224
+          use_pillow: True
+        - type: bgr_to_rgb
+
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+
+global_definitions: ../dataset_definitions.yml

--- a/tools/accuracy_checker/configs/resnet50-binary-0001.yml
+++ b/tools/accuracy_checker/configs/resnet50-binary-0001.yml
@@ -4,10 +4,10 @@ models:
     launchers:
       - framework: dlsdk
         tags:
-          - INT1
+          - FP32-INT1
         device: CPU
-        model:   intel/resnet50-binary-0001/INT1/resnet50-binary-0001.xml
-        weights: intel/resnet50-binary-0001/INT1/resnet50-binary-0001.bin
+        model:   intel/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
+        weights: intel/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
         adapter: classification
 
 

--- a/tools/accuracy_checker/configs/resnet50-binary-0001.yml
+++ b/tools/accuracy_checker/configs/resnet50-binary-0001.yml
@@ -5,11 +5,16 @@ models:
       - framework: dlsdk
         tags:
           - FP32-INT1
-        device: CPU
         model:   intel/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
         weights: intel/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT1
+        model:   intel/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
+        weights: intel/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
+        adapter: classification
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/configs/road-segmentation-adas-0001.yml
+++ b/tools/accuracy_checker/configs/road-segmentation-adas-0001.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
         adapter: segmentation
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.xml
+        weights: intel/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.bin
+        adapter: segmentation
+
     datasets:
       - name: road_segmentation
 

--- a/tools/accuracy_checker/configs/semantic-segmentation-adas-0001.yml
+++ b/tools/accuracy_checker/configs/semantic-segmentation-adas-0001.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
         adapter: segmentation
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.xml
+        weights: intel/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.bin
+        adapter: segmentation
+
     datasets:
       - name: semantic_segmentation_adas
 

--- a/tools/accuracy_checker/configs/single-image-super-resolution-1032.yml
+++ b/tools/accuracy_checker/configs/single-image-super-resolution-1032.yml
@@ -36,9 +36,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/single-image-super-resolution-1032/INT8/single-image-super-resolution-1032.xml
-        weights: intel/single-image-super-resolution-1032/INT8/single-image-super-resolution-1032.bin
+          - FP32-INT8
+        model:   intel/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.xml
+        weights: intel/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.bin
         adapter:
           type: super_resolution
           reverse_channels: True

--- a/tools/accuracy_checker/configs/single-image-super-resolution-1033.yml
+++ b/tools/accuracy_checker/configs/single-image-super-resolution-1033.yml
@@ -36,9 +36,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/single-image-super-resolution-1033/INT8/single-image-super-resolution-1033.xml
-        weights: intel/single-image-super-resolution-1033/INT8/single-image-super-resolution-1033.bin
+          - FP32-INT8
+        model:   intel/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.xml
+        weights: intel/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.bin
         adapter:
           type: super_resolution
           reverse_channels: True

--- a/tools/accuracy_checker/configs/text-detection-0003.yml
+++ b/tools/accuracy_checker/configs/text-detection-0003.yml
@@ -32,10 +32,10 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
+          - FP32-INT8
         device: CPU
-        model:   intel/text-detection-0003/INT8/text-detection-0003.xml
-        weights: intel/text-detection-0003/INT8/text-detection-0003.bin
+        model:   intel/text-detection-0003/FP32-INT8/text-detection-0003.xml
+        weights: intel/text-detection-0003/FP32-INT8/text-detection-0003.bin
         adapter:
           type: pixel_link_text_detection
           pixel_link_out: model/link_logits_/add

--- a/tools/accuracy_checker/configs/text-detection-0004.yml
+++ b/tools/accuracy_checker/configs/text-detection-0004.yml
@@ -30,6 +30,20 @@ models:
           min_area: 300
           min_height: 10
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/text-detection-0004/FP32-INT8/text-detection-0004.xml
+        weights: intel/text-detection-0004/FP32-INT8/text-detection-0004.bin
+        adapter:
+          type: pixel_link_text_detection
+          pixel_link_out: model/link_logits_/add
+          pixel_class_out: model/segm_logits/add
+          pixel_class_confidence_threshold: 0.8
+          pixel_link_confidence_threshold: 0.8
+          min_area: 300
+          min_height: 10
+
     datasets:
       - name: ICDAR2015
 

--- a/tools/accuracy_checker/configs/text-image-super-resolution-0001.yml
+++ b/tools/accuracy_checker/configs/text-image-super-resolution-0001.yml
@@ -20,9 +20,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/text-image-super-resolution-0001/INT8/text-image-super-resolution-0001.xml
-        weights: intel/text-image-super-resolution-0001/INT8/text-image-super-resolution-0001.bin
+          - FP32-INT8
+        model:   intel/text-image-super-resolution-0001/FP32-INT8/text-image-super-resolution-0001.xml
+        weights: intel/text-image-super-resolution-0001/FP32-INT8/text-image-super-resolution-0001.bin
         adapter:
           type: super_resolution
 

--- a/tools/accuracy_checker/configs/text-recognition-0012.yml
+++ b/tools/accuracy_checker/configs/text-recognition-0012.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/text-recognition-0012/FP16/text-recognition-0012.bin
         adapter: beam_search_decoder
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   intel/text-recognition-0012/FP32-INT8/text-recognition-0012.xml
+        weights: intel/text-recognition-0012/FP32-INT8/text-recognition-0012.bin
+        adapter: beam_search_decoder
+
     datasets:
       - name: ICDAR2013
 

--- a/tools/accuracy_checker/configs/vehicle-attributes-recognition-barrier-0039.yml
+++ b/tools/accuracy_checker/configs/vehicle-attributes-recognition-barrier-0039.yml
@@ -24,9 +24,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/vehicle-attributes-recognition-barrier-0039/INT8/vehicle-attributes-recognition-barrier-0039.xml
-        weights: intel/vehicle-attributes-recognition-barrier-0039/INT8/vehicle-attributes-recognition-barrier-0039.bin
+          - FP32-INT8
+        model:   intel/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.xml
+        weights: intel/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.bin
         adapter:
           type: vehicle_attributes
           color_out: color

--- a/tools/accuracy_checker/configs/vehicle-detection-adas-0002.yml
+++ b/tools/accuracy_checker/configs/vehicle-detection-adas-0002.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.xml
-        weights: intel/vehicle-detection-adas-0002/INT8/vehicle-detection-adas-0002.bin
+          - FP32-INT8
+        model:   intel/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.xml
+        weights: intel/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/vehicle-detection-adas-binary-0001.yml
+++ b/tools/accuracy_checker/configs/vehicle-detection-adas-binary-0001.yml
@@ -4,9 +4,9 @@ models:
     launchers:
       - framework: dlsdk
         tags:
-          - INT1
-        model:   intel/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.xml
-        weights: intel/vehicle-detection-adas-binary-0001/INT1/vehicle-detection-adas-binary-0001.bin
+          - FP32-INT1
+        model:   intel/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.xml
+        weights: intel/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.bin
         adapter: ssd
 
     datasets:

--- a/tools/accuracy_checker/configs/vehicle-license-plate-detection-barrier-0106.yml
+++ b/tools/accuracy_checker/configs/vehicle-license-plate-detection-barrier-0106.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - INT8
-        model:   intel/vehicle-license-plate-detection-barrier-0106/INT8/vehicle-license-plate-detection-barrier-0106.xml
-        weights: intel/vehicle-license-plate-detection-barrier-0106/INT8/vehicle-license-plate-detection-barrier-0106.bin
+          - FP32-INT8
+        model:   intel/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.xml
+        weights: intel/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.bin
         adapter: ssd
 
     datasets:


### PR DESCRIPTION
- changed paths to INT8 and INT1 models
- removed explicit device setting
- removed extra empy lines and some unused parameters (mo_params when IR used)