### PR TITLE
instance_segmentation: fix

### DIFF
--- a/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo.py
+++ b/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo.py
@@ -155,7 +155,6 @@ def main():
 
     log.info('Loading IR to the plugin...')
     exec_net = ie.load_network(network=net, device_name=args.device, num_requests=2)
-    del net
 
     try:
         input_source = int(args.input_source)
@@ -276,8 +275,6 @@ def main():
 
     cv2.destroyAllWindows()
     cap.release()
-    del exec_net
-    del ie
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For Ubuntu16 the demo drew wrong masks sometimes.
I was deleting and returning back parts of the demo's code to find what causes it.
It appeared, that deleting the line `del net` fixes the issue.
Delete `del exec_net` and `del ie` just because they are not really needed.