### PR TITLE
Add ctc beam search decoder for text_detection demo

### DIFF
--- a/demos/text_detection_demo/README.md
+++ b/demos/text_detection_demo/README.md
@@ -46,6 +46,7 @@ Options:
     -no_show                     Optional. If it is true, then detected text will not be shown on image frame. By default, it is false.
     -r                           Optional. Output Inference results as raw values.
     -u                           Optional. List of monitors to show initially.
+    -b                           Optional. Default bandwidth is 0 it will use CTC Greedy Decoder.
 ```
 
 Running the application with the empty list of options yields the usage message given above and an error message.

--- a/demos/text_detection_demo/README.md
+++ b/demos/text_detection_demo/README.md
@@ -46,7 +46,7 @@ Options:
     -no_show                     Optional. If it is true, then detected text will not be shown on image frame. By default, it is false.
     -r                           Optional. Output Inference results as raw values.
     -u                           Optional. List of monitors to show initially.
-    -b                           Optional. Default bandwidth is 0 it will use CTC Greedy Decoder.
+    -b                           Optional. Bandwidth for CTC beam search decoder. Default value is 0, in this case CTC greedy decoder will be used.
 ```
 
 Running the application with the empty list of options yields the usage message given above and an error message.

--- a/demos/text_detection_demo/include/text_recognition.hpp
+++ b/demos/text_detection_demo/include/text_recognition.hpp
@@ -7,4 +7,22 @@
 #include <string>
 #include <vector>
 
+class beam
+{
+public:
+    beam(std::string _text, float _pB, float _pNB, float _pT)
+    {
+        sentance = _text;
+        pB = _pB;
+        pNB = _pNB;
+        pT = _pT;
+    };
+public :
+    std::string sentance;
+    float pB;
+    float pNB;
+    float pT;
+};
+
 std::string CTCGreedyDecoder(const std::vector<float> &data, const std::string& alphabet, char pad_symbol, double *conf);
+std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::string& alphabet, char pad_symbol, double *conf, int bandwidth);

--- a/demos/text_detection_demo/include/text_recognition.hpp
+++ b/demos/text_detection_demo/include/text_recognition.hpp
@@ -7,22 +7,5 @@
 #include <string>
 #include <vector>
 
-class beam
-{
-public:
-    beam(std::string _text, float _pB, float _pNB, float _pT)
-    {
-        sentance = _text;
-        pB = _pB;
-        pNB = _pNB;
-        pT = _pT;
-    };
-public :
-    std::string sentance;
-    float pB;
-    float pNB;
-    float pT;
-};
-
 std::string CTCGreedyDecoder(const std::vector<float> &data, const std::string& alphabet, char pad_symbol, double *conf);
 std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::string& alphabet, char pad_symbol, double *conf, int bandwidth);

--- a/demos/text_detection_demo/main.cpp
+++ b/demos/text_detection_demo/main.cpp
@@ -137,9 +137,6 @@ int main(int argc, char *argv[]) {
         auto cls_conf_threshold = static_cast<float>(FLAGS_cls_pixel_thr);
         auto link_conf_threshold = static_cast<float>(FLAGS_link_pixel_thr);
         auto decoder_bandwidth = FLAGS_b;
-        if (decoder_bandwidth < 0) {
-            throw std::invalid_argument("Parameter -b cannot lower than 0.");
-        }
 
         slog::info << "Loading network files" << slog::endl;
         Cnn text_detection, text_recognition;

--- a/demos/text_detection_demo/main.cpp
+++ b/demos/text_detection_demo/main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
         auto link_conf_threshold = static_cast<float>(FLAGS_link_pixel_thr);
         auto decoder_bandwidth = FLAGS_b;
         if (decoder_bandwidth < 0) {
-            throw std::logic_error("Parameter -b cannot lower than 0.");
+            throw std::invalid_argument("Parameter -b cannot lower than 0.");
         }
 
         slog::info << "Loading network files" << slog::endl;

--- a/demos/text_detection_demo/main.cpp
+++ b/demos/text_detection_demo/main.cpp
@@ -136,6 +136,10 @@ int main(int argc, char *argv[]) {
         auto extension_path = FLAGS_l;
         auto cls_conf_threshold = static_cast<float>(FLAGS_cls_pixel_thr);
         auto link_conf_threshold = static_cast<float>(FLAGS_link_pixel_thr);
+        auto decoder_bandwidth = FLAGS_b;
+        if (decoder_bandwidth < 0) {
+            throw std::logic_error("Parameter -b cannot lower than 0.");
+        }
 
         slog::info << "Loading network files" << slog::endl;
         Cnn text_detection, text_recognition;
@@ -230,7 +234,11 @@ int main(int argc, char *argv[]) {
                     std::vector<float> output_data(ouput_data_pointer, ouput_data_pointer + output_shape[0] * output_shape[2]);
 
                     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-                    res = CTCGreedyDecoder(output_data, kAlphabet, kPadSymbol, &conf);
+                    if (decoder_bandwidth == 0) {
+                        res = CTCGreedyDecoder(output_data, kAlphabet, kPadSymbol, &conf);
+                    } else {
+                        res = CTCBeamSearchDecoder(output_data, kAlphabet, kPadSymbol, &conf, decoder_bandwidth);
+                    }
                     std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
                     text_recognition_postproc_time += std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
 

--- a/demos/text_detection_demo/src/text_recognition.cpp
+++ b/demos/text_detection_demo/src/text_recognition.cpp
@@ -27,11 +27,13 @@ namespace  {
         *prob = 1.0f / static_cast<float>(sum);
     }
 
-    void softmax(const std::vector<float>::const_iterator& begin, const std::vector<float>::const_iterator& end, std::vector<float> &prob) {
+    std::vector<float> softmax(const std::vector<float>::const_iterator& begin, const std::vector<float>::const_iterator& end) {
+        std::vector<float> prob(end - begin, 0.f);
         std::transform(begin, end, prob.begin(), static_cast<double(*)(double)>(std::exp));
         float sum = std::accumulate(prob.begin(), prob.end(), 0.0f);
         for (int i = 0; i < static_cast<int>(prob.size()); i++)
             prob[i] /= sum;
+        return prob;
     }
 
     struct BeamElement {
@@ -87,8 +89,7 @@ std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::stri
     for (std::vector<float>::const_iterator it = data.begin(); it != data.end(); it += num_classes) {
         curr.clear();
 
-        std::vector<float> prob = std::vector<float>(num_classes, 0.f);
-        softmax(it, it + num_classes, prob);
+        std::vector<float> prob = softmax(it, it + num_classes);
 
         for(const auto& candidate: last) {
             float prob_not_blank = 0.f;

--- a/demos/text_detection_demo/src/text_recognition.cpp
+++ b/demos/text_detection_demo/src/text_recognition.cpp
@@ -41,7 +41,7 @@ namespace  {
         float prob_not_blank;        //!< The probability that the last char in CTC sequence
                                      //!< for the beam element is NOT the special blank char
 
-        float prob() {               //!< The probability of the beam element.
+        float prob() const {         //!< The probability of the beam element.
             return prob_blank + prob_not_blank;
         }
     };
@@ -90,9 +90,9 @@ std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::stri
         std::vector<float> prob = std::vector<float>(num_classes, 0.f);
         softmax(it, it + num_classes, prob);
 
-        for(auto& candidate: last) {
+        for(const auto& candidate: last) {
             float prob_not_blank = 0.f;
-            std::vector<int> candidate_sentence = candidate.sentence;
+            const std::vector<int>& candidate_sentence = candidate.sentence;
             if (!candidate_sentence.empty()) {
                 int n = candidate_sentence.back();
                 prob_not_blank = candidate.prob_not_blank * prob[n];
@@ -105,14 +105,10 @@ std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::stri
             if (check_res == std::end(curr)) {
                 curr.push_back(BeamElement{candidate.sentence, prob_blank, prob_not_blank});
             } else {
-                // auto index = std::distance(curr.begin(), check_res);
-                // curr[index].prob_not_blank  += prob_not_blank;
                 check_res->prob_not_blank  += prob_not_blank;
-                // if (curr[index].prob_blank != 0.f) {
                 if (check_res->prob_blank != 0.f) {
                     throw std::logic_error("Probability that the last char in CTC-sequence is the special blank char must be zero here");
                 }
-                // curr[index].prob_blank = prob_blank;
                 check_res->prob_blank = prob_blank;
             }
 
@@ -133,8 +129,6 @@ std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::stri
                 if (check_res == std::end(curr)) {
                     curr.push_back(BeamElement{extend, 0.f, prob_not_blank});
                 } else {
-                    // auto index = std::distance(curr.begin(), check_res);
-                    // curr[index].prob_not_blank += prob_not_blank;
                     check_res->prob_not_blank += prob_not_blank;
                 }
             }

--- a/demos/text_detection_demo/src/text_recognition.cpp
+++ b/demos/text_detection_demo/src/text_recognition.cpp
@@ -140,14 +140,9 @@ std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::stri
         });
 
         last.clear();
-        if (bandwidth > static_cast<int>(curr.size())) {
-            for (int _b = 0; _b < static_cast<int>(curr.size()); _b++) {
-                last.push_back(curr[_b]);
-            }
-        } else {
-            for (int _b = 0; _b < bandwidth; _b++) {
-                last.push_back(curr[_b]);
-            }
+        int num_to_copy = std::min(bandwidth, static_cast<int>(curr.size()));
+        for (int b = 0; b < num_to_copy; b++) {
+            last.push_back(curr[b]);
         }
     }
 

--- a/demos/text_detection_demo/src/text_recognition.cpp
+++ b/demos/text_detection_demo/src/text_recognition.cpp
@@ -25,6 +25,14 @@ namespace  {
         }
         *prob = 1.0f / static_cast<float>(sum);
     }
+
+    void softmax_layer(const std::vector<float>::const_iterator& begin, const std::vector<float>::const_iterator& end, std::vector<float> &prob)
+    {
+        std::transform(begin, end, prob.begin(), static_cast<double(*)(double)>(std::exp));
+        float sum = std::accumulate(prob.begin(), prob.end(), 0.0f);
+        for (int i = 0; i < static_cast<int>(prob.size()); i++)
+            prob[i] /= sum;
+    }
 }  // namespace
 
 std::string CTCGreedyDecoder(const std::vector<float> &data, const std::string& alphabet, char pad_symbol, double *conf) {
@@ -53,3 +61,91 @@ std::string CTCGreedyDecoder(const std::vector<float> &data, const std::string& 
     }
     return res;
 }
+
+std::string CTCBeamSearchDecoder(const std::vector<float> &data, const std::string& alphabet, char pad_symbol, double *conf, int bandwidth) {
+    std::string res = "";
+
+    const int num_classes = alphabet.length();
+
+    std::vector<beam> curr;
+    std::vector<beam> last;
+
+    beam init("", 1.f, 0.f, 1.f);
+    last.push_back(init);
+
+    for (std::vector<float>::const_iterator it = data.begin(); it != data.end(); it += num_classes) {
+        curr.clear();
+
+        std::vector<float> prob = std::vector<float>(num_classes, 0.f);
+        softmax_layer(it, it + num_classes, prob);
+
+        for (int _candidate = 0; _candidate < static_cast<int>(last.size()); _candidate++) {
+            float _pNB = 0.f;
+            auto __can = last[_candidate];
+            std::string __can_sentance = __can.sentance;
+            if (__can_sentance != "") {
+                int n = static_cast<int>(__can_sentance.back());
+                _pNB = __can.pNB * prob[n];
+            }
+            float _pB = __can.pT * prob[(num_classes - 1)];
+
+            auto check_res = std::find_if(curr.begin(), curr.end(), [__can_sentance](beam const& n) {
+                return n.sentance == __can_sentance;
+            });
+            if (check_res == std::end(curr)) {
+                curr.push_back(beam(__can.sentance, _pB, _pNB, _pB + _pNB));
+            } else {
+                auto __i = std::distance(curr.begin(), check_res);
+                curr[__i].pNB += _pNB;
+                curr[__i].pB = _pB;
+                curr[__i].pT = curr[__i].pB + curr[__i].pNB;
+            }
+
+            for (int i = 0; i < num_classes - 1; i++) {
+                auto extand_t = __can_sentance + static_cast<char>(i);
+                if (__can_sentance.length() > 0 && __can.sentance.back() == static_cast<char>(i)) {
+                    _pNB = prob[i] * __can.pB;
+                } else {
+                    _pNB = prob[i] * __can.pT;
+                }
+                
+                auto check_res = std::find_if(curr.begin(), curr.end(), [extand_t](beam const& n) {
+                    return n.sentance == extand_t;
+                });
+
+                if (check_res == std::end(curr)) {
+                    curr.push_back(beam(extand_t, 0.f, _pNB, _pNB));
+                } else {
+                    auto __i = std::distance(curr.begin(), check_res);
+                    curr[__i].pNB += _pNB;
+                    curr[__i].pT += _pNB;
+                }
+            }
+        }
+
+        sort(curr.begin(), curr.end(), [](const beam &a, const beam &b) -> bool {
+            return a.pT > b.pT;
+        });
+
+        last.clear();
+        if (bandwidth > static_cast<int>(curr.size())) {
+            for (int _b = 0; _b < static_cast<int>(curr.size()); _b++) {
+                last.push_back(curr[_b]);
+            }
+        } else {
+            for (int _b = 0; _b < bandwidth; _b++) {
+                last.push_back(curr[_b]);
+            }
+        }
+    }
+
+    auto idx = last[0].sentance;
+    *conf = last[0].pT;
+    for (int _idx = 0; _idx < static_cast<int>(idx.length()); _idx++)
+    {
+        res += alphabet[static_cast<int>(idx[_idx])];
+    }
+
+    return res;
+}
+

--- a/demos/text_detection_demo/text_detection_demo.hpp
+++ b/demos/text_detection_demo/text_detection_demo.hpp
@@ -43,7 +43,7 @@ static const char input_data_type_message[] = "Required. Input data type: \"imag
                                               "\"video\" (for a saved video), "
                                               "\"webcam\" (for a webcamera device). By default, it is \"image\".";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
-static const char decoder_bandwidth_message[] = "Optional. Default bandwidth is 0 it will use CTC Greedy Decoder.";
+static const char decoder_bandwidth_message[] = "Optional. Bandwidth for CTC beam search decoder. Default value is 0, in this case CTC greedy decoder will be used.";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(i, "", input_message);

--- a/demos/text_detection_demo/text_detection_demo.hpp
+++ b/demos/text_detection_demo/text_detection_demo.hpp
@@ -65,7 +65,7 @@ DEFINE_string(c, "", custom_gpu_library_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_bool(r, false, raw_output_message);
 DEFINE_string(u, "", utilization_monitors_message);
-DEFINE_int32(b, 0, decoder_bandwidth_message);
+DEFINE_uint32(b, 0, decoder_bandwidth_message);
 
 /**
 * @brief This function shows a help message

--- a/demos/text_detection_demo/text_detection_demo.hpp
+++ b/demos/text_detection_demo/text_detection_demo.hpp
@@ -43,6 +43,7 @@ static const char input_data_type_message[] = "Required. Input data type: \"imag
                                               "\"video\" (for a saved video), "
                                               "\"webcam\" (for a webcamera device). By default, it is \"image\".";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
+static const char decoder_bandwidth_message[] = "Optional. Default bandwidth is 0 it will use CTC Greedy Decoder.";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(i, "", input_message);
@@ -64,6 +65,7 @@ DEFINE_string(c, "", custom_gpu_library_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_bool(r, false, raw_output_message);
 DEFINE_string(u, "", utilization_monitors_message);
+DEFINE_int32(b, 0, decoder_bandwidth_message);
 
 /**
 * @brief This function shows a help message
@@ -93,4 +95,5 @@ static void showUsage() {
     std::cout << "    -no_show                     " << no_show_message << std::endl;
     std::cout << "    -r                           " << raw_output_message << std::endl;
     std::cout << "    -u                           " << utilization_monitors_message << std::endl;
+    std::cout << "    -b                           " << decoder_bandwidth_message << std::endl;
 }


### PR DESCRIPTION
Add another decoder method for text recognition. Just using the flag `-b` to assign bandwidth, default is `0`. If the bandwidth larger than `0` will use CTC beam search decoder, bandwidth is `0` will use CTC greedy decoder, and bandwidth is lower than `0` will show an error message and stop the program.