### PR TITLE
AC: adopt human pose adapter to work with openpose

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -119,6 +119,7 @@ AccuracyChecker supports following set of adapters:
 * `human_pose_estimation` - converting output of model for human pose estimation to `PoseEstimationPrediction`.
   * `part_affinity_fields_out` - name of output layer with keypoints pairwise relations (part affinity fields).
   * `keypoints_heatmap_out` - name of output layer with keypoints heatmaps.
+  The output layers can be omitted if model has only one output layer - concatenation of this 2.
 * `beam_search_decoder` - realization CTC Beam Search decoder for symbol sequence recognition, converting model output to `CharacterRecognitionPrediction`.
   * `beam_size` -  size of the beam to use during decoding (default 10).
   * `blank_label` - index of the CTC blank label.


### PR DESCRIPTION
in the original CMU openpose  implementation part affinity fields and keypoints heatmaps joined to the one layer. It is difficult to get intermediate blob in the Caffe (no restriction select another layers during model conversion via MO), so I extend adapter for human-pose-estimation to cover Caffe openpose model

