### PR TITLE
AC configs: fix missed metrics section in road-segmentation-adas-0001

### DIFF
--- a/tools/accuracy_checker/configs/road-segmentation-adas-0001.yml
+++ b/tools/accuracy_checker/configs/road-segmentation-adas-0001.yml
@@ -25,5 +25,11 @@ models:
 
     datasets:
       - name: road_segmentation
+        metrics:
+          - type: mean_iou
+            presenter: print_vector
+          - type: mean_accuracy
+            presenter: print_vector
+
 
 global_definitions: ../dataset_definitions.yml


### PR DESCRIPTION
accidentally missed metrics in OMZ config