### PR TITLE
crossroad_camera: replace person-reidentification-retail 0079 with 0031

### DIFF
--- a/demos/crossroad_camera_demo/README.md
+++ b/demos/crossroad_camera_demo/README.md
@@ -5,7 +5,7 @@ This demo provides an inference pipeline for persons' detection, recognition and
 * `person-vehicle-bike-detection-crossroad-0078`, which is a primary detection network for finding the persons (and other objects if needed)
 * `person-attributes-recognition-crossroad-0230`, which is executed on top of the results from the first network and
 reports person attributes like gender, has hat, has long-sleeved clothes
-* `person-reidentification-retail-0079`, which is executed on top of the results from the first network and prints
+* `person-reidentification-retail-0031`, which is executed on top of the results from the first network and prints
 a vector of features for each detected person. This vector is used to conclude if it is already detected person or not.
 
 For more information about the pre-trained models, refer to the [model documentation](../../models/intel/index.md).
@@ -88,7 +88,7 @@ If Person Attributes Recognition or Person Reidentification Retail are enabled, 
 
 > **NOTE**: On VPU devices (Intel® Movidius™ Neural Compute Stick, Intel® Neural Compute Stick 2, and Intel® Vision Accelerator Design with Intel® Movidius™ VPUs) this demo has been tested on the following Model Downloader available topologies: 
 >* `person-attributes-recognition-crossroad-0230`
->* `person-reidentification-retail-0079`
+>* `person-reidentification-retail-0031`
 >* `person-vehicle-bike-detection-crossroad-0078`
 > Other models may produce unexpected results on these devices.
 


### PR DESCRIPTION
person-reidentification-retail-0079 was removed.