### PR TITLE
AC: replace deprecated config option for vpu logging

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -571,7 +571,7 @@ class DLSDKLauncher(Launcher):
         if self._is_vpu():
             log_level = self.config.get('_vpu_log_level')
             if log_level:
-                self.plugin.set_config({'VPU_LOG_LEVEL': log_level})
+                self.plugin.set_config({'LOG_LEVEL': log_level})
 
     def auto_num_requests(self):
         concurrency_device = {

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -474,21 +474,6 @@ class DLSDKLauncher(Launcher):
                 del self.exec_network
                 self.exec_network = self.plugin.load(self.network, num_requests=self._num_requests)
 
-
-    @property
-    def async_mode(self):
-        return self._async_mode
-
-    @async_mode.setter
-    def async_mode(self, flag):
-        if flag:
-            # if 'CPU' in self._devices_list():
-            #     self.plugin.set_config({'CPU_THROUGHPUT_STREAMS': 'CPU_THROUGHPUT_AUTO'})
-            #     self.plugin.set_config({'CPU_BIND_THREAD': 'YES'})
-            if 'GPU' in self._devices_list():
-                self.plugin.set_config({'GPU_THROUGHPUT_STREAMS': 'GPU_THROUGHPUT_AUTO'})
-        self._async_mode = flag
-
     @property
     def infer_requests(self):
         return self.exec_network.requests

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -474,6 +474,21 @@ class DLSDKLauncher(Launcher):
                 del self.exec_network
                 self.exec_network = self.plugin.load(self.network, num_requests=self._num_requests)
 
+
+    @property
+    def async_mode(self):
+        return self._async_mode
+
+    @async_mode.setter
+    def async_mode(self, flag):
+        if flag:
+            # if 'CPU' in self._devices_list():
+            #     self.plugin.set_config({'CPU_THROUGHPUT_STREAMS': 'CPU_THROUGHPUT_AUTO'})
+            #     self.plugin.set_config({'CPU_BIND_THREAD': 'YES'})
+            if 'GPU' in self._devices_list():
+                self.plugin.set_config({'GPU_THROUGHPUT_STREAMS': 'GPU_THROUGHPUT_AUTO'})
+        self._async_mode = flag
+
     @property
     def infer_requests(self):
         return self.exec_network.requests

--- a/tools/accuracy_checker/configs/faster_rcnn_resnet50_coco.yml
+++ b/tools/accuracy_checker/configs/faster_rcnn_resnet50_coco.yml
@@ -4,13 +4,15 @@ models:
       - framework: dlsdk
         tags:
           - FP32
-        model:   public/faster_rcnn_resnet50_coco/FP32/faster_rcnn_resnet50_coco.xml
-        weights: public/faster_rcnn_resnet50_coco/FP32/faster_rcnn_resnet50_coco.bin
+        model:   faster_rcnn_resnet50_coco/tf/FP32/faster_rcnn_resnet50_coco.xml
+        weights: faster_rcnn_resnet50_coco/tf/FP32/faster_rcnn_resnet50_coco.bin
         adapter: ssd
         inputs:
           - name: image_info
             type: CONST_INPUT
             value: [[600, 1024, 1]]
+        async_mode: True
+        num_requests: 8
 
       - framework: dlsdk
         tags:

--- a/tools/accuracy_checker/configs/faster_rcnn_resnet50_coco.yml
+++ b/tools/accuracy_checker/configs/faster_rcnn_resnet50_coco.yml
@@ -4,15 +4,13 @@ models:
       - framework: dlsdk
         tags:
           - FP32
-        model:   faster_rcnn_resnet50_coco/tf/FP32/faster_rcnn_resnet50_coco.xml
-        weights: faster_rcnn_resnet50_coco/tf/FP32/faster_rcnn_resnet50_coco.bin
+        model:   public/faster_rcnn_resnet50_coco/FP32/faster_rcnn_resnet50_coco.xml
+        weights: public/faster_rcnn_resnet50_coco/FP32/faster_rcnn_resnet50_coco.bin
         adapter: ssd
         inputs:
           - name: image_info
             type: CONST_INPUT
             value: [[600, 1024, 1]]
-        async_mode: True
-        num_requests: 8
 
       - framework: dlsdk
         tags:


### PR DESCRIPTION
VPU_LOG_LEVEL is deprecated, use LOG_LEVEL instead.