### PR TITLE
object_detection_demo_centernet: make compatible with NumPy < 1.15

### DIFF
--- a/demos/python_demos/object_detection_demo_centernet/detector.py
+++ b/demos/python_demos/object_detection_demo_centernet/detector.py
@@ -196,7 +196,7 @@ class Detector(object):
         filtered_detections = detections[mask]
         scale = max(image_sizes)
         center = np.array(image_sizes[:2])/2.0
-        dets = self._transform(filtered_detections, np.flip(center), scale, height, width)
+        dets = self._transform(filtered_detections, np.flip(center, 0), scale, height, width)
         return dets
 
     def infer(self, image):


### PR DESCRIPTION
NumPy 1.15 is when the axis parameter was made optional.

The NumPy version in the Ubuntu 18.04 repositories is 1.13, so it would be good to be compatible with that.