### PR TITLE
AC: remove cpu_extension from dataset definitions

### DIFF
--- a/tools/accuracy_checker/dataset_definitions.yml
+++ b/tools/accuracy_checker/dataset_definitions.yml
@@ -1,7 +1,3 @@
-launchers:
-  - framework: dlsdk
-    cpu_extensions: AUTO
-
 datasets:
   - name: ms_coco_mask_rcnn
     annotation_conversion:


### PR DESCRIPTION
removed cpu_extensions usage in global_definitions (removed in the package in upcoming release)