### PR TITLE
Publish new versions of Intel models

### DIFF
--- a/models/intel/action-recognition-0001-decoder/model.yml
+++ b/models/intel/action-recognition-0001-decoder/model.yml
@@ -18,20 +18,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/action-recognition-0001-decoder.xml
-    size: 117057
-    sha256: 109077898a609912894256b15d70c77bf8e87ad06826af46a56c66826a30b511
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
+    size: 117062
+    sha256: e3ec5f5bb201ec6052575dc21e5ae3cfad9988c7ca82ecf1f930ce0700f09c80
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
   - name: FP32/action-recognition-0001-decoder.bin
     size: 30238776
-    sha256: 8912b5f695ac7a639b61d258798a85968035739808c2bdffde28c44544b5e543
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
+    sha256: 94b20a3d531c2f72fa4230aaed22ed9140f8923ed60907cbf1a0a48147d7663d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
   - name: FP16/action-recognition-0001-decoder.xml
-    size: 117017
-    sha256: 407aa15f983979bd28a4b8dfb97888590cd047e7a8706fe1458faa9512c6d546
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
+    size: 117022
+    sha256: 0382a460591d0a04cce49134e4e26d278e7fcebce804294e2b1b754f20a4e738
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
   - name: FP16/action-recognition-0001-decoder.bin
     size: 15119512
-    sha256: 2dcf41b1480aeaadb7e8802c35f493e8812b47971884a3ecb2d52fd212adbb5d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
+    sha256: 04108ac97f6815a1929b0cf3a6a5b539b28236ea7cf6bd4329011ca768257f23
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/action-recognition-0001-encoder/model.yml
+++ b/models/intel/action-recognition-0001-encoder/model.yml
@@ -19,19 +19,19 @@ task_type: action_recognition
 files:
   - name: FP32/action-recognition-0001-encoder.xml
     size: 98457
-    sha256: 0f69cb19460f48da142814579f28038dbf5ec4e94f98b3c6a0cd8b3da773e79b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
+    sha256: 194c96210668526c58d293a20a8b955b484f35e9779f6c994e2d6ad60b855de2
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
   - name: FP32/action-recognition-0001-encoder.bin
     size: 85104664
     sha256: c33e24b3f74918104eeafc106ee7f0b56804f03b87098c14ad66af6386cdb648
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
   - name: FP16/action-recognition-0001-encoder.xml
     size: 98417
-    sha256: 4dbc80939688b0f47d53067b0cb03cd2b15b7876cc247cb653dd64d4bbea326c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
+    sha256: 37c18864aa2cd9ce1a2c75c3e94f67a21cfd9b7984c41efb261fdf46eb6732c5
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
   - name: FP16/action-recognition-0001-encoder.bin
     size: 42552332
     sha256: 57d374b873dc87c72e5baab53245d59f1b866f6e2c3e670c923537f45018782c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/age-gender-recognition-retail-0013/model.yml
+++ b/models/intel/age-gender-recognition-retail-0013/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/age-gender-recognition-retail-0013.xml
     size: 30004
-    sha256: 136885ef5fb22d247d609634c0a4b48ab46c070b8f2c8cb57f740923e0cffd02
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
+    sha256: 988ad3b0ee3b793598b47f3b0328f7beb58c9a59e0ec6b436c8c6f0cff485e2a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
   - name: FP32/age-gender-recognition-retail-0013.bin
     size: 8552076
     sha256: 4dab79cfedebd628f3327367a91c9736a32fbf9cc733cbbf1629d16910d4ace7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
   - name: FP16/age-gender-recognition-retail-0013.xml
-    size: 29994
-    sha256: f0c3cb68d04aa1f4474fb7f7802c60e8c0c573eb861bd05c7a9eccf2f5a1b57e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
+    size: 29998
+    sha256: 86fd1c1845d46d8f8fc09659db2657d778317ad92a83a042901c5d1482561c85
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
   - name: FP16/age-gender-recognition-retail-0013.bin
     size: 4276038
     sha256: 401101e0a01b3d68add39deae833bcf9f54238d37dd13e3fb1534aa8fbe4719d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
   - name: FP32-INT8/age-gender-recognition-retail-0013.xml
     size: 64387
-    sha256: 47f67d249fc5187318ffc716452ad495e05c3175d0c8d20d78915250ad9c2161
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.xml
+    sha256: b3fba20acd6318ec1eed376e9491b4cf371aa1d8a82becbd3e5d2b1c390dc63d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.xml
   - name: FP32-INT8/age-gender-recognition-retail-0013.bin
     size: 8565952
     sha256: 0efcef2c78fa5208d85d2eb5fc69955c6d97a2ba2948c67a75b0dcb3b74da41e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/asl-recognition-0003/model.yml
+++ b/models/intel/asl-recognition-0003/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/asl-recognition-0003.xml
-    size: 239471
-    sha256: c77b9b414fe4e58f82739881f524d00e21c4b9fbb8a01c9abf0372822506eb96
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/asl-recognition-0003/FP32/asl-recognition-0003.xml
+    size: 239494
+    sha256: 961de5b24ac154bb153ac5ac94614d5f60214d9b0809f0a356fa6b7ec8c58c8c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP32/asl-recognition-0003.xml
   - name: FP32/asl-recognition-0003.bin
     size: 16515220
-    sha256: 0444e2f72f4b98ef2c4fbf5cafe26562c1386559eb5b99eca7a77e2e52fad9f4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/asl-recognition-0003/FP32/asl-recognition-0003.bin
+    sha256: 41c6508a94d86603084dd41a46e4085bc05fcd84f3ecd65ef44a7e03001e7459
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP32/asl-recognition-0003.bin
   - name: FP16/asl-recognition-0003.xml
-    size: 239364
-    sha256: c22eecd090c06077941cbf011fedc5d516e46193a014421d6915e6a4157549ad
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/asl-recognition-0003/FP16/asl-recognition-0003.xml
+    size: 239391
+    sha256: 771b824a0e72e2dce600f6279a2542e3fa9fb61fe68eeb80a6aed3f0c45ee1ce
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP16/asl-recognition-0003.xml
   - name: FP16/asl-recognition-0003.bin
     size: 8257622
-    sha256: c18725ff155e383c261cd0f7ab2556191c8dd5f3dd0fa716aa131e3b1292663c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/asl-recognition-0003/FP16/asl-recognition-0003.bin
+    sha256: a2590f1e5d65480d0dc439b717af8bdf9d5a2c270c716ea6f269d558326dc8af
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP16/asl-recognition-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002-decoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002-decoder/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-decoder.xml
-    size: 120884
-    sha256: f0a1806363cad8934fc498fa4f7b4a363b8688d49213a8c0875114dd934eeae2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
+    size: 120889
+    sha256: b2a9981db70a05c997e577c9b9ffb4f7c6bb12f35f3896509f2cb06d68679e43
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
   - name: FP32/driver-action-recognition-adas-0002-decoder.bin
     size: 29436428
-    sha256: fbefb055d8fa7a40461ce11175e9717291eed46caa8614cc42450ee28d4e467d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
+    sha256: 80deefba45d9b002c9780c9d9bcd2285b7be3f6b2ca319e2705898e725bd57c4
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
   - name: FP16/driver-action-recognition-adas-0002-decoder.xml
-    size: 120844
-    sha256: cc7aedbc5ddec61379f5836a07631fd16a3d4c2ca6005a8f835d865464372440
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
+    size: 120849
+    sha256: 781018424e5648cfeaa4ca4df618dcc72229cc542d81e1a12ede34738e0fd880
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
   - name: FP16/driver-action-recognition-adas-0002-decoder.bin
     size: 14718330
-    sha256: d2973b89668dbad748bb1e758f0f425e43a1878d77ae0874b32c103c8d39572e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
+    sha256: 1a6a163af7f634d8efff026855971445056fa6bff1da48e44cd35b1ea6c4cb43
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002-encoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002-encoder/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-encoder.xml
-    size: 128340
-    sha256: c387fd552f874eda35254e089aa311394288c23db2b52fba471019c43811f340
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
+    size: 128344
+    sha256: 0977cdfa7ad27481537064551e19afd980807ef083ede081378c1771a7659ce4
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
   - name: FP32/driver-action-recognition-adas-0002-encoder.bin
     size: 11450776
     sha256: 12bf9bfebc74719d42bc2190bd00064ecf41b820df891040fcaa57f5eb4cffcb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
   - name: FP16/driver-action-recognition-adas-0002-encoder.xml
-    size: 128280
-    sha256: 890939c366a5923843278fb4cfeeeb394daf81e3134231e3cc1b5ba657526ad5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
+    size: 128284
+    sha256: 99d4942a8add95e350ba4d464e3d91353d8106d3aa3835fb0a39c4c2efb34bf2
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
   - name: FP16/driver-action-recognition-adas-0002-encoder.bin
     size: 5725388
     sha256: 165b34437d1c73bf5adf356ddc18fb6bb11b4d99d8db0921dd25894d886535ef
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/emotions-recognition-retail-0003/model.yml
+++ b/models/intel/emotions-recognition-retail-0003/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/emotions-recognition-retail-0003.xml
-    size: 37676
-    sha256: 791af4f0e758a8afbdf601f52ee71b629a4a1e40620193d44889c0373ee13484
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
+    size: 37679
+    sha256: 26c0f66ee047b22190260982451dc3e8a7c2f14f5dc45274c98a3edf8d928c5e
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
   - name: FP32/emotions-recognition-retail-0003.bin
     size: 9930028
     sha256: bcb9b1a910fa3cd18a638bb1dbb0597c4ef7a080d1b83008c8e8c2c3c42b99dd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
   - name: FP16/emotions-recognition-retail-0003.xml
-    size: 37661
-    sha256: 5daac113d4038f8f8ea3add8e7f51b8c9c30f406c55dff2878022dbcc69478db
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
+    size: 37658
+    sha256: 8a746c263b250c9d820067d2833938e03ba66a621e60fca33cd3c3909c9b43d3
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
   - name: FP16/emotions-recognition-retail-0003.bin
     size: 4965014
     sha256: e62fb4b819b3b3ad8aafcd308d4353db2f164a1a31d78de6cf5970837aeb6f7b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
   - name: FP32-INT8/emotions-recognition-retail-0003.xml
-    size: 102858
-    sha256: feda999c90612880f9e405de0856db3812cf9a20a233db333608352f9f8581b4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.xml
+    size: 102859
+    sha256: 39527b1453600fd3ed32f7e3d3748a6a7bc82c8ad6780436dc23cc873c90571d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.xml
   - name: FP32-INT8/emotions-recognition-retail-0003.bin
     size: 9947612
     sha256: ff8ee9cee69cdc7043ec94522459770dfda865ff979a0c8beb73d7515f4a1df2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-adas-0001/model.yml
+++ b/models/intel/face-detection-adas-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/face-detection-adas-0001.xml
-    size: 233164
-    sha256: cbbf8e3381ee4f7bce940342bd01ae5bd9f84f975a94b44440b0f08f80183b62
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
+    size: 232996
+    sha256: 425237529f865b34830969a1f6980ee69f96b952ec9b94479136609119326a61
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
   - name: FP32/face-detection-adas-0001.bin
     size: 4212072
     sha256: 85a9334e031289692884e2aefbcb4ca401b003a3f25ff4dd0e669ba32f98cc0b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
   - name: FP16/face-detection-adas-0001.xml
-    size: 233128
-    sha256: c265a9560c9faee2629fe03d66a9ee10f6a5f77d2b096778148be3a18068c9a1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
+    size: 232965
+    sha256: e7c599c81b75468fda871205365bf03157adb1bf28dfaf3e7261d99574cd0ea4
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
   - name: FP16/face-detection-adas-0001.bin
     size: 2106088
     sha256: df0f5799d801c6afb355d1c4771693c782efbb58d2eb2238982eac8fe84bc821
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
   - name: FP32-INT8/face-detection-adas-0001.xml
-    size: 504125
-    sha256: 0e48caa20874982acc4fddc4ee6a29e0f2275384dbc4448b651366dd1cf99e38
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.xml
+    size: 503962
+    sha256: e2cc810b7e87cc9964ebe279b4f13218b4e4cf0128e8755bf26f0fbf3c1ab2ac
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.xml
   - name: FP32-INT8/face-detection-adas-0001.bin
     size: 4291532
     sha256: d3ffb0da33361253d4027def5acddf104a6919c920582f084974a4f9d8529ffd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-adas-binary-0001/model.yml
+++ b/models/intel/face-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/face-detection-adas-binary-0001.xml
     size: 116647
     sha256: fde8c465a5e3f3425fb567d31b9591ff8be589930c8488639f8feddf7f0301f2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.xml
   - name: FP32-INT1/face-detection-adas-binary-0001.bin
     size: 1840444
     sha256: 0e0742b61fb924e937a8974da8a2e15cc6afc15630afa3f220676ee7a3a99700
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0004/model.yml
+++ b/models/intel/face-detection-retail-0004/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/face-detection-retail-0004.xml
-    size: 101850
-    sha256: ad2a2b0b085d22f6a9be6b8e6edd007b8e088e13499f543134dd6cbe63a1e78b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
+    size: 101813
+    sha256: 0f4b7cffe0c486f561bab67db01f9c43f7ee2a11191f7d43c137cd2d5ff88e9a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
   - name: FP32/face-detection-retail-0004.bin
     size: 2352984
     sha256: 89349ce12dd21c5263fb302cd3ffd4b73c35ea12ed98aff863d03a2cf3a32464
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
   - name: FP16/face-detection-retail-0004.xml
-    size: 101808
-    sha256: c9811d155c657feab2047920814b7c387bec3a5c61d0bfbfd5d470aab9f8111c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
+    size: 101771
+    sha256: 1d1b7943d6d06069f86b12bbbd3b270832efbc47420bfe2047e20f25edcd88ba
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
   - name: FP16/face-detection-retail-0004.bin
     size: 1176544
     sha256: ab7def342edab22e69ba1ef4e971983ea4e0f337c43b0a49c7ef3a7627f6cf1a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
   - name: FP32-INT8/face-detection-retail-0004.xml
-    size: 231525
-    sha256: b15c30ea6595ac40b77a704ba739ca20715cb6dfb16945b657609810c1633b25
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.xml
+    size: 231504
+    sha256: 64f58998397778333237ac34f3535810da337242e02cc1e310154529b583de4a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.xml
   - name: FP32-INT8/face-detection-retail-0004.bin
     size: 2372492
     sha256: f696f0651da3cf3b07915356fa6f7332dde671ac51b26e3be8209df3d7f7e5e0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0005/model.yml
+++ b/models/intel/face-detection-retail-0005/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/face-detection-retail-0005.xml
-    size: 145883
-    sha256: 0708aa23b0bd6af5f80b6527b2e683d7f17368183140851ffd1d76fb2e9ae60b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
+    size: 145894
+    sha256: 7f8b8b477e83186e64b90b671ecc55010404710294daebb210019e0c802f0e51
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
   - name: FP32/face-detection-retail-0005.bin
     size: 4083132
     sha256: bc174f03f2314bdbb7e1abfb5136ccb34507d8225f87b040c5a77493f1a6c307
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
   - name: FP16/face-detection-retail-0005.xml
-    size: 145802
-    sha256: 6eca6aaa56b52cedf4677e87eeb7ccfecc8592369e008c904bba6b60c468c21a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
+    size: 145813
+    sha256: 3249940f7de11e2d5b36ed47fdf632ef52e50c15e6c025f84cb834b77c20411a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
   - name: FP16/face-detection-retail-0005.bin
     size: 2041618
     sha256: fef3746455eec3d1e69730b556809a225a4f714b6bc0b4bacfe5c7bb1a944105
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
   - name: FP32-INT8/face-detection-retail-0005.xml
-    size: 414499
-    sha256: 4f738deb8ef666fd355865b6114910af456d43c7f85a1333ade2217ae911509b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.xml
+    size: 414518
+    sha256: ab7f8be6489e8d3c02229d584fde3e4caa405d8147fd2f293f5455f627568d16
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.xml
   - name: FP32-INT8/face-detection-retail-0005.bin
     size: 4214360
     sha256: 0525d556261936e710d8b540f540718869e36c2e7347ee111dd68c259f6e5d54
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-reidentification-retail-0095/model.yml
+++ b/models/intel/face-reidentification-retail-0095/model.yml
@@ -18,27 +18,27 @@ task_type: face_recognition
 files:
   - name: FP32/face-reidentification-retail-0095.xml
     size: 225830
-    sha256: a16ac1cfe4334a50ca2ce48639e46f8e981351eb25943f73e3425a47939662b3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
+    sha256: 6c89104cbb43cc7506039a83283d957cfccfb5670524a71898855f3ab1b7d516
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
   - name: FP32/face-reidentification-retail-0095.bin
     size: 4427256
     sha256: 03836a6a1d03828322491b0608a579b1c47e5097d355c489b5b8aaf5fce1ef48
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
   - name: FP16/face-reidentification-retail-0095.xml
     size: 225721
-    sha256: c1077d4285a4ed52ffbaf191b3f17a9dbd3403befee154491e9383fd55f21d00
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
+    sha256: a9f24e50aee183a892646aa12ff727ba1fbd0807e73b5eade9925c9747713837
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
   - name: FP16/face-reidentification-retail-0095.bin
     size: 2213724
     sha256: c2f8a7b9268e5b5236574d6fda2216df43c03acaa39c078848a98fbb707ae0a3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
   - name: FP32-INT8/face-reidentification-retail-0095.xml
     size: 643466
-    sha256: 6fc1dbbffacd8a9412cb6009f21c6940d889674d31a9fb6e51ff9de4bcfcc760
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.xml
+    sha256: ad70c2724fabf4e33820fc30ee0362c1a61148f7df44c525700d9eab0f3c07ca
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.xml
   - name: FP32-INT8/face-reidentification-retail-0095.bin
     size: 4551656
     sha256: eaae8881109a2dab91fb7fddc73052378b015d6f3aa61b1c772eca21f87e4741
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/facial-landmarks-35-adas-0002/model.yml
+++ b/models/intel/facial-landmarks-35-adas-0002/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/facial-landmarks-35-adas-0002.xml
-    size: 237153
-    sha256: 0428363f5e595a49f717d602d10cc6cc47cd902b8bc2bd8e3c03a483f51cce56
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
+    size: 237137
+    sha256: 1e9d78083ce30543879921d687ced55abd9cf8b7f3c5561967eb6d619b3a1075
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
   - name: FP32/facial-landmarks-35-adas-0002.bin
     size: 18381152
     sha256: bd41c25201c2ea688a75549c11b9e10aa98e51dcc5a6dd783e84cdcf55a1011e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
   - name: FP16/facial-landmarks-35-adas-0002.xml
-    size: 237016
-    sha256: 73158b2f389e0c2748fd37e4098127adf2c856ab46d6d60fc654dae4ce5f025e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
+    size: 237000
+    sha256: 6f2dbe79c171cac9af14194f1cab8efbc0f27f0c42e21b8b32d9dac2970e47c6
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
   - name: FP16/facial-landmarks-35-adas-0002.bin
     size: 9190584
     sha256: 88a2064849da0e6a31557f489ca4d652aa99e5a9676da0c5c857ee5d8cc26fe4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
   - name: FP32-INT8/facial-landmarks-35-adas-0002.xml
-    size: 588508
-    sha256: 21036182e3ba5657b4a0f86a94330ac665c085617321a282f42e942beef3f890
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.xml
+    size: 588492
+    sha256: 2450458b5c2fafcb2cd29a96e0bc43e622966bd8fe718017e6a4ad4da36a50de
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.xml
   - name: FP32-INT8/facial-landmarks-35-adas-0002.bin
     size: 18441156
     sha256: f81ebf7c25f30138c2fa44530f51f516783ea790c5b6cacbaa5b31d95c73cbb7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/gaze-estimation-adas-0002/model.yml
+++ b/models/intel/gaze-estimation-adas-0002/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/gaze-estimation-adas-0002.xml
-    size: 63630
-    sha256: 181d0dfe7257c8f1cb2872bf01c30f5806b270957d76f3bce21a7962d920c855
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
+    size: 63634
+    sha256: d338f9c0340c05c94ab4f4eba5f03651c07f1bb7a7f602ae1ceaaa934ba69340
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
   - name: FP32/gaze-estimation-adas-0002.bin
     size: 7529308
     sha256: df935569980ab2654c46463fccb0ecc9ddd90423dcee85b3f933aa375baa15cf
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
   - name: FP16/gaze-estimation-adas-0002.xml
     size: 63589
-    sha256: 54cb251b65cab1bb45f8251b3980096c3f85a33a37a258c523e0c53fd690454c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
+    sha256: b7495c85b498bfc9ebfc4a77753e5c3b6bab0572ac926d9868abaca67eb7a20b
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
   - name: FP16/gaze-estimation-adas-0002.bin
     size: 3764670
     sha256: 03fa9ec80b6edf2ff6bfe5208e1fa13f17be534b80461de7e91b70f0ec1bcf85
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
   - name: FP32-INT8/gaze-estimation-adas-0002.xml
     size: 142699
-    sha256: 7208d5c77929af6fa6488edf4f28b31a88c8328af6af8399dd76d54994a63e8e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.xml
+    sha256: 5ffe720fc36ff2f079cb937ce4949ba6046fc6944b2064077e61eab089ecd4a9
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.xml
   - name: FP32-INT8/gaze-estimation-adas-0002.bin
     size: 7542172
     sha256: 0254e6bacc23912ba647a626ebe9e4562e8b824ab157442714dbf2e3d13d4996
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/handwritten-score-recognition-0003/model.yml
+++ b/models/intel/handwritten-score-recognition-0003/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/handwritten-score-recognition-0003.xml
-    size: 96646
-    sha256: d688be5cd218c5a948231e87682aa7234a8d27c8be01c0a199658346d3927b1a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
+    size: 96645
+    sha256: 0c093abc57d9757e349839aa35d1427d48a0afa6aa62ece11f5c2a8084246e20
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
   - name: FP32/handwritten-score-recognition-0003.bin
     size: 41121968
-    sha256: 8d63056b8a26cb0effb3f4b18021e32e7dd6a53d2adcb95395e21225f052c8f4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
+    sha256: 7066eae3cf926dcddcdc8564ebd36342139202db38f80c40590c8018d9132d22
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
   - name: FP16/handwritten-score-recognition-0003.xml
-    size: 96621
-    sha256: f0e2ca0946d70b88c34a78a23dd0c54632e2c1f111fed31ca7701d58f7154e05
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
+    size: 96620
+    sha256: ea0fab2c94bcc91b0d02193ed5932ae3733b59de9322b5aed1cca46e194227cb
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
   - name: FP16/handwritten-score-recognition-0003.bin
     size: 20561040
-    sha256: fb5924d6ff2586e372ad63e23ead5c27b71dd9060fac4e3ca26ae5796032712a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
+    sha256: 253c042f74ff3343f7140b95b8dcdaed39512136cd0955bd8d44a953cd16ca86
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
   - name: FP32-INT8/handwritten-score-recognition-0003.xml
     size: 130751
-    sha256: c5d63fc230a4f773034645ef6320a595172486ac8b280c83ee43a744a07cb3db
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.xml
+    sha256: b7fb2ca7c8a0b90f44fe416b3b55ee01c65981b2fbe1993f38a4cc34609928f9
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.xml
   - name: FP32-INT8/handwritten-score-recognition-0003.bin
     size: 41140556
     sha256: bec80fa6fd3ec3d64922c757d550f012c5ea24846396afb4073d3f4ce4e607b5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/head-pose-estimation-adas-0001/model.yml
+++ b/models/intel/head-pose-estimation-adas-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: head_pose_estimation
 files:
   - name: FP32/head-pose-estimation-adas-0001.xml
-    size: 50616
-    sha256: 220658619de3a54ea9ec5d68566422fb84d382ced778215231b898003432a0db
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
+    size: 50625
+    sha256: a5040b8f12e43cc89d66578c1ec4b31d519d5e0cc8b2df9b2268e764184d2c2c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
   - name: FP32/head-pose-estimation-adas-0001.bin
     size: 7647604
     sha256: a9110b175f7cb082049d5fcd4c48825e9c00688901aecb22fa70c2535aff282c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
   - name: FP16/head-pose-estimation-adas-0001.xml
-    size: 50606
-    sha256: cfd5dbe98da6a07bca27b40ffb647121831a8950d084fa3490a3cefeaf06f2eb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
+    size: 50609
+    sha256: 48d4f67d83439165422d73d7aa9d10bac724372c2fef5ddc659179a27f2abdf5
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
   - name: FP16/head-pose-estimation-adas-0001.bin
     size: 3823810
     sha256: e37b71a654656a78d4014ae8e46baab83a9c06a41df5f5c5122e9bbee46a63f2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
   - name: FP32-INT8/head-pose-estimation-adas-0001.xml
-    size: 81648
-    sha256: 03e726f842362063ad7c107842432e2e96b4cd910b453f17eade60be2118201d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.xml
+    size: 81654
+    sha256: a6eaa94cb3a88efb2121a56a18d421abe44b9ffe7925a0ff92eb1fc037786170
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.xml
   - name: FP32-INT8/head-pose-estimation-adas-0001.bin
     size: 7657904
     sha256: 460e2160619fce6e9986e99130c55468e95e0364f7907fb339555807029da296
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/human-pose-estimation-0001/model.yml
+++ b/models/intel/human-pose-estimation-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: human_pose_estimation
 files:
   - name: FP32/human-pose-estimation-0001.xml
-    size: 143780
-    sha256: 183de6110007266ef0bf618d7e33b35e048a8fc138dae31028f3f4162d13e9aa
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
+    size: 143776
+    sha256: 00909cbe5a4a005f8b3364fcecddde3eb858a6b105c4a49ced603a6c706647e2
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
   - name: FP32/human-pose-estimation-0001.bin
     size: 16394712
     sha256: 1cd32cb5f9f4633b8ee1451144f749ddd75038c4c5fe862e704e489908b79a78
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
   - name: FP16/human-pose-estimation-0001.xml
     size: 143708
-    sha256: 3876e677bdbcbbf6b947c420af2044be70e2bd3b4d5be1e623019a3a554b9991
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
+    sha256: 6650867461eeaa67cabdcb6bc7543c18cfdb791ffc9f92bfaf2f84f846b0eb3a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
   - name: FP16/human-pose-estimation-0001.bin
     size: 8197356
     sha256: c1c828d5d1ea2b03035692a8600f06d787fe1a20e79dac159c4293ed7063a382
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
   - name: FP32-INT8/human-pose-estimation-0001.xml
-    size: 408100
-    sha256: 549224717f98eb3c05e83d33cf68e4528fe870472e3ae97c5d936b420c06823f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.xml
+    size: 408108
+    sha256: 182bc988974f62451159bafff61eb220bb72e54041ba18bfb6f8f5539d0ede14
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.xml
   - name: FP32-INT8/human-pose-estimation-0001.bin
     size: 16513820
     sha256: 482635ee949716049bd7dd5a69ab66a6d5f29a5cc86598c0369035be2d1fa274
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/image-retrieval-0001/model.yml
+++ b/models/intel/image-retrieval-0001/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/image-retrieval-0001.xml
     size: 139943
-    sha256: 48828e3dcf606bde9ed530712e088418f66a5f60158b0e1b32e59328e21176fa
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/image-retrieval-0001/FP32/image-retrieval-0001.xml
+    sha256: c83121052a5b11ffab220110a21c39d149915013aa6b11d778c75bdb7cf4b91b
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32/image-retrieval-0001.xml
   - name: FP32/image-retrieval-0001.bin
     size: 10139176
     sha256: 337b7602546e34877bdaba7b7a873698dd1ca46265ef8c0c83b2531f360293f8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/image-retrieval-0001/FP32/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32/image-retrieval-0001.bin
   - name: FP16/image-retrieval-0001.xml
     size: 139873
-    sha256: fce70ebb676cbda13280c85dcc9754122f2c6e7c819284ad0f3cdf46070eda4c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/image-retrieval-0001/FP16/image-retrieval-0001.xml
+    sha256: e79ee524141620d809d6ad4ab4a90357767b9f4ab473cf96c9835cb3228eaf5b
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP16/image-retrieval-0001.xml
   - name: FP16/image-retrieval-0001.bin
     size: 5069656
     sha256: 638931867ab133c8c6b0fa659a19b12d5b9ac6ce52f72b961f1d35e8ff812edd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/image-retrieval-0001/FP16/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP16/image-retrieval-0001.bin
   - name: FP32-INT8/image-retrieval-0001.xml
-    size: 361649
-    sha256: 3968c96932f270069aba863a612a811f4900443e5cb4dea47a3872852696e467
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/image-retrieval-0001/FP32-INT8/image-retrieval-0001.xml
+    size: 402534
+    sha256: 2e3a39c6323ca92824ea9e0f056b1a9d2e3c2a41ba79b12c14ebac25fe2ca05a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32-INT8/image-retrieval-0001.xml
   - name: FP32-INT8/image-retrieval-0001.bin
-    size: 10279008
-    sha256: 47b341d286d046b7b5c10eb59ea8d8acf27056fa08f3044563df6042c1886a39
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/image-retrieval-0001/FP32-INT8/image-retrieval-0001.bin
+    size: 10316580
+    sha256: 8247914522e23c4ca8c291f59d6cb4d29dc780121fbc79eb8e02052eeb1796fc
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32-INT8/image-retrieval-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0010/model.yml
+++ b/models/intel/instance-segmentation-security-0010/model.yml
@@ -19,20 +19,20 @@ description: >-
 task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0010.xml
-    size: 486374
-    sha256: f2bdc63bd4bf867fc31aaebe2d5a441233aea6d7558017aafe356ecb0c383ba3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.xml
+    size: 486379
+    sha256: 55ebb92d791ed3a2dfff86afb0b7e49e645ee82dd20bbabf688b6e72aa8e6e3e
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.xml
   - name: FP32/instance-segmentation-security-0010.bin
     size: 688762056
     sha256: 030bb05fead246de1380b79d2d07674210f0bfab101a10d4827dd10b6abfdf4b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.bin
   - name: FP16/instance-segmentation-security-0010.xml
     size: 486165
-    sha256: c9c9101bb6bfa37bd40d9071fdcab950c62adb22265a77e355fcb4b55bdc7b69
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.xml
+    sha256: f868338d5b3351415d1491c27ffc3b3d71bf5d13e9d3723934f7d87e44aea4c6
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.xml
   - name: FP16/instance-segmentation-security-0010.bin
     size: 344381242
     sha256: 8b8e17a8faeae41258f9fc3e758d987152a817c820aa82e1fd9bdbc2cf5db248
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0050/model.yml
+++ b/models/intel/instance-segmentation-security-0050/model.yml
@@ -19,19 +19,19 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0050.xml
     size: 270494
-    sha256: 32a7a6cf04757d73b667f31652ec8a5ec79299191ffa5e3bfbf0ac1499d628bd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.xml
+    sha256: e89cc0d36e75eb841e1411d7bacf85bce6a74a459f1e669cf7b74e517b469d8c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.xml
   - name: FP32/instance-segmentation-security-0050.bin
     size: 121497384
     sha256: 763f3503dc5f5fabd2021fa915783827929eb6b75555ddd95307e2226ec9325b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.bin
   - name: FP16/instance-segmentation-security-0050.xml
-    size: 270390
-    sha256: 7aa7a528a019e9168c3e8588c164a8f9f90acfd9d3a8a0d5ad44411f50c9703e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.xml
+    size: 270385
+    sha256: 241b3a173be16620ff702a9cca42c9f1af36cb1a58de7c324b83bc3af5b0d81d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.xml
   - name: FP16/instance-segmentation-security-0050.bin
     size: 60748730
     sha256: 07a471da43c24d183feb048cf823e87e8add9952f43ad3da97b9425b38906e4b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0083/model.yml
+++ b/models/intel/instance-segmentation-security-0083/model.yml
@@ -19,19 +19,19 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0083.xml
     size: 512548
-    sha256: 9b1a47ac20ad3696cf715b4373844f0fe49930dbd67625b6335c005c03347262
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.xml
+    sha256: 02bd492c2463bf0c9fc37a498fe732ff13cde99e3fe13716dd41543a9e312d37
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.xml
   - name: FP32/instance-segmentation-security-0083.bin
     size: 564274472
     sha256: 1305d27772c2fc16d84f78e3c6609eb065e106656403d1f0765270b334e7f1db
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.bin
   - name: FP16/instance-segmentation-security-0083.xml
-    size: 512350
-    sha256: e7eaf9ab03a76d306ebc7e4044198a02b62c90ae20f9df251271ceaf8430d8da
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.xml
+    size: 512345
+    sha256: 84c5dd774b59f9f1ff3af990a0a2804205bf57a3294fb77c6f768131768d1b40
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.xml
   - name: FP16/instance-segmentation-security-0083.bin
     size: 282137274
     sha256: ae7bf1b3f18d3333df32bb9c5a09cbe7738396d6473fdd050508d4f38356c64f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/landmarks-regression-retail-0009/model.yml
+++ b/models/intel/landmarks-regression-retail-0009/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/landmarks-regression-retail-0009.xml
     size: 42709
-    sha256: 07876df557d32deeb24d4abc2bc1d0fb1b5c16bf54987f5e4dffda6e3f8a35d2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
+    sha256: a2e7153c88da9db490bc6729841843de45ac85d34d2e4b0b353218a6a124ba0f
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
   - name: FP32/landmarks-regression-retail-0009.bin
     size: 762464
     sha256: 46795837d35e8199b7c5b57e1f76297827bf516a150c0d5643197d8c325f1dbc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
   - name: FP16/landmarks-regression-retail-0009.xml
-    size: 42694
-    sha256: 5dc7dc198f9ea9866f9bb436fb7b2d21338679015e6487ec9872a5eee3871ee2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
+    size: 42690
+    sha256: a442963ed3638e5e37bac5257f93ee4d91a168c76963a3d6b6aaa94fd8b89182
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
   - name: FP16/landmarks-regression-retail-0009.bin
     size: 381248
     sha256: 973b13e64b3576f754a690266b069438b531bc657233d09d7b382ca36e6cf1e4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
   - name: FP32-INT8/landmarks-regression-retail-0009.xml
     size: 78229
-    sha256: 71a163081148c46773098db363e9679f7954c5dba0a44b5b431738394f162345
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.xml
+    sha256: fcac29d5735cae8c84835655098a6c472c60557cda768ba713c8bab4516dbd60
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.xml
   - name: FP32-INT8/landmarks-regression-retail-0009.bin
     size: 767188
     sha256: 2a4bbc1f41d80e3ad2125d9297825d49379647ee2f61d982962135d1a146ecb7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/license-plate-recognition-barrier-0001/model.yml
+++ b/models/intel/license-plate-recognition-barrier-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/license-plate-recognition-barrier-0001.xml
-    size: 48901
-    sha256: 892a32b8174c2e81990a2ac3b4b754f7ad8ee92b32ac47f7408f6a97c43f1898
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
+    size: 48902
+    sha256: faba913a941346054c1de86910d4b9ecd2d3263adbd77b84256d590887e6c349
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
   - name: FP32/license-plate-recognition-barrier-0001.bin
     size: 4871940
-    sha256: ccadac90772667c730d78f736f9e8fcb67bdbfcc25575b37634e6ec74dfaf7da
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
+    sha256: 3ef022a17b5f303c676c9c3a23669d09a257a54acdb894b6db295acc141cc4dd
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
   - name: FP16/license-plate-recognition-barrier-0001.xml
-    size: 48882
-    sha256: d1f51451ffa020534716f1f122d81a9049803d7ffac4d3a8a1156ee06e256af6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
+    size: 48883
+    sha256: 44d2ce4933b1855adb06e497e51a62a0a1ea4e46fb8c10f4fc6dbfa41a1bb812
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
   - name: FP16/license-plate-recognition-barrier-0001.bin
     size: 2436038
-    sha256: a1db2c8c25cda70d8efdda6a8dcb70180e4bc9a613a3db8d49926b4153892e13
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
+    sha256: 184d9312c71b660639898edb46b85a99477e8d6a756b2b611e71a3afad5f25c1
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
   - name: FP32-INT8/license-plate-recognition-barrier-0001.xml
-    size: 105462
-    sha256: af1778b159e2068fbf6f30b774fbd90b4cbb6f16f2d562a0e9991b2ea102e693
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.xml
+    size: 105464
+    sha256: 9c460017d4f9e72fb13c49b493e7d8f3bfbe02942635611856a7c686dbb1f33c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.xml
   - name: FP32-INT8/license-plate-recognition-barrier-0001.bin
     size: 4882552
     sha256: 309f08580e1284a702c4d661ffc64cb370dfeb66622724b8dfb1e2ebee646720
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
+++ b/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.xml
-    size: 245760
-    sha256: 2b321ea42dadd8101fae5ce29aa4c78dd4199fd44cb9271743b40cf756c06874
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
+    size: 245532
+    sha256: 08211608229fa2d3c1804fbbe3dfd6b4c6053b66a15a09587d459f0d55c7f713
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 6598568
     sha256: 9b8288591d18c3e3daa8bc48f9f2f14ecb1bf83032fe6439d6bc7b43f9f1a4e9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.xml
-    size: 245714
-    sha256: ec657b88c13c70ed4b85e6f0499e68d416597f9ebadbe94db1076be5103949a1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
+    size: 245492
+    sha256: 4a63ed9cad1ba87f7d0642fae25b8c220daca4787c93fed361fe4afc1f53f8cc
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 3299336
     sha256: 3f9739b91277bc916f29b17d043115c6669e113e5d60d61589063d8054c40d7d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
-    size: 478514
-    sha256: 6e7df57081651b7e4916774a541b6e802311fab8e22b8d9c9887688d5a521e80
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
+    size: 478288
+    sha256: 56f865a35a4e4ba06530d25684095eb8f6bfb1209884267a695c6fdde2995741
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 6693280
     sha256: 6157784eebd2a2e08bc5b0076f8d11868fbc096a0e60f5e34d72c8dd3ed32bb5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-detection-adas-0002/model.yml
+++ b/models/intel/pedestrian-detection-adas-0002/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/pedestrian-detection-adas-0002.xml
-    size: 245643
-    sha256: 6a60480fbb35744e689d2d4d8a5ad209a259f32ab857621f3058b21ac5ca4108
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
+    size: 245415
+    sha256: 0de0a708706119034d3701ce6952c1a57565accc87224dce3ec7199f6e182dfd
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
   - name: FP32/pedestrian-detection-adas-0002.bin
     size: 4660248
     sha256: de3e3b12eb631d0fa67db14d7cd3c3aaea7edc78e460485dcdae3a447f4d4288
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
   - name: FP16/pedestrian-detection-adas-0002.xml
-    size: 245592
-    sha256: ee6a73c44ebe34d4bebc1d9781ed8ee287901a620677d40d2029eeb66d49c3bd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
+    size: 245366
+    sha256: ebddb83288206aa6b54a3fae16da3dcdbf48d2ec3e94251a3e46f975bbcd2737
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
   - name: FP16/pedestrian-detection-adas-0002.bin
     size: 2330176
     sha256: 693753b7466da913b537016b31e3012f8ce6a885ac0897e3986eeca66d4ef8e6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
   - name: FP32-INT8/pedestrian-detection-adas-0002.xml
-    size: 478273
-    sha256: 26d6cecde26e734f17b5ae62da718ee27c06e0f779e1797eaefd2bee380487ef
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.xml
+    size: 478047
+    sha256: 51e0233c814eb6f4b8b99dbc6e4bbc38a50c41201cbb9e0fc796f1fceb788054
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.xml
   - name: FP32-INT8/pedestrian-detection-adas-0002.bin
     size: 4740408
     sha256: 38c3e849bd872a604a1374dffdb18520718c3c2d16fe13ce07642a986f68a273
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-detection-adas-binary-0001/model.yml
+++ b/models/intel/pedestrian-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/pedestrian-detection-adas-binary-0001.xml
     size: 114635
     sha256: e64e7ce32c87e1c698b50abb8f2cf1d96c7651d45fc20bac09c417e046afa7f4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.xml
   - name: FP32-INT1/pedestrian-detection-adas-binary-0001.bin
     size: 2338004
     sha256: 7c2761ca3859ef55a80d9ed924225df7ba363fcb151e4ec2f7d1061b70bdb374
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-attributes-recognition-crossroad-0230/model.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0230/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-attributes-recognition-crossroad-0230.xml
     size: 173334
-    sha256: 89033e91124d5a5ad7f880c4d521046f7031fe05f038df5112abec5cb3ecd912
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
+    sha256: 8b76a741eff4235771189391233b4d8ecb9200a66056d878bfa2e47df2abba88
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
   - name: FP32/person-attributes-recognition-crossroad-0230.bin
     size: 2939232
     sha256: 01432edde876a4be8c7ef87801b7c45a09a442daec06551fd2db7c81f1d76407
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
   - name: FP16/person-attributes-recognition-crossroad-0230.xml
     size: 173249
-    sha256: 75432019787605322894a2766005403bef49fce0426089e44ceb09612eb76530
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
+    sha256: 8da44a3585baa57dcf948a56bf757467c7ceb6202e57bb7bc5dcf9876b027c97
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
   - name: FP16/person-attributes-recognition-crossroad-0230.bin
     size: 1469624
     sha256: 61327cb5748a234c0320456e83dc8e42756c3a9856f15580a111493da47366fc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
   - name: FP32-INT8/person-attributes-recognition-crossroad-0230.xml
     size: 469747
-    sha256: 485fc4ce8d9b03df5c6c0123e9581ef7aca7eaf06e413a8a1def04100ba02cf6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.xml
+    sha256: 3cc456644788a8412ab660e7553c6e5eecd95cdf1bd6c9ef558e032f9f4831c3
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.xml
   - name: FP32-INT8/person-attributes-recognition-crossroad-0230.bin
     size: 2967604
     sha256: 40cd74f6b0f653d041750825990b2a2620202850f2d40754ae3229ee79c4bf33
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0005/model.yml
+++ b/models/intel/person-detection-action-recognition-0005/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0005.xml
-    size: 651645
-    sha256: e02bf103c8100ce0e830944578f47eafde3abb13898e91a32b1735fc401aa0ac
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
+    size: 651604
+    sha256: f8e95345d1d532dc7a7765e7b3a74765d343b223276a6acb0248320976dabe59
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
   - name: FP32/person-detection-action-recognition-0005.bin
     size: 7800360
     sha256: 2982e6c2683229a450d674c362cc11abd640dce4e39e95925c7957a28011f147
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
   - name: FP16/person-detection-action-recognition-0005.xml
-    size: 651397
-    sha256: 858c5622aada85a57ce7af3956bb992876a78c1052cea8ec280f62745ae8afb8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
+    size: 651360
+    sha256: f58a1dc88aefa2a7021a8aa74e48da8633038c09be7e7407914ee4b8e1634268
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
   - name: FP16/person-detection-action-recognition-0005.bin
     size: 3900234
     sha256: 159f52fdd28bef5a3ef3edd998fe08fd4d51c4a3fb2b9134b82a09f6a252c378
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
   - name: FP32-INT8/person-detection-action-recognition-0005.xml
-    size: 1697280
-    sha256: 554b10132b76c50c329952b3921a259c1ca1f458f21e6cd81279ced4df879a00
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.xml
+    size: 1697244
+    sha256: 86f01c4faac1373e6dfa46dbe1a0c40f65da19e7ac6c6093c54ea43f37e6bdc3
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.xml
   - name: FP32-INT8/person-detection-action-recognition-0005.bin
     size: 7972512
     sha256: cd8f809d2a6dfe12808a9a49c62fa3501c22fdff2c955961746a3c24e20d7db4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0006/model.yml
+++ b/models/intel/person-detection-action-recognition-0006/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0006.xml
     size: 756045
-    sha256: edf797a4c991b085f5686148de7af110b15c2fc97169cc7fdd8603dc04a57a9c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.xml
+    sha256: 9fd43747b5caf9911788b576b382d34e3a38737e83db964b752bc3c2310fab06
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.xml
   - name: FP32/person-detection-action-recognition-0006.bin
     size: 7458352
     sha256: 888d01b994c58baa65ab20b948439620222512ee49d45e6f443f271d7637f603
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.bin
   - name: FP16/person-detection-action-recognition-0006.xml
     size: 755767
-    sha256: ebc666d7a03a96aad00559f9ac748508b83cd86995d2f73de1bfb9d5c3544271
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.xml
+    sha256: 26a849634e4accd3522709334614a174aaebca55eb06fb9311c0ad8347b6c18d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.xml
   - name: FP16/person-detection-action-recognition-0006.bin
     size: 3729222
     sha256: 6752e639f4035582f77209a6030cded78ec4869b628ad9cdde1907d8cfd13368
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.bin
   - name: FP32-INT8/person-detection-action-recognition-0006.xml
     size: 1897672
-    sha256: 0c5d58798f6fac3df0349f3613e3255660d33280de38350892b28facf648ad4e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.xml
+    sha256: fc0f32b1b7038ad7ddbb583d50fcef5a132328aa86e304b943e3db2229bedddc
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.xml
   - name: FP32-INT8/person-detection-action-recognition-0006.bin
     size: 7652264
     sha256: 6ec864ac04c366c7bcfd77b8548b22d0d8797c4b6ad63bc759f10781aa573e7a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-teacher-0002/model.yml
+++ b/models/intel/person-detection-action-recognition-teacher-0002/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-teacher-0002.xml
-    size: 651654
-    sha256: 38c13ba407e38db1303ca77d54cd40395323217a4fe212195806e993df45342f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
+    size: 651612
+    sha256: 4b81fc7c111fa119bdb229cd9e73474d06d649479d73117bee4e1db97ece7af9
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
   - name: FP32/person-detection-action-recognition-teacher-0002.bin
     size: 7800360
     sha256: ebe9c7cdca28a408302b3b1f241afdc670abc251bd692c13a3140c78b08b0498
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
   - name: FP16/person-detection-action-recognition-teacher-0002.xml
-    size: 651410
-    sha256: 196d7bd58c16a21e02faec877cc397dd82cfeb9d209f0717b7dd94254819cca4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
+    size: 651368
+    sha256: 062b59018dffa6f6c2b27de36e61bcfcfdb2d454aacc666db9b11db107b76910
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
   - name: FP16/person-detection-action-recognition-teacher-0002.bin
     size: 3900234
     sha256: 190e9b71ae02e022c6afe2dc9fb59939066e046234ff35f4ceab6ddfabab7883
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
   - name: FP32-INT8/person-detection-action-recognition-teacher-0002.xml
-    size: 1697289
-    sha256: 5572fde061fd5d7b7073b287d73be11d6ade21bbffac6a3b1a20e8fd7319b347
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.xml
+    size: 1697252
+    sha256: aefa562cc9f34d4546a594004ce9032f3cb40302deeac0d97113fa860038e626
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.xml
   - name: FP32-INT8/person-detection-action-recognition-teacher-0002.bin
     size: 7972512
     sha256: 9423a50cb23b265d8862108a7ab88e1536c1b342276d792af56ff3d34d70553d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-asl-0001/model.yml
+++ b/models/intel/person-detection-asl-0001/model.yml
@@ -19,10 +19,10 @@ files:
   - name: FP32/person-detection-asl-0001.xml
     size: 437553
     sha256: 097915163ad9af6c1d578ba3dc2899389ea96de3a4a3ab48cf9c14ac8e113f40
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-asl-0001/FP32/person-detection-asl-0001.xml
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-asl-0001/FP32/person-detection-asl-0001.xml
   - name: FP32/person-detection-asl-0001.bin
     size: 4026308
     sha256: 06a95e62010880b9c02d34f1d71da081022ef0a97f91093425284d73d4ccb93d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-asl-0001/FP32/person-detection-asl-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-asl-0001/FP32/person-detection-asl-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-raisinghand-recognition-0001/model.yml
+++ b/models/intel/person-detection-raisinghand-recognition-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-raisinghand-recognition-0001.xml
-    size: 651651
-    sha256: b54161b021b689e46acb22ed56b4daade0696e5712f83272ded1652a1fa78996
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
+    size: 651612
+    sha256: 7aa92bc4d83b04c4ac90adb01c6646993065aa1fed9f6a8afd989ad69a4e1999
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
   - name: FP32/person-detection-raisinghand-recognition-0001.bin
     size: 7799848
     sha256: 5183cc9d4d71e208a2cc70db9ea98bf14657d07b2bfafd050aeae9687e4359c4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
   - name: FP16/person-detection-raisinghand-recognition-0001.xml
-    size: 651407
-    sha256: b918e8c382bc20112126dc1883089dd9bf88df747045ef319b27db4e9cf4e106
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
+    size: 651370
+    sha256: f93f4c5666c90091754a33cb19b84a7907868c54490a07c7c5bc9c26693e33ce
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
   - name: FP16/person-detection-raisinghand-recognition-0001.bin
     size: 3899978
     sha256: 601543473374722d45eb56b3aa8f7f250f33e1bb548d63e392332441e97c87d8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
   - name: FP32-INT8/person-detection-raisinghand-recognition-0001.xml
-    size: 1697270
-    sha256: 443ea52f1286329109d0d218bd0b2566527349f67ce871df4b2d2886cacf4881
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.xml
+    size: 1697233
+    sha256: 2fd7f01918a9b8742f739ba2180d20e5ce9c4c97ae8924b04f755e2181fd3803
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.xml
   - name: FP32-INT8/person-detection-raisinghand-recognition-0001.bin
     size: 7971992
     sha256: 7d7e37fb6404d15a9adedbf89f62b7748043c0f7cb98fea907467c9e78609e9d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0002/model.yml
+++ b/models/intel/person-detection-retail-0002/model.yml
@@ -18,27 +18,19 @@ task_type: detection
 files:
   - name: FP32/person-detection-retail-0002.xml
     size: 267908
-    sha256: 8aa513eecbb42d90d79793b737d6516c94e0651066a856a53d809cfa38c22d38
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
+    sha256: ece1e74431e697ca5cbc29ee70478256e805a4835d61d858ba469f4ca8399f40
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
   - name: FP32/person-detection-retail-0002.bin
     size: 12976100
     sha256: 8150eb7ea3352abb272276deb3ce64d0414464e9f4bf02739ec4f2770b8acb75
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
   - name: FP16/person-detection-retail-0002.xml
     size: 267785
-    sha256: 8cf67f55ca74b75aecd48cecff850e93b02fc3a17f4408d70fb610ebe721e2cd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
+    sha256: a432bc296615f9693d9595eeb432f71a5243785962e52f0dc46a2607a010bbc9
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
   - name: FP16/person-detection-retail-0002.bin
     size: 6488130
     sha256: 32008b134ea50eb70a4f97d74562a0a2c542d3c30f19a5d7ef1b57e8615d7039
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
-  - name: FP32-INT8/person-detection-retail-0002.xml
-    size: 694526
-    sha256: a00c865501523a9bad99879a6df85dbe2dbe6d0e6266d4e245237eb9417466af
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0002/FP32-INT8/person-detection-retail-0002.xml
-  - name: FP32-INT8/person-detection-retail-0002.bin
-    size: 13051624
-    sha256: d700bd305d836b6f136043d71647f5f501edb0cf9251e60c6a25f4f239289403
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0002/FP32-INT8/person-detection-retail-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0013/model.yml
+++ b/models/intel/person-detection-retail-0013/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-retail-0013.xml
-    size: 354296
-    sha256: 045a29f2f74584948ab4d9421671b9409c1e7fe9799a0f0d56b08c9fb41cac79
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
+    size: 354259
+    sha256: f89da9c8e4ffb7e923a76fc9d868b948a8323bb28f6f307b0d5e9c1711f3dabe
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
   - name: FP32/person-detection-retail-0013.bin
     size: 2891364
     sha256: 6f09cb7061328942f9d5e9fc81631a4234be66a26daa50cd672d4077ee82ad44
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
   - name: FP16/person-detection-retail-0013.xml
-    size: 354146
-    sha256: 5ae1a1c2a4d316f0137f13756b1fd9d150aa06fe05a9ede26d386d26f763d1d0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
+    size: 354105
+    sha256: f210747a932a580eb5a92c65c08fc6c4297a2f8a959c8ce9b0c8bcdbaf47b857
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
   - name: FP16/person-detection-retail-0013.bin
     size: 1445736
     sha256: 56eeccbeb3f27144046edacb95b459d60f3930f54051ef5b9e5253923c07b672
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
   - name: FP32-INT8/person-detection-retail-0013.xml
-    size: 931316
-    sha256: deab2e4808955cf05f84c457b500f8e5f11e9a3c1db31fa532718d28edfee0c1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.xml
+    size: 931278
+    sha256: b5e2c8981d807f909c2da53670c091b5a17a3ca36498b4d323b82679c3afea88
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.xml
   - name: FP32-INT8/person-detection-retail-0013.bin
     size: 2969676
     sha256: 523b79294453845934e068f4a906b9bf88b4c70ab705f2137e089439f4555b92
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0031/model.yml
+++ b/models/intel/person-reidentification-retail-0031/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0031.xml
-    size: 136148
-    sha256: 7c053ae4158e2450a4aa4c3dfcd553076849c26f7a7baf43274636f51a4c401b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
+    size: 136149
+    sha256: ef6d3ffbcd7eb38ccdcfb2f9394d35ee48f00363d60ea16658c4aae08301e6c1
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
   - name: FP32/person-reidentification-retail-0031.bin
     size: 1120216
-    sha256: c6e6b092d2c805745008bc180bc3a3198deca4e7873b5fd1187ee3ca06092d54
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.bin
+    sha256: 8343531e60f2e36da8311bb768de42b9b03b51d848510da74cb5bf7cbb790823
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.bin
   - name: FP16/person-reidentification-retail-0031.xml
-    size: 136086
-    sha256: dba533af8f5f580b6ffeb9772d38c92b11611869d637b43a40fd6d1e616449b7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
+    size: 136087
+    sha256: d3ce8f1e5680f0aeaf63232ef5be1c7d59d64b87eaafa266d05665724c4914c2
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
   - name: FP16/person-reidentification-retail-0031.bin
     size: 560124
-    sha256: a31764fadff6da6d3bf17b54840590f53c3ac9fa912c8a0297e06da2c91e2882
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.bin
+    sha256: 67e230352812b64ede186c62aaf7369a63fd6f5d8d9a8c98fb7138dac1dfd8bb
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.bin
   - name: FP32-INT8/person-reidentification-retail-0031.xml
-    size: 299442
-    sha256: 3576ad166598cbac617c6eea74bc16375ebd74abd049777ab9c8810ca797726b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.xml
+    size: 299505
+    sha256: 036e65ac42e7003d7a3c274eb6256914cf6cdf384ec9e4d15a3fc97338e4285c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.xml
   - name: FP32-INT8/person-reidentification-retail-0031.bin
     size: 1140656
     sha256: aa4458b93c5f5f25cb9716e0204fb41f4d5cb74da31d2ed61a02dbea810c593c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0103/model.yml
+++ b/models/intel/person-reidentification-retail-0103/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0103.xml
-    size: 429045
-    sha256: 57e2cb5bae933d8e5e83c0f151b4cc4fd68232de4365fe5c63b84a8bcc1c306b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.xml
+    size: 429050
+    sha256: d65e2e090af3e81b7b295e400711aa3165ed4b020e38e8c5d03f11016425de0a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.xml
   - name: FP32/person-reidentification-retail-0103.bin
     size: 2365244
     sha256: 816f560505526a0c8d4b66d0629c0bd00f5df201fb76186e860851521bf14f91
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.bin
   - name: FP16/person-reidentification-retail-0103.xml
     size: 428744
-    sha256: a4283dae8b0b21e57370f5ffd4fd88318168ee60c015f226cde4592581cb640e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.xml
+    sha256: 4382bcc012223d750f9b95aba73188fc0671cb225e682751ddf08d7cebf7fdd1
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.xml
   - name: FP16/person-reidentification-retail-0103.bin
     size: 1182656
     sha256: e17a3a323cf771918350d777d9398143e7ad8a6b404eb294b67ee2a837f36cae
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.bin
   - name: FP32-INT8/person-reidentification-retail-0103.xml
     size: 1215718
-    sha256: ffb93cc22846bf0d7f778ee3361448f9b5ee4cb24b2cd6570d18aebb30d0051b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.xml
+    sha256: 1d10e09c6e95303e3169caa1f7a681e221aaaa36a831a3f21a60db698d09f91c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.xml
   - name: FP32-INT8/person-reidentification-retail-0103.bin
     size: 2462604
-    sha256: 94ed7eb7a4ae29191264d8841ef588e3939fdba17be935c5eaa772e5c36a055c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.bin
+    sha256: facec60e589283bc1a44cca6212435bdf46cdd5910296591617a1bc26c8b4a44
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0107/model.yml
+++ b/models/intel/person-reidentification-retail-0107/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0107.xml
     size: 428541
-    sha256: 05ddafb78912927de5d361ba5ef2c98ee4dc5e9f39fb34fc812e44bdf8d0c6e9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.xml
+    sha256: 809723f4aea3e9fbb691c19109e0fb2710f8a7dfc5726801002f1569bce8024e
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.xml
   - name: FP32/person-reidentification-retail-0107.bin
     size: 728532
     sha256: 06c020c064a2659bf2e84319a1afbd1229a6493c31cb7d34d912f87637b18e9a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.bin
   - name: FP16/person-reidentification-retail-0107.xml
     size: 428330
-    sha256: 177e14c9b58e2d8a53e73e90a0806f2c5aa16b0caab9832ac5f8476645e273e6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.xml
+    sha256: 4ee1a995f96ef887c80db96b803400f6c7519b3fd54c3cc02d6e03cf9e1eb0e3
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.xml
   - name: FP16/person-reidentification-retail-0107.bin
     size: 364300
     sha256: 1966e4681a747a7767e144780069de5bf9440579c8153cd1c1aead69e4da2242
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.bin
   - name: FP32-INT8/person-reidentification-retail-0107.xml
     size: 1213621
-    sha256: c7b7cb0344b167284d22d33ccfcfd0b2aa3dd69e98a6c67bd76af818ce51bd95
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.xml
+    sha256: 719829f289b07e733f99f3916525279dd58debd7172187dd444a5e0ea168a019
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.xml
   - name: FP32-INT8/person-reidentification-retail-0107.bin
     size: 778660
-    sha256: b20b24680e13d7f7c159ffd0a1ff5bd7dabceea6ea1a424295e198a4901f6592
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.bin
+    sha256: 091509c01d8a91e9452a881913bf4fb615c141050f9567a1b66051c95de47421
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0200/model.yml
+++ b/models/intel/person-reidentification-retail-0200/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0200.xml
-    size: 445430
-    sha256: 37c8e70443013aa06a15263daf57c8c3f2d0fe0fb03b5a4716e54024b3d5e83e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.xml
+    size: 445425
+    sha256: 2d5c2c089aa5aae96b1dd0aa4569d0f1e4e469d3bf9aa9eb2d84882feb33d2fa
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.xml
   - name: FP32/person-reidentification-retail-0200.bin
     size: 18800388
-    sha256: 249d48480bd5a3b124a62cb6da8f0aecd535275a0d27f55cb74916a370450046
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.bin
+    sha256: c20933d02c015aa44f4f2c2675c2498d11c45b2c8031f4f533e6636814bdeeca
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.bin
   - name: FP16/person-reidentification-retail-0200.xml
-    size: 445280
-    sha256: 59e56bf927b9b998791866824f14c36f56968a1ca70d872edfb26a5339fee308
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.xml
+    size: 445275
+    sha256: cd392484c83d685664330a9299716ead935a10bf2b453536566174ff2d7b74b6
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.xml
   - name: FP16/person-reidentification-retail-0200.bin
     size: 9400240
-    sha256: d127cdbb49a83bd14f66470eda597644c7996df9abf86951a67d8976f5f486e1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.bin
+    sha256: f3acdd8e8eed0b875ba35d31fd7a5b837eecc26b9b170e149d29fcafb329ca41
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.bin
   - name: FP32-INT8/person-reidentification-retail-0200.xml
-    size: 1269198
-    sha256: 543654a435e3de8511c912939eab76d1d2c885252cc7af54b0e5226274ec4223
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.xml
+    size: 1269251
+    sha256: dc1c416f4548504908926e3a53b2bd7e6ffd5bb6eae9d707cfb5f268c94cb011
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.xml
   - name: FP32-INT8/person-reidentification-retail-0200.bin
-    size: 19002408
-    sha256: 0b0ccfe91b037e2874aea7642c782f9edd634cbc687ca748d2650ee038ef6264
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.bin
+    size: 19002500
+    sha256: 44de11d0f2a289c57c45808d308cfdadedf565ad1b1db25c513e230755afd713
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
@@ -19,28 +19,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.xml
-    size: 354883
-    sha256: 393d763bf1fef03ab3371e928cfb8806c7184988156efc275e48cb76a1604233
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
+    size: 354805
+    sha256: 1fd5b4107faa003ef6d1dec6d0e77b12cc23a64df02d7762f36ff1977a0ac6d1
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.bin
     size: 4713980
     sha256: 178e05f0635b0ee35b577a9dd31ea6da2a2a842635793f1ad18907d00f3a966a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.xml
-    size: 354711
-    sha256: a69d2fe81ac55a272c9edcb8dd3b20aa237530d25fd5baaf9d4b79094713bd7e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
+    size: 354633
+    sha256: 57c5a43d8f1856e5a2a37b2f490df24d0fb43210480c5f65ca37f3c3d0a5c973
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.bin
     size: 2357042
     sha256: a074ff0cad298ed9c35d0ce6ed58e09ee05216b907c97e6bb50f1b77a046bcfd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-0078.xml
-    size: 960368
-    sha256: 45161570a64b492b15afe1e19541d34dcb900a7cfb0cc16a66be12e1bdcb07cd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.xml
+    size: 960289
+    sha256: f759eb05e5dfb07e2ad7d1fc8588294c2776380e6e7d31931eb3833b78b22876
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-0078.bin
     size: 4796540
     sha256: a5c797b9d0a2202c7e574bae55c90ea4cca594510fdfa3a1800c9832f466d52c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.xml
-    size: 194297
-    sha256: cfaaa5f792af3c8c7d95182100a3015dcfc108221c5495b6c07e620c0c075ca0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
+    size: 194329
+    sha256: a4581f31ebdc565c318a88e9f0dc82643c41427e47bcd92cf4ce8f998feae8d8
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.bin
     size: 11548004
     sha256: 61c9deaca903bb107aecfc31faeb402c894e0d43ab3817db8d9d05d43dfa68cf
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.xml
-    size: 194179
-    sha256: 518bf493e99b28b35c1fe1593814d19393dfd3d48ce857060080e807b3ec5210
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
+    size: 194216
+    sha256: f90bf5b3b9c85f746b07be5600128ae109f7ab372424aa70007ace271a5bc957
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.bin
     size: 5774054
     sha256: a0ba3bc9ca17330c731b395153651c22a666050cd06413c01059070681dc79a7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-1016.xml
-    size: 510358
-    sha256: 1e5cdaecdd84e43625a843fbaf207937892c48d77afe4c628634f2fa33bbcad8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.xml
+    size: 510391
+    sha256: d89d8e072975764f6d47f09c84af954ddc916802d6d58be73cfab53ec2f5194d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-1016.bin
     size: 11777480
     sha256: 0abdc201405b2f910f3ddd49307afd89ee43ab80009f9827b4f16e7aa7274157
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/product-detection-0001/model.yml
+++ b/models/intel/product-detection-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/product-detection-0001.xml
-    size: 273134
-    sha256: 38c747749a03b0e79c88bae7199441b4970dc7b59b0a5a873d1354815fde3acd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/product-detection-0001/FP32/product-detection-0001.xml
+    size: 273200
+    sha256: 31b7c786f42432339faec5779b719017120944061805eafe78da190ac70a1fea
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32/product-detection-0001.xml
   - name: FP32/product-detection-0001.bin
     size: 12850036
     sha256: 93f2ccd0ce7ba88f190f51b8a62d67fd5178444496f068dc33488fb1949e2726
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/product-detection-0001/FP32/product-detection-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32/product-detection-0001.bin
   - name: FP16/product-detection-0001.xml
-    size: 272951
-    sha256: f97699d82cfd2292ef81aa25c7b2e2c66fd5d4bd0fd640ad91c54b3d8ed55313
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/product-detection-0001/FP16/product-detection-0001.xml
+    size: 273017
+    sha256: 302bcb7ef314f6eaa19951d6c62e39f640d7ffc107718bc4de27d27a71365953
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP16/product-detection-0001.xml
   - name: FP16/product-detection-0001.bin
     size: 6425070
     sha256: ecc6f6bdae9a49c1749a324e0e98320a0a9aae97cc0c2b536853ee46b9178690
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/product-detection-0001/FP16/product-detection-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP16/product-detection-0001.bin
   - name: FP32-INT8/product-detection-0001.xml
-    size: 610779
-    sha256: 90eadc7f4ac8ae0c2e9317b087beaba0bd253dae909dc324848f233f16769ba9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/product-detection-0001/FP32-INT8/product-detection-0001.xml
+    size: 674722
+    sha256: cea1c66540e4ec5187f9bc2450694db8931b9648863b95aa03334d1b2f9bc089
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32-INT8/product-detection-0001.xml
   - name: FP32-INT8/product-detection-0001.bin
-    size: 13061616
-    sha256: 4f4160c9e4aec4a64091182c4d93ec46a0e74877b2b49ffc7c26be8d42c59c09
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/product-detection-0001/FP32-INT8/product-detection-0001.bin
+    size: 13101168
+    sha256: 741f6bee9d617ca20a5c5813ed3defc240b4fdef84c4c2582e3e4bb586460d1f
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32-INT8/product-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
@@ -18,19 +18,19 @@ task_type: classification
 files:
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
     size: 93588
-    sha256: 4098e5ee05a2be766db7d4aa04f8ecc6e04a3c04eda0c6bc0eaff97272476c14
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
+    sha256: 1454fca6b719e7ef59cd24f357cd83a847df465e6c0991c357a981a873c8094d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 4190944
     sha256: 69f0fef2a4373fb4a72a9fe99442f14e8d367470422f9068976284114193e833
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
     size: 93562
-    sha256: 5e9af9908717506f3539025265e1b65d9c159a2860c4c204fd2d3082853e3a4b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
+    sha256: 455ea2ead098934482d89dfb6c955e00017dfdcfe58d3b4d8408627d0caf1ead
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 2782080
     sha256: 57a2767a0dd7eddb59830b93a01ce5f6ef0906abb252602f89f7dd28071a6dd5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/resnet50-binary-0001/model.yml
+++ b/models/intel/resnet50-binary-0001/model.yml
@@ -18,19 +18,19 @@ task_type: classification
 files:
   - name: FP32-INT1/resnet50-binary-0001.xml
     size: 227762
-    sha256: 7e2f475eb6c93e9ecf753b6070989a2c7e65addf786834f84aff72bd71735106
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
+    sha256: 750c212fd2f2626a3b9151c43c63939f89c5a3a95a02d1b3cc4d03ecdbfdcaea
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
   - name: FP32-INT1/resnet50-binary-0001.bin
     size: 22112976
     sha256: 35c724a526d54d32badf20a5bf929925d333a4e67bcf493c854ce4d5a3e258cb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
   - name: FP16-INT1/resnet50-binary-0001.xml
     size: 227668
-    sha256: e8c694f4f6f5cbb6ef91390c4761f914da0ee0e42144919b3a2062a3ef53e5ed
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
+    sha256: 35a465039ca3d4bb5d85839e8110383fc9698d2408293f71ec237053e61ffbe2
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
   - name: FP16-INT1/resnet50-binary-0001.bin
     size: 12348784
     sha256: cb98ba6a96cc46d1eae9786e964b1fad2b41d74470c2032a1961fb66ece91332
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/road-segmentation-adas-0001/model.yml
+++ b/models/intel/road-segmentation-adas-0001/model.yml
@@ -19,27 +19,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/road-segmentation-adas-0001.xml
     size: 357680
-    sha256: fa5253e9b227b0e094cf103de473c34992fc39500d8166dedc9176c03e91b5eb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
+    sha256: b862c63f6ad3abe344ec39db65537477e172681232b3a7bea96d97d74b911daa
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
   - name: FP32/road-segmentation-adas-0001.bin
     size: 737200
     sha256: ae43e7d5dd1ad62cbe62a2d8aa5dd3721b7581f26763ba3c69660da2a91c3d87
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
   - name: FP16/road-segmentation-adas-0001.xml
     size: 357525
-    sha256: 8de92e20667fde9b3e584e2896acdb365eca055f60449c563510fbf7d705306e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
+    sha256: ec08c6a8880ca77af329d37cfc5750c904a205c7b4561352422e8b152a04ed8c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
   - name: FP16/road-segmentation-adas-0001.bin
     size: 368632
     sha256: ddbc38aaee27ed8166d1190519380a91cdea8cf7f4bc71585d939fd6ead6b159
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
   - name: FP32-INT8/road-segmentation-adas-0001.xml
     size: 1057411
-    sha256: fcdbc69178a684c2469cd5f8238470bb80346c3d4cc8560ae220f1503aa4183c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.xml
+    sha256: 005024bb7a8cfcd0a887d92f944b8329dcdb75484e76c916c9251d069c42f9d6
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.xml
   - name: FP32-INT8/road-segmentation-adas-0001.bin
     size: 783048
     sha256: 6c6cb1de3831c294f79cc6d693edb5d36874608dd4bfd45b2ee88dc6df390b98
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/semantic-segmentation-adas-0001/model.yml
+++ b/models/intel/semantic-segmentation-adas-0001/model.yml
@@ -19,28 +19,28 @@ description: >-
 task_type: semantic_segmentation
 files:
   - name: FP32/semantic-segmentation-adas-0001.xml
-    size: 182365
-    sha256: 9dd8e592170ba483039adad3b5416247ed25cbff3c18825c47c1213cec86cf94
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
+    size: 182085
+    sha256: ed7a85e055a2f87dee81cd097a13d996f4d49d698b89c27cd76f70a7e30c8b14
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
   - name: FP32/semantic-segmentation-adas-0001.bin
     size: 26743564
     sha256: 6d2592c07c91ed1de76c683a2c5753c89f0a61c215bc553f2a6b30faa05b37ba
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
   - name: FP16/semantic-segmentation-adas-0001.xml
-    size: 182284
-    sha256: a3a38be0193f2b26095574e1cdd3530559b8b5c49ad3fbda5a82fd822a7bd5dd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
+    size: 182004
+    sha256: 985a77b47dbae4a360176f64c6883aca463c169d649183da7232f0e63039ddfa
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
   - name: FP16/semantic-segmentation-adas-0001.bin
     size: 13371824
     sha256: a6366b6cd8e6456bdea4d2709e4d062c434a94cfabb62905dfbb4cd50b3df5d5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
   - name: FP32-INT8/semantic-segmentation-adas-0001.xml
-    size: 506560
-    sha256: dfd30150a61aa4035e348ae674ef502af26f0fc8b3799e6bc9345a8e269470a8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.xml
+    size: 506262
+    sha256: 6dc1efc337eb1cd6bf82801ec9e9d4a504ec8941f6e650530b7e1bcd32086de3
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.xml
   - name: FP32-INT8/semantic-segmentation-adas-0001.bin
     size: 26858920
     sha256: 6a2362f6c06fe1d569699d82f461245e7233e4cbc99f729baba3acec3bf5207b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1032/model.yml
+++ b/models/intel/single-image-super-resolution-1032/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1032.xml
     size: 41192
-    sha256: b66fedd64b4cd0c37e714e54cadc43b874c7a6a415c8dc23dce391e39a243516
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
+    sha256: 2ae653c1e2b4e8015c7a794e3de7166f027737ed3b7faec2b4074dfce0a2639d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
   - name: FP32/single-image-super-resolution-1032.bin
     size: 119556
     sha256: 82b5338155835d6b4307721e6a9b28775a4550b61c31d76aac1a8b5d5612d7dc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
   - name: FP16/single-image-super-resolution-1032.xml
     size: 41166
-    sha256: 348ec2236488d0dcb3d423fec3b9bebd749e54c08ae486f98fcc8e247811915d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
+    sha256: 22d0d66d1e9d0781b017ef7004647deb86878ecbb526ef2cfb0fba1a045f5bcb
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
   - name: FP16/single-image-super-resolution-1032.bin
     size: 59882
     sha256: abae5907d40ef7e47d680435a99484b74076a985a6b8c3353b64fa77e6d3c149
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
   - name: FP32-INT8/single-image-super-resolution-1032.xml
     size: 122462
-    sha256: 654bfedd6071cece4330272405df9e104101dca0af3f539d378d838f34d22892
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.xml
+    sha256: 6f6ca9fcbe53340ce1acbc5210b156f17517481de2cb7fc92c6d1770c35ac9ce
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.xml
   - name: FP32-INT8/single-image-super-resolution-1032.bin
     size: 121724
     sha256: e14739375434b1645d0b6745947aae73fd9b915750b033ce08f25aab93b0b25e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1033/model.yml
+++ b/models/intel/single-image-super-resolution-1033/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1033.xml
     size: 36335
-    sha256: b66a3bfd06478140a7ebd69708c8d0008ba9d29dcc702ca4afe8a3b90177d067
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
+    sha256: a5166b0f8582b25f300c7447ef81468f2db09bae734c1b31ee13333bb6039711
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
   - name: FP32/single-image-super-resolution-1033.bin
     size: 121812
     sha256: 47b0c1d3b28c1193fdb7838cebdad29e010abfdc7664ef06257bd659f4f08474
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
   - name: FP16/single-image-super-resolution-1033.xml
-    size: 36319
-    sha256: 2c5e655c58fd370300ae3465d026e4d6586e6804f4a5378e42a4a671be4111e0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
+    size: 36316
+    sha256: a09e083c3ecb5f6987a97d517f6adda8a9a2279983e37c6c9a8580863b8d825f
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
   - name: FP16/single-image-super-resolution-1033.bin
     size: 60970
     sha256: 771dd5b865006aea3a04a6b5e858c34fe619913d8aa1279cd9b6a40c05ef0df7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
   - name: FP32-INT8/single-image-super-resolution-1033.xml
     size: 113556
-    sha256: 8aa8a39ee25739786dd59d23b18329d2753ec37c3472c1a051a0ac0728ac3b50
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.xml
+    sha256: 1c38a37a1462c95078c36b50d4d4e7f6b0adc7bfa1d5ed74207f37495555b0b2
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.xml
   - name: FP32-INT8/single-image-super-resolution-1033.bin
     size: 124040
     sha256: d066c186597ae2d74f42250945a8f0c315f284e4d1fd7126c263228cc94e8c13
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0003/model.yml
+++ b/models/intel/text-detection-0003/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-detection-0003.xml
     size: 178392
-    sha256: fcad7422ae13f244b37f7ef4e36964bdecd0b474774d410dc044baaf50b5e3f0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0003/FP32/text-detection-0003.xml
+    sha256: fb6526724978d02c1c34f90e5f68ec27510acefae57d3ebc0489014257bd902b
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32/text-detection-0003.xml
   - name: FP32/text-detection-0003.bin
     size: 26986280
     sha256: 03430c799fa873e859eb0018318e741fd58b8ff6b9891949cb931876db3bf0e1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0003/FP32/text-detection-0003.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32/text-detection-0003.bin
   - name: FP16/text-detection-0003.xml
     size: 178312
-    sha256: 9c8f15dcefd1b29e82c70bec42b4d50981ee0b7b84a5502eeff9fba2e472b5ea
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0003/FP16/text-detection-0003.xml
+    sha256: a79db693edd5b9bb0ede95ca667ad07693fd586f51cdff90ab324eef77f5f91c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP16/text-detection-0003.xml
   - name: FP16/text-detection-0003.bin
     size: 13493056
     sha256: 84fc3ce490259047e3a48f2810f4cd2a38ad20c12a82f96e39f4ccb78b86b1f7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0003/FP16/text-detection-0003.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP16/text-detection-0003.bin
   - name: FP32-INT8/text-detection-0003.xml
     size: 557004
-    sha256: 3c76945afb9ebb669da5098d9603ed4ab47debc5d1a61dbed6eea5eff25ef86e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0003/FP32-INT8/text-detection-0003.xml
+    sha256: 8834507c02dabb0ac1ada2a59a4e9d2c05d9a54b7d84cdb7cf63ed1804b97205
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32-INT8/text-detection-0003.xml
   - name: FP32-INT8/text-detection-0003.bin
     size: 27219792
     sha256: 5eeffd8c051eba2661f87e43d08721576e0a346af569694a6859b748916233e1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0003/FP32-INT8/text-detection-0003.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32-INT8/text-detection-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0004/model.yml
+++ b/models/intel/text-detection-0004/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-detection-0004.xml
     size: 156936
-    sha256: bdc4f42d3020f99430364a6af2adf30b20a7817a57efcf33b179c4f58db4482a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0004/FP32/text-detection-0004.xml
+    sha256: 85ede4c0d469fb0ac0806f98b02e75485e351d4fa34fe1fab48869ab4a404120
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32/text-detection-0004.xml
   - name: FP32/text-detection-0004.bin
     size: 17312168
     sha256: 6da6456f27123be2d9a0e68bb73a7750f6aaee2f0af75d7f34ec6fa97f6727dc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0004/FP32/text-detection-0004.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32/text-detection-0004.bin
   - name: FP16/text-detection-0004.xml
-    size: 156839
-    sha256: 9a2c8f21ccfe54cc520cfe3ed7295178e99e6174913a64c2699394557bccf731
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0004/FP16/text-detection-0004.xml
+    size: 156835
+    sha256: 52b910fff9d5c88c58e8e0ac385e8695bffe33d136e3752de51430c17710aee5
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP16/text-detection-0004.xml
   - name: FP16/text-detection-0004.bin
     size: 8656000
     sha256: 719639a52b46f94455ad8c2fb6d0e0bb98c485179f4321c558d5d88aacfbfd0e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0004/FP16/text-detection-0004.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP16/text-detection-0004.bin
   - name: FP32-INT8/text-detection-0004.xml
     size: 461339
-    sha256: 68a3d329defcc6b97098e06e1a568aa9dbf84e8bec014fe8c9d1a185db0e7be2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0004/FP32-INT8/text-detection-0004.xml
+    sha256: bcec9ec2f95f1c7b46fa9a2296e36b33126b343c1c7e980443e6633beeebb80b
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32-INT8/text-detection-0004.xml
   - name: FP32-INT8/text-detection-0004.bin
     size: 17559056
     sha256: fa2e973387c7b8a1e8d3165dae15e72e0537ef8e55eeae98081b0fb2b88676c6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-detection-0004/FP32-INT8/text-detection-0004.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32-INT8/text-detection-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-image-super-resolution-0001/model.yml
+++ b/models/intel/text-image-super-resolution-0001/model.yml
@@ -18,27 +18,19 @@ task_type: image_processing
 files:
   - name: FP32/text-image-super-resolution-0001.xml
     size: 11356
-    sha256: 8b8d29eafaf58abfb419ee106c7dcedb60f2535a076df4312e15285598e8fa6b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.xml
+    sha256: fb51c561eafeec139c1736ab95e6972cf82980247d11a9e36e9237f32bc458b9
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.xml
   - name: FP32/text-image-super-resolution-0001.bin
     size: 10836
     sha256: 033d58430a2744302a2729291d66d4c74ee6bce517b6ae36f1b5a0e8b27d82ff
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
   - name: FP16/text-image-super-resolution-0001.xml
     size: 11346
-    sha256: bd3a27754d39b955741885950260f26da57e86151c096752ffae6f01ec9b7ffa
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.xml
+    sha256: bd2452d4e1968479c5537f4cad0ac4b7d15e7d7bba49608e06e9b96550fb3b63
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.xml
   - name: FP16/text-image-super-resolution-0001.bin
     size: 5418
     sha256: f203818d73b933e5004aff85aeb84783dbf0be9e5c296d2995fc0678ff719e9c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
-  - name: FP32-INT8/text-image-super-resolution-0001.xml
-    size: 27041
-    sha256: ef2b53bc9f9eac73b4d76f2a9d7fdae27d7865024fa5ed26dd85f0799725b3bc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-image-super-resolution-0001/FP32-INT8/text-image-super-resolution-0001.xml
-  - name: FP32-INT8/text-image-super-resolution-0001.bin
-    size: 11228
-    sha256: f1680f577b003e5d6674d5b2d07277171487dac7707dbd18b686755e438127aa
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-image-super-resolution-0001/FP32-INT8/text-image-super-resolution-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-recognition-0012/model.yml
+++ b/models/intel/text-recognition-0012/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/text-recognition-0012.xml
-    size: 119138
-    sha256: ec0c79bb39a369f56c2e38cc2d21a3c1d0b1cd049c693ab151f48f958a19fab5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-recognition-0012/FP32/text-recognition-0012.xml
+    size: 119137
+    sha256: 9fed384cca2aec53214fbff8f922608882f1f69868c1e07e869586b5612485e0
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32/text-recognition-0012.xml
   - name: FP32/text-recognition-0012.bin
     size: 47470864
-    sha256: af88da0433321350cf2451b5839907debdc398aeb99f54290296e620060186c0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-recognition-0012/FP32/text-recognition-0012.bin
+    sha256: 9d08734a7128e2099ba0c64ef347c0faf2470611ef627995f66343299473b14a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32/text-recognition-0012.bin
   - name: FP16/text-recognition-0012.xml
-    size: 119106
-    sha256: 291de6f634931821a163d9f51221877a23ba084ad284306685cc1482aed5ee29
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-recognition-0012/FP16/text-recognition-0012.xml
+    size: 119105
+    sha256: 7f23f42a3e2c9207f68dd6716d8f3ffbb4e8f1d5a26147829cfae9b835f1321e
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP16/text-recognition-0012.xml
   - name: FP16/text-recognition-0012.bin
     size: 23735488
-    sha256: a58ef22c6b26a5da07e6a0d8e9e3f721e51b313cf31ab8edea061e4a4426af42
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-recognition-0012/FP16/text-recognition-0012.bin
+    sha256: 6e3cd9139e9bfc32bd4ae7054e97d6050754552c78703df9bda96c313573cc8a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP16/text-recognition-0012.bin
   - name: FP32-INT8/text-recognition-0012.xml
     size: 153421
-    sha256: 7e8a95352f1083654235bb2a184d00a15fbe76ed4512647b729a8dcc813d0b43
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-recognition-0012/FP32-INT8/text-recognition-0012.xml
+    sha256: b148ce47f98a6a41c467274eeb5ad7330a29cf7e33b0126c6784bb8e0830e6fd
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32-INT8/text-recognition-0012.xml
   - name: FP32-INT8/text-recognition-0012.bin
     size: 47489644
     sha256: 0bac02a212d27677fbacc5f1535190eb05e633f49274f42d1e31c32f55dca17e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-recognition-0012/FP32-INT8/text-recognition-0012.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32-INT8/text-recognition-0012.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0001-detector/model.yml
+++ b/models/intel/text-spotting-0001-detector/model.yml
@@ -18,19 +18,19 @@ task_type: detection
 files:
   - name: FP32/text-spotting-0001-detector.xml
     size: 275848
-    sha256: 7baade8ffdf54e0b3a012dd814d0c8beeb245d0f454eabf4c36825998702ccbc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-detector/FP32/text-spotting-0001-detector.xml
+    sha256: 6027c81c80e93d2652157350bfecd80ef91546b14c902bf3ae078a4d3347fbae
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP32/text-spotting-0001-detector.xml
   - name: FP32/text-spotting-0001-detector.bin
     size: 105906904
     sha256: 3a4e3e7c3d0673a778882f5e6aaa217128473e79c5cb90c614d77ad25a108d42
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-detector/FP32/text-spotting-0001-detector.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP32/text-spotting-0001-detector.bin
   - name: FP16/text-spotting-0001-detector.xml
     size: 275734
-    sha256: b8a7c047c8b573f7c00a03286d5aacf243319d5416161b2edc7d706c4f4a81f7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-detector/FP16/text-spotting-0001-detector.xml
+    sha256: 382031ffbef4a0931fd14813f085d3f294ad188fdc5291b7cf5e43148c977483
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP16/text-spotting-0001-detector.xml
   - name: FP16/text-spotting-0001-detector.bin
     size: 52953494
     sha256: 776648224b38f5023606b52f1782f4423b56ff588de8a7b7ea15c5e0fca15eb8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-detector/FP16/text-spotting-0001-detector.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP16/text-spotting-0001-detector.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0001-recognizer-decoder/model.yml
+++ b/models/intel/text-spotting-0001-recognizer-decoder/model.yml
@@ -18,20 +18,20 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/text-spotting-0001-recognizer-decoder.xml
-    size: 30554
-    sha256: 9dbdcfc3ba7749946ba19d60306ce10d287228373004dd2b41c4c35123f5d220
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.xml
+    size: 30543
+    sha256: 7a45447713c1b1cead9cfc7176dcbb3b356a1fc247ade055201e5697ac547b26
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.xml
   - name: FP32/text-spotting-0001-recognizer-decoder.bin
     size: 2707804
-    sha256: 491096a70af0682fdde50df311fd623e8c9d5bbaff7eaba4559883a7babb92a2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.bin
+    sha256: 00cb0cef419a01661ca1c1b9977b1edebe581427dd28a593ba34505971544303
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.bin
   - name: FP16/text-spotting-0001-recognizer-decoder.xml
-    size: 30538
-    sha256: 312249389d25ef218be126a5b6dac9144af982e739cebf16f35597b1879cb591
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.xml
+    size: 30527
+    sha256: 01c2a7b426c91f195c45883b64a3a89b2276a4ecc2598f109820f3436e3f5d4c
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.xml
   - name: FP16/text-spotting-0001-recognizer-decoder.bin
     size: 1354000
-    sha256: f92b37ffae9d7152a71d6134b8028a46da88443077be30017c03a60fd25af003
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.bin
+    sha256: 58fb88820edf08b2809f2f7d7c563c86082b13342f01206ffc98707ed2a66948
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0001-recognizer-encoder/model.yml
+++ b/models/intel/text-spotting-0001-recognizer-encoder/model.yml
@@ -19,19 +19,19 @@ task_type: feature_extraction
 files:
   - name: FP32/text-spotting-0001-recognizer-encoder.xml
     size: 9906
-    sha256: 9d9f3de8b98ced78eb47ef75729a080cedd7877b98c04dab4197f877b2d5be01
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.xml
+    sha256: e83d95fc0938ff3c4a40cff80fd2621114ac3d99d8d12942b5d2fb4693d9a002
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.xml
   - name: FP32/text-spotting-0001-recognizer-encoder.bin
     size: 5311488
     sha256: df3b4d491c953b022afbed4e0492b8f41046da3a6d3c65054884ac15af135942
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.bin
   - name: FP16/text-spotting-0001-recognizer-encoder.xml
     size: 9903
-    sha256: edb25b5717e82ecd02666a018a6a365cb42e01cac6d12a78fa88b5264df1a4c2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.xml
+    sha256: dce746a5d4a6b1b03b0da1c2cf1bba3623ab8faa2ecd60e46a6793c65bf1f94f
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.xml
   - name: FP16/text-spotting-0001-recognizer-encoder.bin
     size: 2655744
     sha256: e0a2315c344e2adf69c31b24faa16fdc9496f48a9ba98c25ecef640f23710517
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/vehicle-attributes-recognition-barrier-0039.xml
-    size: 33361
-    sha256: 0836ccc0831f9a1d6b46f3397c44b5867c553087c2d760f082220c70241e81ae
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
+    size: 33365
+    sha256: 0c61e77df8fbb5c6ede62410025d58413aaa60405af9a0da27a374057ff87aeb
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP32/vehicle-attributes-recognition-barrier-0039.bin
     size: 2504020
     sha256: 26594e8bfc4e8de30a2186f4c30cfd44b82a4f4b4656fb32aa12d4f4888c832a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP16/vehicle-attributes-recognition-barrier-0039.xml
-    size: 33351
-    sha256: 40f8920c4e7fce3b12a0e63b7d9cafe9a3bb076bb9ddc33d5b9e94f28031dc6c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
+    size: 33347
+    sha256: fe601fdc8cce0d1ebcc95393b9d0397c52702288995a4da987a04f90558379e4
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP16/vehicle-attributes-recognition-barrier-0039.bin
     size: 1252018
     sha256: aed57f9cfdfc7dbd8955c5f6b15966bd0131050129835e2046451f06e4bde7b9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP32-INT8/vehicle-attributes-recognition-barrier-0039.xml
     size: 87151
-    sha256: 060ec28b06a5453168513acf75adf3a1de8c1904813f7b47dc9bc608269815c0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.xml
+    sha256: 92ea62baa2689ead54c0d46e59463814112c9f4abf04459eeb0eb1e948216f60
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP32-INT8/vehicle-attributes-recognition-barrier-0039.bin
     size: 2512408
     sha256: 649ee0087b451d4d9099156452a2b80092b5af673fc457f0cdd6cd6fd1aa05a4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-adas-0002/model.yml
+++ b/models/intel/vehicle-detection-adas-0002/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/vehicle-detection-adas-0002.xml
-    size: 216221
-    sha256: 2141193c4972f763357f4d637b9ef7f252346686bd7657e544bf75bec4e8a614
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
+    size: 216037
+    sha256: f6563cc8625b5969807bf27b1a6bd5dc55515289fe4e7f897cbd77a52af631d5
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
   - name: FP32/vehicle-detection-adas-0002.bin
     size: 4314552
     sha256: 6d0e114769bed9c8bd6666e098f891d7c158508bd7db6ba2bd4d09de17db1b69
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
   - name: FP16/vehicle-detection-adas-0002.xml
-    size: 216179
-    sha256: 5af831d811bc60aa8e4db0ce106586671f8fdeed269591d74d103257a9988b21
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
+    size: 215991
+    sha256: 17896bbbc1914087df57b5ef356441c1cfaff1820d22888312b57d0f79dc5297
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
   - name: FP16/vehicle-detection-adas-0002.bin
     size: 2157328
     sha256: e119b3bec50bc836f2eb26a56a40a6d5e3c33bde819f3e6d00f829978092742b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
   - name: FP32-INT8/vehicle-detection-adas-0002.xml
-    size: 438790
-    sha256: a48ce6cc22f491e49092ec4c447e2cb92495a9378b95b9afab8ebd69bf81042b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.xml
+    size: 438606
+    sha256: 28c2f7729561230b98b87c617da97b85d62029103195daed726fa3411f8abe6d
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.xml
   - name: FP32-INT8/vehicle-detection-adas-0002.bin
     size: 4389736
     sha256: 9fe53648e0a377c00e8b985817cd25dad320008e8d0a1048af4ac88aabf1a929
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-adas-binary-0001/model.yml
+++ b/models/intel/vehicle-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/vehicle-detection-adas-binary-0001.xml
     size: 105969
     sha256: c98bf5984895b1309861597ec36181446877407cd985bb490e14461f41312670
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.xml
   - name: FP32-INT1/vehicle-detection-adas-binary-0001.bin
     size: 2160500
     sha256: afdd8a2f175b2f19c07083ff23b2e28105f3d1c7dc06a4b1a1d5c2c42b98294f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
+++ b/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-license-plate-detection-barrier-0106.xml
     size: 204474
-    sha256: e14f46c3554d076a05e90cd9ced900b5c6ac70e48ce9759ea8b73a61401012c4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
+    sha256: 8193604cbadd987d324691180f69fffd0b4c53bf466942995d4a8abda30b093a
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP32/vehicle-license-plate-detection-barrier-0106.bin
     size: 2573380
     sha256: 2a6f1cd0eb8731ef059a91299bce0be026d2cebb1ae42cbee37b6aef7da2764b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
   - name: FP16/vehicle-license-plate-detection-barrier-0106.xml
-    size: 204411
-    sha256: 58a8cede2c4d06a206ef6f01244071660be6e85420565b286c11ae6659b2e822
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
+    size: 204406
+    sha256: 39e5bf4fccb20ccbe4dd89861f973d2532ce5efc25ec0c3af9a61c6f6c9f3086
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP16/vehicle-license-plate-detection-barrier-0106.bin
     size: 1286758
     sha256: 57652e098f93ee712eb412267612cb7bf2713475f96ec1e18eca10e4bef69785
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
   - name: FP32-INT8/vehicle-license-plate-detection-barrier-0106.xml
     size: 519016
-    sha256: aa67ba1598f9e902e60b4cf1f1eba96cf159ae109f5335702bdcd0a43006fea1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.xml
+    sha256: 092689a2ee9b5f6c089da2acc44ab07304106c1d9b6a5f2c0c07e1715067ed69
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP32-INT8/vehicle-license-plate-detection-barrier-0106.bin
     size: 2642612
     sha256: 2f81d5803d76e90f9000c17083536ece01e7127c407e5bec7a6caef07ac01082
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20191230_170000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE


### PR DESCRIPTION
These should fix the demo tests.

Some of the `*-INT8` models are not available due to known issues with quantization. They may be uploaded later.