### PR TITLE
Publish new versions of Intel models

### DIFF
--- a/models/intel/action-recognition-0001-decoder/model.yml
+++ b/models/intel/action-recognition-0001-decoder/model.yml
@@ -18,20 +18,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/action-recognition-0001-decoder.xml
-    size: 117062
-    sha256: e3ec5f5bb201ec6052575dc21e5ae3cfad9988c7ca82ecf1f930ce0700f09c80
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
+    size: 117064
+    sha256: 662329658703c2e69659be688f48d900fe56adf7a467d1f7511e18443e2ef87a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
   - name: FP32/action-recognition-0001-decoder.bin
     size: 30238776
     sha256: 94b20a3d531c2f72fa4230aaed22ed9140f8923ed60907cbf1a0a48147d7663d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
   - name: FP16/action-recognition-0001-decoder.xml
-    size: 117022
-    sha256: 0382a460591d0a04cce49134e4e26d278e7fcebce804294e2b1b754f20a4e738
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
+    size: 117024
+    sha256: cee9b6fd416bfab880fe1e782d1705ee799d60b7ef84615a7c26c80d92efef43
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
   - name: FP16/action-recognition-0001-decoder.bin
     size: 15119512
     sha256: 04108ac97f6815a1929b0cf3a6a5b539b28236ea7cf6bd4329011ca768257f23
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/action-recognition-0001-encoder/model.yml
+++ b/models/intel/action-recognition-0001-encoder/model.yml
@@ -18,20 +18,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/action-recognition-0001-encoder.xml
-    size: 98457
-    sha256: 194c96210668526c58d293a20a8b955b484f35e9779f6c994e2d6ad60b855de2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
+    size: 98459
+    sha256: 27a2f6b6a53f5c860c729bb532fc50f0d8e84e180f6e99a97c1de1c292e5e728
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
   - name: FP32/action-recognition-0001-encoder.bin
     size: 85104664
     sha256: c33e24b3f74918104eeafc106ee7f0b56804f03b87098c14ad66af6386cdb648
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
   - name: FP16/action-recognition-0001-encoder.xml
-    size: 98417
-    sha256: 37c18864aa2cd9ce1a2c75c3e94f67a21cfd9b7984c41efb261fdf46eb6732c5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
+    size: 98419
+    sha256: 901c3ab3b9134db90c1ef2fa4b523fa4ddc795de9fbeb250ddefce466ea83e39
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
   - name: FP16/action-recognition-0001-encoder.bin
     size: 42552332
     sha256: 57d374b873dc87c72e5baab53245d59f1b866f6e2c3e670c923537f45018782c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/age-gender-recognition-retail-0013/model.yml
+++ b/models/intel/age-gender-recognition-retail-0013/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/age-gender-recognition-retail-0013.xml
-    size: 30004
-    sha256: 988ad3b0ee3b793598b47f3b0328f7beb58c9a59e0ec6b436c8c6f0cff485e2a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
+    size: 30006
+    sha256: ca2c4826b9370038643d97a434bb9621adea4baf4279e5b9c3a83002456fd755
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
   - name: FP32/age-gender-recognition-retail-0013.bin
     size: 8552076
     sha256: 4dab79cfedebd628f3327367a91c9736a32fbf9cc733cbbf1629d16910d4ace7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
   - name: FP16/age-gender-recognition-retail-0013.xml
-    size: 29998
-    sha256: 86fd1c1845d46d8f8fc09659db2657d778317ad92a83a042901c5d1482561c85
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
+    size: 29996
+    sha256: a375a5d8617ff1913dfc1210f5bb07493d72293c0efa87c1abcdfe181ae8a2b0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
   - name: FP16/age-gender-recognition-retail-0013.bin
     size: 4276038
     sha256: 401101e0a01b3d68add39deae833bcf9f54238d37dd13e3fb1534aa8fbe4719d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
   - name: FP32-INT8/age-gender-recognition-retail-0013.xml
     size: 64387
-    sha256: b3fba20acd6318ec1eed376e9491b4cf371aa1d8a82becbd3e5d2b1c390dc63d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.xml
+    sha256: 930b5e2ef06d890a79e91f16ecbe54ce08abcb6923cfb56afa464750588d7a21
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.xml
   - name: FP32-INT8/age-gender-recognition-retail-0013.bin
     size: 8565952
     sha256: 0efcef2c78fa5208d85d2eb5fc69955c6d97a2ba2948c67a75b0dcb3b74da41e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/age-gender-recognition-retail-0013/FP32-INT8/age-gender-recognition-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/asl-recognition-0003/model.yml
+++ b/models/intel/asl-recognition-0003/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/asl-recognition-0003.xml
-    size: 239494
-    sha256: 961de5b24ac154bb153ac5ac94614d5f60214d9b0809f0a356fa6b7ec8c58c8c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP32/asl-recognition-0003.xml
+    size: 239496
+    sha256: 26f952c4d025372074d2a54c895805ed12780b744eb2fdd618b7b4d3c10a03ef
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/asl-recognition-0003/FP32/asl-recognition-0003.xml
   - name: FP32/asl-recognition-0003.bin
     size: 16515220
     sha256: 41c6508a94d86603084dd41a46e4085bc05fcd84f3ecd65ef44a7e03001e7459
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP32/asl-recognition-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/asl-recognition-0003/FP32/asl-recognition-0003.bin
   - name: FP16/asl-recognition-0003.xml
-    size: 239391
-    sha256: 771b824a0e72e2dce600f6279a2542e3fa9fb61fe68eeb80a6aed3f0c45ee1ce
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP16/asl-recognition-0003.xml
+    size: 239393
+    sha256: 01da9dfcf28238b6fe949cca171088e45f33bcc3e420b75924878d3d202e684b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/asl-recognition-0003/FP16/asl-recognition-0003.xml
   - name: FP16/asl-recognition-0003.bin
     size: 8257622
     sha256: a2590f1e5d65480d0dc439b717af8bdf9d5a2c270c716ea6f269d558326dc8af
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/asl-recognition-0003/FP16/asl-recognition-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/asl-recognition-0003/FP16/asl-recognition-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002-decoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002-decoder/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-decoder.xml
-    size: 120889
-    sha256: b2a9981db70a05c997e577c9b9ffb4f7c6bb12f35f3896509f2cb06d68679e43
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
+    size: 120891
+    sha256: 94efc539bd05250ce27b5a9ed14463a415d8455fcf0b7bd13e027d1ebebd5ebf
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
   - name: FP32/driver-action-recognition-adas-0002-decoder.bin
     size: 29436428
     sha256: 80deefba45d9b002c9780c9d9bcd2285b7be3f6b2ca319e2705898e725bd57c4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
   - name: FP16/driver-action-recognition-adas-0002-decoder.xml
-    size: 120849
-    sha256: 781018424e5648cfeaa4ca4df618dcc72229cc542d81e1a12ede34738e0fd880
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
+    size: 120851
+    sha256: 76d2fee0612c9bdb14cbbc3e8345e63cea4d09824bc6dee0b6393a82dd9effe2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
   - name: FP16/driver-action-recognition-adas-0002-decoder.bin
     size: 14718330
     sha256: 1a6a163af7f634d8efff026855971445056fa6bff1da48e44cd35b1ea6c4cb43
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002-encoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002-encoder/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-encoder.xml
-    size: 128344
-    sha256: 0977cdfa7ad27481537064551e19afd980807ef083ede081378c1771a7659ce4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
+    size: 128346
+    sha256: 067e4067c883c6fcd5a432e3c6fb3b405f7b0d1b5857d64deaba3a70146ff2b4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
   - name: FP32/driver-action-recognition-adas-0002-encoder.bin
     size: 11450776
     sha256: 12bf9bfebc74719d42bc2190bd00064ecf41b820df891040fcaa57f5eb4cffcb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
   - name: FP16/driver-action-recognition-adas-0002-encoder.xml
-    size: 128284
-    sha256: 99d4942a8add95e350ba4d464e3d91353d8106d3aa3835fb0a39c4c2efb34bf2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
+    size: 128282
+    sha256: 60694a0b9f7386590d6d395f4d0f4700c2193fb01ed0cfe7e3b8cb7a041d3652
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
   - name: FP16/driver-action-recognition-adas-0002-encoder.bin
     size: 5725388
     sha256: 165b34437d1c73bf5adf356ddc18fb6bb11b4d99d8db0921dd25894d886535ef
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/emotions-recognition-retail-0003/model.yml
+++ b/models/intel/emotions-recognition-retail-0003/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/emotions-recognition-retail-0003.xml
-    size: 37679
-    sha256: 26c0f66ee047b22190260982451dc3e8a7c2f14f5dc45274c98a3edf8d928c5e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
+    size: 37686
+    sha256: 702e374b7dc11b369c13c2f9c5fc638c617d19a9c625eba5fdac9d190fddba41
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
   - name: FP32/emotions-recognition-retail-0003.bin
     size: 9930028
     sha256: bcb9b1a910fa3cd18a638bb1dbb0597c4ef7a080d1b83008c8e8c2c3c42b99dd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
   - name: FP16/emotions-recognition-retail-0003.xml
-    size: 37658
-    sha256: 8a746c263b250c9d820067d2833938e03ba66a621e60fca33cd3c3909c9b43d3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
+    size: 37662
+    sha256: 76ba0e171289711e1d1b8418e2bdebf4940485c6c2e0a75d2572ef7dbcee762f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
   - name: FP16/emotions-recognition-retail-0003.bin
     size: 4965014
     sha256: e62fb4b819b3b3ad8aafcd308d4353db2f164a1a31d78de6cf5970837aeb6f7b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
   - name: FP32-INT8/emotions-recognition-retail-0003.xml
-    size: 102859
-    sha256: 39527b1453600fd3ed32f7e3d3748a6a7bc82c8ad6780436dc23cc873c90571d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.xml
+    size: 102858
+    sha256: 0b739388e9341f083df2d9b23506a13c234782d53e08f2e8051c0189e6e926ba
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.xml
   - name: FP32-INT8/emotions-recognition-retail-0003.bin
     size: 9947612
     sha256: ff8ee9cee69cdc7043ec94522459770dfda865ff979a0c8beb73d7515f4a1df2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/emotions-recognition-retail-0003/FP32-INT8/emotions-recognition-retail-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-adas-0001/model.yml
+++ b/models/intel/face-detection-adas-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/face-detection-adas-0001.xml
-    size: 232996
-    sha256: 425237529f865b34830969a1f6980ee69f96b952ec9b94479136609119326a61
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
+    size: 232998
+    sha256: 62b4bf7dead77e16a47428b541aa4f3c506cdf3c7e31a317aa75771dd907557c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
   - name: FP32/face-detection-adas-0001.bin
     size: 4212072
     sha256: 85a9334e031289692884e2aefbcb4ca401b003a3f25ff4dd0e669ba32f98cc0b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
   - name: FP16/face-detection-adas-0001.xml
-    size: 232965
-    sha256: e7c599c81b75468fda871205365bf03157adb1bf28dfaf3e7261d99574cd0ea4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
+    size: 232967
+    sha256: c0b9d34eba1fe6c76755fada4dc65634068eddf343a219b501ac71439348eac1
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
   - name: FP16/face-detection-adas-0001.bin
     size: 2106088
     sha256: df0f5799d801c6afb355d1c4771693c782efbb58d2eb2238982eac8fe84bc821
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
   - name: FP32-INT8/face-detection-adas-0001.xml
     size: 503962
-    sha256: e2cc810b7e87cc9964ebe279b4f13218b4e4cf0128e8755bf26f0fbf3c1ab2ac
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.xml
+    sha256: 8959f287e3caf098948b2faee40d67e019c4b794948476fcdc8a28e58cb79125
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.xml
   - name: FP32-INT8/face-detection-adas-0001.bin
     size: 4291532
     sha256: d3ffb0da33361253d4027def5acddf104a6919c920582f084974a4f9d8529ffd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-0001/FP32-INT8/face-detection-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-adas-binary-0001/model.yml
+++ b/models/intel/face-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/face-detection-adas-binary-0001.xml
     size: 116647
     sha256: fde8c465a5e3f3425fb567d31b9591ff8be589930c8488639f8feddf7f0301f2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.xml
   - name: FP32-INT1/face-detection-adas-binary-0001.bin
     size: 1840444
     sha256: 0e0742b61fb924e937a8974da8a2e15cc6afc15630afa3f220676ee7a3a99700
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0004/model.yml
+++ b/models/intel/face-detection-retail-0004/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/face-detection-retail-0004.xml
-    size: 101813
-    sha256: 0f4b7cffe0c486f561bab67db01f9c43f7ee2a11191f7d43c137cd2d5ff88e9a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
+    size: 101815
+    sha256: 81d31d708214bb4dd4dcef469fa18c611ad5c3f88447ba0986963696cfad8401
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
   - name: FP32/face-detection-retail-0004.bin
     size: 2352984
     sha256: 89349ce12dd21c5263fb302cd3ffd4b73c35ea12ed98aff863d03a2cf3a32464
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
   - name: FP16/face-detection-retail-0004.xml
-    size: 101771
-    sha256: 1d1b7943d6d06069f86b12bbbd3b270832efbc47420bfe2047e20f25edcd88ba
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
+    size: 101773
+    sha256: 7e8e76df3b70ac24967f625f096b1a9c6f2474e099e94210b177be0a5175e521
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
   - name: FP16/face-detection-retail-0004.bin
     size: 1176544
     sha256: ab7def342edab22e69ba1ef4e971983ea4e0f337c43b0a49c7ef3a7627f6cf1a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
   - name: FP32-INT8/face-detection-retail-0004.xml
-    size: 231504
-    sha256: 64f58998397778333237ac34f3535810da337242e02cc1e310154529b583de4a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.xml
+    size: 231496
+    sha256: 4bac1bae22ab8f34c15a7504bd97ce3e57a71a5b63ec08435a1bdf180b38ab18
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.xml
   - name: FP32-INT8/face-detection-retail-0004.bin
     size: 2372492
     sha256: f696f0651da3cf3b07915356fa6f7332dde671ac51b26e3be8209df3d7f7e5e0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0004/FP32-INT8/face-detection-retail-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0005/model.yml
+++ b/models/intel/face-detection-retail-0005/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/face-detection-retail-0005.xml
-    size: 145894
-    sha256: 7f8b8b477e83186e64b90b671ecc55010404710294daebb210019e0c802f0e51
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
+    size: 145896
+    sha256: 2a105498942571686ac856a6dcbe9ef33b54039d69bb861f5d3a98b58bbef016
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
   - name: FP32/face-detection-retail-0005.bin
     size: 4083132
     sha256: bc174f03f2314bdbb7e1abfb5136ccb34507d8225f87b040c5a77493f1a6c307
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
   - name: FP16/face-detection-retail-0005.xml
-    size: 145813
-    sha256: 3249940f7de11e2d5b36ed47fdf632ef52e50c15e6c025f84cb834b77c20411a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
+    size: 145815
+    sha256: 72732d512f311ab1fc96d76c5caaf253e84a944fb0899fc5bf3e4cdbebf2f827
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
   - name: FP16/face-detection-retail-0005.bin
     size: 2041618
     sha256: fef3746455eec3d1e69730b556809a225a4f714b6bc0b4bacfe5c7bb1a944105
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
   - name: FP32-INT8/face-detection-retail-0005.xml
     size: 414518
-    sha256: ab7f8be6489e8d3c02229d584fde3e4caa405d8147fd2f293f5455f627568d16
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.xml
+    sha256: bfe8445ef8005454f9d2d9d5857c0e9de37c3e9dd474d6fb8882a32e2461e138
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.xml
   - name: FP32-INT8/face-detection-retail-0005.bin
     size: 4214360
     sha256: 0525d556261936e710d8b540f540718869e36c2e7347ee111dd68c259f6e5d54
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-detection-retail-0005/FP32-INT8/face-detection-retail-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-reidentification-retail-0095/model.yml
+++ b/models/intel/face-reidentification-retail-0095/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: face_recognition
 files:
   - name: FP32/face-reidentification-retail-0095.xml
-    size: 225830
-    sha256: 6c89104cbb43cc7506039a83283d957cfccfb5670524a71898855f3ab1b7d516
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
+    size: 225832
+    sha256: 3d0c0bebecb1d138dff373124d63e9baaa97b0259992f8741eb581d50c43b156
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
   - name: FP32/face-reidentification-retail-0095.bin
     size: 4427256
     sha256: 03836a6a1d03828322491b0608a579b1c47e5097d355c489b5b8aaf5fce1ef48
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
   - name: FP16/face-reidentification-retail-0095.xml
-    size: 225721
-    sha256: a9f24e50aee183a892646aa12ff727ba1fbd0807e73b5eade9925c9747713837
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
+    size: 225728
+    sha256: b8677b046dacd91a9ea0dfe388a7d58701fc09dfd8388716342da406078633b0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
   - name: FP16/face-reidentification-retail-0095.bin
     size: 2213724
     sha256: c2f8a7b9268e5b5236574d6fda2216df43c03acaa39c078848a98fbb707ae0a3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
   - name: FP32-INT8/face-reidentification-retail-0095.xml
     size: 643466
-    sha256: ad70c2724fabf4e33820fc30ee0362c1a61148f7df44c525700d9eab0f3c07ca
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.xml
+    sha256: 6814d50c0ef1339d28447ffdd47335540a8d910bc8494c6afc185983f34bd466
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.xml
   - name: FP32-INT8/face-reidentification-retail-0095.bin
     size: 4551656
     sha256: eaae8881109a2dab91fb7fddc73052378b015d6f3aa61b1c772eca21f87e4741
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/face-reidentification-retail-0095/FP32-INT8/face-reidentification-retail-0095.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/facial-landmarks-35-adas-0002/model.yml
+++ b/models/intel/facial-landmarks-35-adas-0002/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/facial-landmarks-35-adas-0002.xml
-    size: 237137
-    sha256: 1e9d78083ce30543879921d687ced55abd9cf8b7f3c5561967eb6d619b3a1075
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
+    size: 237139
+    sha256: 4cb90657a60311184f3505ef973563180729bb7e8d5a2f6a42f9109c1af7bfdb
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
   - name: FP32/facial-landmarks-35-adas-0002.bin
     size: 18381152
     sha256: bd41c25201c2ea688a75549c11b9e10aa98e51dcc5a6dd783e84cdcf55a1011e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
   - name: FP16/facial-landmarks-35-adas-0002.xml
-    size: 237000
-    sha256: 6f2dbe79c171cac9af14194f1cab8efbc0f27f0c42e21b8b32d9dac2970e47c6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
+    size: 237002
+    sha256: 702d476efcab1e89519ff14b76812c61cd5123f86f5fc343512fa416a9a94e27
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
   - name: FP16/facial-landmarks-35-adas-0002.bin
     size: 9190584
     sha256: 88a2064849da0e6a31557f489ca4d652aa99e5a9676da0c5c857ee5d8cc26fe4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
   - name: FP32-INT8/facial-landmarks-35-adas-0002.xml
     size: 588492
-    sha256: 2450458b5c2fafcb2cd29a96e0bc43e622966bd8fe718017e6a4ad4da36a50de
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.xml
+    sha256: d41ba7372ca2db93bd269db32567022109d3e2a9b7aed3da0ef1e8e021f95be2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.xml
   - name: FP32-INT8/facial-landmarks-35-adas-0002.bin
     size: 18441156
     sha256: f81ebf7c25f30138c2fa44530f51f516783ea790c5b6cacbaa5b31d95c73cbb7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/facial-landmarks-35-adas-0002/FP32-INT8/facial-landmarks-35-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/gaze-estimation-adas-0002/model.yml
+++ b/models/intel/gaze-estimation-adas-0002/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/gaze-estimation-adas-0002.xml
-    size: 63634
-    sha256: d338f9c0340c05c94ab4f4eba5f03651c07f1bb7a7f602ae1ceaaa934ba69340
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
+    size: 63632
+    sha256: c676d6d02a128a7496ea8c93d15ffe10697e4171e64d164f4e90e659a2dbea6b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
   - name: FP32/gaze-estimation-adas-0002.bin
     size: 7529308
     sha256: df935569980ab2654c46463fccb0ecc9ddd90423dcee85b3f933aa375baa15cf
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
   - name: FP16/gaze-estimation-adas-0002.xml
-    size: 63589
-    sha256: b7495c85b498bfc9ebfc4a77753e5c3b6bab0572ac926d9868abaca67eb7a20b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
+    size: 63591
+    sha256: daba62fae98a3719b8c95e5c821287ff0bb43b99d4c52e45e2615f6c88ffa67c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
   - name: FP16/gaze-estimation-adas-0002.bin
     size: 3764670
     sha256: 03fa9ec80b6edf2ff6bfe5208e1fa13f17be534b80461de7e91b70f0ec1bcf85
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
   - name: FP32-INT8/gaze-estimation-adas-0002.xml
     size: 142699
-    sha256: 5ffe720fc36ff2f079cb937ce4949ba6046fc6944b2064077e61eab089ecd4a9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.xml
+    sha256: 1a2a07f51c29e6b2282e183baf3820fe434a8f009cb71bb274fdb5e5d21c4ed6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.xml
   - name: FP32-INT8/gaze-estimation-adas-0002.bin
     size: 7542172
     sha256: 0254e6bacc23912ba647a626ebe9e4562e8b824ab157442714dbf2e3d13d4996
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/gaze-estimation-adas-0002/FP32-INT8/gaze-estimation-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/handwritten-score-recognition-0003/model.yml
+++ b/models/intel/handwritten-score-recognition-0003/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/handwritten-score-recognition-0003.xml
-    size: 96645
-    sha256: 0c093abc57d9757e349839aa35d1427d48a0afa6aa62ece11f5c2a8084246e20
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
+    size: 80600
+    sha256: 2136bb229ad044d354dc03591b35462989d92ff7716fb1cf30ba83748d162c5a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
   - name: FP32/handwritten-score-recognition-0003.bin
-    size: 41121968
-    sha256: 7066eae3cf926dcddcdc8564ebd36342139202db38f80c40590c8018d9132d22
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
+    size: 41121956
+    sha256: 55350eecb10ea7c95b495a44dcd78b8287e124abed4689956aea23bff062b8ff
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
   - name: FP16/handwritten-score-recognition-0003.xml
-    size: 96620
-    sha256: ea0fab2c94bcc91b0d02193ed5932ae3733b59de9322b5aed1cca46e194227cb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
+    size: 80575
+    sha256: 287586935587d49032a94322f345fc36f356c1b34b3af2b87ba1da23b08b5427
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
   - name: FP16/handwritten-score-recognition-0003.bin
-    size: 20561040
-    sha256: 253c042f74ff3343f7140b95b8dcdaed39512136cd0955bd8d44a953cd16ca86
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
+    size: 20561030
+    sha256: b19f78f990bbfd7d86c52c075a094a18578de3243b5d531692bf8bd9afd4d9f4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
   - name: FP32-INT8/handwritten-score-recognition-0003.xml
-    size: 130751
-    sha256: b7fb2ca7c8a0b90f44fe416b3b55ee01c65981b2fbe1993f38a4cc34609928f9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.xml
+    size: 114475
+    sha256: 88c6c1bdaa04ac926ef851d4284543a0ba71334e0fe573a3ca314a967d139476
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.xml
   - name: FP32-INT8/handwritten-score-recognition-0003.bin
-    size: 41140556
-    sha256: bec80fa6fd3ec3d64922c757d550f012c5ea24846396afb4073d3f4ce4e607b5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.bin
+    size: 41140544
+    sha256: c0bb0af31e9657fa36f7ed9094b8ef9c2fb0f1d03576a2ebe6751ba3e072622d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/handwritten-score-recognition-0003/FP32-INT8/handwritten-score-recognition-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/head-pose-estimation-adas-0001/model.yml
+++ b/models/intel/head-pose-estimation-adas-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: head_pose_estimation
 files:
   - name: FP32/head-pose-estimation-adas-0001.xml
-    size: 50625
-    sha256: a5040b8f12e43cc89d66578c1ec4b31d519d5e0cc8b2df9b2268e764184d2c2c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
+    size: 50622
+    sha256: 5e0994e906aff30241441e0910e3527ca6d8ca0d756457adb34e53d418016cc7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
   - name: FP32/head-pose-estimation-adas-0001.bin
     size: 7647604
     sha256: a9110b175f7cb082049d5fcd4c48825e9c00688901aecb22fa70c2535aff282c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
   - name: FP16/head-pose-estimation-adas-0001.xml
-    size: 50609
-    sha256: 48d4f67d83439165422d73d7aa9d10bac724372c2fef5ddc659179a27f2abdf5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
+    size: 50610
+    sha256: f98f34ff5b2382c7c9185ac3aa8a329db268c9f9d93eb40c385f5812e1ef3913
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
   - name: FP16/head-pose-estimation-adas-0001.bin
     size: 3823810
     sha256: e37b71a654656a78d4014ae8e46baab83a9c06a41df5f5c5122e9bbee46a63f2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
   - name: FP32-INT8/head-pose-estimation-adas-0001.xml
-    size: 81654
-    sha256: a6eaa94cb3a88efb2121a56a18d421abe44b9ffe7925a0ff92eb1fc037786170
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.xml
+    size: 81656
+    sha256: c5697706a3cf57386e626bb5c666c737373a18379e20f0ae135fa5eb4404a1be
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.xml
   - name: FP32-INT8/head-pose-estimation-adas-0001.bin
     size: 7657904
     sha256: 460e2160619fce6e9986e99130c55468e95e0364f7907fb339555807029da296
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/head-pose-estimation-adas-0001/FP32-INT8/head-pose-estimation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/human-pose-estimation-0001/model.yml
+++ b/models/intel/human-pose-estimation-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: human_pose_estimation
 files:
   - name: FP32/human-pose-estimation-0001.xml
-    size: 143776
-    sha256: 00909cbe5a4a005f8b3364fcecddde3eb858a6b105c4a49ced603a6c706647e2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
+    size: 143782
+    sha256: 4d2cc5d3a8c395affa74ae640a63ba9bae9bd5871527d65f62a87cc5b40831e9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
   - name: FP32/human-pose-estimation-0001.bin
     size: 16394712
     sha256: 1cd32cb5f9f4633b8ee1451144f749ddd75038c4c5fe862e704e489908b79a78
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
   - name: FP16/human-pose-estimation-0001.xml
-    size: 143708
-    sha256: 6650867461eeaa67cabdcb6bc7543c18cfdb791ffc9f92bfaf2f84f846b0eb3a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
+    size: 143706
+    sha256: 75bda095e6fa1b1c118e085c4e5f4be9d9d9db512578fd6ec57b3113d5b42dae
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
   - name: FP16/human-pose-estimation-0001.bin
     size: 8197356
     sha256: c1c828d5d1ea2b03035692a8600f06d787fe1a20e79dac159c4293ed7063a382
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
   - name: FP32-INT8/human-pose-estimation-0001.xml
-    size: 408108
-    sha256: 182bc988974f62451159bafff61eb220bb72e54041ba18bfb6f8f5539d0ede14
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.xml
+    size: 408100
+    sha256: 6e22b77c4e5f2c39bb14603c3bfa2d902210a3fdb3fe89443eab5fb149c3a470
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.xml
   - name: FP32-INT8/human-pose-estimation-0001.bin
     size: 16513820
     sha256: 482635ee949716049bd7dd5a69ab66a6d5f29a5cc86598c0369035be2d1fa274
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/human-pose-estimation-0001/FP32-INT8/human-pose-estimation-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/image-retrieval-0001/model.yml
+++ b/models/intel/image-retrieval-0001/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/image-retrieval-0001.xml
-    size: 139943
-    sha256: c83121052a5b11ffab220110a21c39d149915013aa6b11d778c75bdb7cf4b91b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32/image-retrieval-0001.xml
+    size: 139941
+    sha256: 9ccf302bde086b4173f6214fce186c50c59f45f0d90e42cdeb887bdba5d69320
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/image-retrieval-0001/FP32/image-retrieval-0001.xml
   - name: FP32/image-retrieval-0001.bin
     size: 10139176
     sha256: 337b7602546e34877bdaba7b7a873698dd1ca46265ef8c0c83b2531f360293f8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/image-retrieval-0001/FP32/image-retrieval-0001.bin
   - name: FP16/image-retrieval-0001.xml
-    size: 139873
-    sha256: e79ee524141620d809d6ad4ab4a90357767b9f4ab473cf96c9835cb3228eaf5b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP16/image-retrieval-0001.xml
+    size: 139875
+    sha256: bdbd7fb3700cf8e44853c03bd489cfb9b5ef3fd50828ce5cace938fbebf0218e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/image-retrieval-0001/FP16/image-retrieval-0001.xml
   - name: FP16/image-retrieval-0001.bin
     size: 5069656
     sha256: 638931867ab133c8c6b0fa659a19b12d5b9ac6ce52f72b961f1d35e8ff812edd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP16/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/image-retrieval-0001/FP16/image-retrieval-0001.bin
   - name: FP32-INT8/image-retrieval-0001.xml
-    size: 402534
-    sha256: 2e3a39c6323ca92824ea9e0f056b1a9d2e3c2a41ba79b12c14ebac25fe2ca05a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32-INT8/image-retrieval-0001.xml
+    size: 402526
+    sha256: 506c619a98d1de256a5a179cd7d086a9cd340de3ef045acba9dfa4cf2b8863d8
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/image-retrieval-0001/FP32-INT8/image-retrieval-0001.xml
   - name: FP32-INT8/image-retrieval-0001.bin
     size: 10316580
     sha256: 8247914522e23c4ca8c291f59d6cb4d29dc780121fbc79eb8e02052eeb1796fc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/image-retrieval-0001/FP32-INT8/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/image-retrieval-0001/FP32-INT8/image-retrieval-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0010/model.yml
+++ b/models/intel/instance-segmentation-security-0010/model.yml
@@ -19,20 +19,20 @@ description: >-
 task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0010.xml
-    size: 486379
-    sha256: 55ebb92d791ed3a2dfff86afb0b7e49e645ee82dd20bbabf688b6e72aa8e6e3e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.xml
+    size: 486381
+    sha256: f7acf2406403565dcd021bdab3746218462ef2afaabdea3be3a9669dac395c97
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.xml
   - name: FP32/instance-segmentation-security-0010.bin
     size: 688762056
     sha256: 030bb05fead246de1380b79d2d07674210f0bfab101a10d4827dd10b6abfdf4b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.bin
   - name: FP16/instance-segmentation-security-0010.xml
-    size: 486165
-    sha256: f868338d5b3351415d1491c27ffc3b3d71bf5d13e9d3723934f7d87e44aea4c6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.xml
+    size: 486167
+    sha256: 706e59c4d68b5d1e81338c9fd3856bb7d21e781f959dc97beca35904d8db7afa
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.xml
   - name: FP16/instance-segmentation-security-0010.bin
     size: 344381242
     sha256: 8b8e17a8faeae41258f9fc3e758d987152a817c820aa82e1fd9bdbc2cf5db248
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0050/model.yml
+++ b/models/intel/instance-segmentation-security-0050/model.yml
@@ -18,20 +18,28 @@ description: >-
 task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0050.xml
-    size: 270494
-    sha256: e89cc0d36e75eb841e1411d7bacf85bce6a74a459f1e669cf7b74e517b469d8c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.xml
+    size: 270496
+    sha256: 866ce49eb932bd070e68e8cf229c38e1d378612f4f1bc835ae65af5a3715416b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.xml
   - name: FP32/instance-segmentation-security-0050.bin
     size: 121497384
     sha256: 763f3503dc5f5fabd2021fa915783827929eb6b75555ddd95307e2226ec9325b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.bin
   - name: FP16/instance-segmentation-security-0050.xml
-    size: 270385
-    sha256: 241b3a173be16620ff702a9cca42c9f1af36cb1a58de7c324b83bc3af5b0d81d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.xml
+    size: 270387
+    sha256: 3b23caae65f36c53155472b47a9623e0b2892de4ee4fb4b82eb1a732818d3f57
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.xml
   - name: FP16/instance-segmentation-security-0050.bin
     size: 60748730
     sha256: 07a471da43c24d183feb048cf823e87e8add9952f43ad3da97b9425b38906e4b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.bin
+  - name: FP32-INT8/instance-segmentation-security-0050.xml
+    size: 676861
+    sha256: 17ec5f1073fe347bac0cb63e599efee7ae93dfd95dd30d98bd237927a6dd23c8
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0050/FP32-INT8/instance-segmentation-security-0050.xml
+  - name: FP32-INT8/instance-segmentation-security-0050.bin
+    size: 121755968
+    sha256: f808b09716132d5670ee213a6f1d3750e3af8bfedbc8e1ed4400ba9e299dd035
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0050/FP32-INT8/instance-segmentation-security-0050.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0083/model.yml
+++ b/models/intel/instance-segmentation-security-0083/model.yml
@@ -18,20 +18,28 @@ description: >-
 task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0083.xml
-    size: 512548
-    sha256: 02bd492c2463bf0c9fc37a498fe732ff13cde99e3fe13716dd41543a9e312d37
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.xml
+    size: 512555
+    sha256: 81e9d91b096b0fed5613f02a397e3fb6e0b7605cdaff0ab9c4e24431c9b07bca
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.xml
   - name: FP32/instance-segmentation-security-0083.bin
     size: 564274472
     sha256: 1305d27772c2fc16d84f78e3c6609eb065e106656403d1f0765270b334e7f1db
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.bin
   - name: FP16/instance-segmentation-security-0083.xml
-    size: 512345
-    sha256: 84c5dd774b59f9f1ff3af990a0a2804205bf57a3294fb77c6f768131768d1b40
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.xml
+    size: 512347
+    sha256: 7371458aa674aff7e7f9ad0cb96a40b35b721576a0e3aec85b36b4fc1e8789ce
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.xml
   - name: FP16/instance-segmentation-security-0083.bin
     size: 282137274
     sha256: ae7bf1b3f18d3333df32bb9c5a09cbe7738396d6473fdd050508d4f38356c64f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.bin
+  - name: FP32-INT8/instance-segmentation-security-0083.xml
+    size: 1392902
+    sha256: ce4df508b7a9a2102e983f73ffb2e5750c8b76c197b9af668669183251c06de9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0083/FP32-INT8/instance-segmentation-security-0083.xml
+  - name: FP32-INT8/instance-segmentation-security-0083.bin
+    size: 565514024
+    sha256: 62f1b57b33e4386c44ddda8ab03d2cca30e30887ca354a2a3fd13dd157ff3f4d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/instance-segmentation-security-0083/FP32-INT8/instance-segmentation-security-0083.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/landmarks-regression-retail-0009/model.yml
+++ b/models/intel/landmarks-regression-retail-0009/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/landmarks-regression-retail-0009.xml
-    size: 42709
-    sha256: a2e7153c88da9db490bc6729841843de45ac85d34d2e4b0b353218a6a124ba0f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
+    size: 42715
+    sha256: ef7aa8f3f2b9730df8612fc7221bd7beb423b6001202a452723efd86993358a3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
   - name: FP32/landmarks-regression-retail-0009.bin
     size: 762464
     sha256: 46795837d35e8199b7c5b57e1f76297827bf516a150c0d5643197d8c325f1dbc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
   - name: FP16/landmarks-regression-retail-0009.xml
-    size: 42690
-    sha256: a442963ed3638e5e37bac5257f93ee4d91a168c76963a3d6b6aaa94fd8b89182
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
+    size: 42692
+    sha256: 01a0c7b4bbb0a12919351d78d551bbbe36a1fa62812c0f6ee1f49d7cc7bc10c0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
   - name: FP16/landmarks-regression-retail-0009.bin
     size: 381248
     sha256: 973b13e64b3576f754a690266b069438b531bc657233d09d7b382ca36e6cf1e4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
   - name: FP32-INT8/landmarks-regression-retail-0009.xml
     size: 78229
-    sha256: fcac29d5735cae8c84835655098a6c472c60557cda768ba713c8bab4516dbd60
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.xml
+    sha256: 1bf202dd4ea57ebc17762ea3173e1c482c1c8efb2aeeec13fa073429bfd766a2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.xml
   - name: FP32-INT8/landmarks-regression-retail-0009.bin
     size: 767188
     sha256: 2a4bbc1f41d80e3ad2125d9297825d49379647ee2f61d982962135d1a146ecb7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/landmarks-regression-retail-0009/FP32-INT8/landmarks-regression-retail-0009.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/license-plate-recognition-barrier-0001/model.yml
+++ b/models/intel/license-plate-recognition-barrier-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/license-plate-recognition-barrier-0001.xml
-    size: 48902
-    sha256: faba913a941346054c1de86910d4b9ecd2d3263adbd77b84256d590887e6c349
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
+    size: 48904
+    sha256: 1440ca7fe1057204c53f977a14b47b51750fd2a6b43b82f9a22720837aca7228
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
   - name: FP32/license-plate-recognition-barrier-0001.bin
     size: 4871940
     sha256: 3ef022a17b5f303c676c9c3a23669d09a257a54acdb894b6db295acc141cc4dd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
   - name: FP16/license-plate-recognition-barrier-0001.xml
-    size: 48883
-    sha256: 44d2ce4933b1855adb06e497e51a62a0a1ea4e46fb8c10f4fc6dbfa41a1bb812
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
+    size: 48885
+    sha256: 7af8d4457e30826bf292f7b4058546cac6f498afa46cf1ae64b923b93f0dc739
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
   - name: FP16/license-plate-recognition-barrier-0001.bin
     size: 2436038
     sha256: 184d9312c71b660639898edb46b85a99477e8d6a756b2b611e71a3afad5f25c1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
   - name: FP32-INT8/license-plate-recognition-barrier-0001.xml
     size: 105464
-    sha256: 9c460017d4f9e72fb13c49b493e7d8f3bfbe02942635611856a7c686dbb1f33c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.xml
+    sha256: 77a4a1eed9f54439cbddffb5e5f0068327af530e023135b273bff8b4b43c81f9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.xml
   - name: FP32-INT8/license-plate-recognition-barrier-0001.bin
     size: 4882552
     sha256: 309f08580e1284a702c4d661ffc64cb370dfeb66622724b8dfb1e2ebee646720
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/license-plate-recognition-barrier-0001/FP32-INT8/license-plate-recognition-barrier-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
+++ b/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.xml
-    size: 245532
-    sha256: 08211608229fa2d3c1804fbbe3dfd6b4c6053b66a15a09587d459f0d55c7f713
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
+    size: 245537
+    sha256: 3fd1c0f8b4a5867c9c7e6fd1be0ec8c71f1f905fb874b529c419980bb436c60a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 6598568
     sha256: 9b8288591d18c3e3daa8bc48f9f2f14ecb1bf83032fe6439d6bc7b43f9f1a4e9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.xml
-    size: 245492
-    sha256: 4a63ed9cad1ba87f7d0642fae25b8c220daca4787c93fed361fe4afc1f53f8cc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
+    size: 245487
+    sha256: 6f24dfc89e0656a544c9a2cd040ca592fbda649328885193aa5eaa57d20d1d6f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 3299336
     sha256: 3f9739b91277bc916f29b17d043115c6669e113e5d60d61589063d8054c40d7d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
     size: 478288
-    sha256: 56f865a35a4e4ba06530d25684095eb8f6bfb1209884267a695c6fdde2995741
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
+    sha256: 9f7c745d9f808018f02d435bb56a9eeadc26789fc37396032c215b97491a6e43
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 6693280
     sha256: 6157784eebd2a2e08bc5b0076f8d11868fbc096a0e60f5e34d72c8dd3ed32bb5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP32-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-detection-adas-0002/model.yml
+++ b/models/intel/pedestrian-detection-adas-0002/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/pedestrian-detection-adas-0002.xml
-    size: 245415
-    sha256: 0de0a708706119034d3701ce6952c1a57565accc87224dce3ec7199f6e182dfd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
+    size: 245421
+    sha256: 69dc36c52afc27f2ffa752e28e1710ca7653b3b7abda6e25c1fde7eb0767b480
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
   - name: FP32/pedestrian-detection-adas-0002.bin
     size: 4660248
     sha256: de3e3b12eb631d0fa67db14d7cd3c3aaea7edc78e460485dcdae3a447f4d4288
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
   - name: FP16/pedestrian-detection-adas-0002.xml
-    size: 245366
-    sha256: ebddb83288206aa6b54a3fae16da3dcdbf48d2ec3e94251a3e46f975bbcd2737
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
+    size: 245369
+    sha256: 233519498b393adc8506bd80dd09d19f89e202b544565e7821a7fdff48bfa306
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
   - name: FP16/pedestrian-detection-adas-0002.bin
     size: 2330176
     sha256: 693753b7466da913b537016b31e3012f8ce6a885ac0897e3986eeca66d4ef8e6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
   - name: FP32-INT8/pedestrian-detection-adas-0002.xml
     size: 478047
-    sha256: 51e0233c814eb6f4b8b99dbc6e4bbc38a50c41201cbb9e0fc796f1fceb788054
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.xml
+    sha256: d04b25d198b5a007d5301fa60d2b67634beaa30886b11c03ddc76df8506aed9a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.xml
   - name: FP32-INT8/pedestrian-detection-adas-0002.bin
     size: 4740408
     sha256: 38c3e849bd872a604a1374dffdb18520718c3c2d16fe13ce07642a986f68a273
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-0002/FP32-INT8/pedestrian-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-detection-adas-binary-0001/model.yml
+++ b/models/intel/pedestrian-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/pedestrian-detection-adas-binary-0001.xml
     size: 114635
     sha256: e64e7ce32c87e1c698b50abb8f2cf1d96c7651d45fc20bac09c417e046afa7f4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.xml
   - name: FP32-INT1/pedestrian-detection-adas-binary-0001.bin
     size: 2338004
     sha256: 7c2761ca3859ef55a80d9ed924225df7ba363fcb151e4ec2f7d1061b70bdb374
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-attributes-recognition-crossroad-0230/model.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0230/model.yml
@@ -18,28 +18,20 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-attributes-recognition-crossroad-0230.xml
-    size: 173334
-    sha256: 8b76a741eff4235771189391233b4d8ecb9200a66056d878bfa2e47df2abba88
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
+    size: 173336
+    sha256: bd911ccf0926eb48aae0c75ba385fd4783e6ad1680b80135b274a731e99b9c67
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
   - name: FP32/person-attributes-recognition-crossroad-0230.bin
     size: 2939232
     sha256: 01432edde876a4be8c7ef87801b7c45a09a442daec06551fd2db7c81f1d76407
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
   - name: FP16/person-attributes-recognition-crossroad-0230.xml
-    size: 173249
-    sha256: 8da44a3585baa57dcf948a56bf757467c7ceb6202e57bb7bc5dcf9876b027c97
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
+    size: 173251
+    sha256: 20f6e12b608e8910bebf5e229b943fb1356d2f2a55265cda04f2a5a7d7afbb58
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
   - name: FP16/person-attributes-recognition-crossroad-0230.bin
     size: 1469624
     sha256: 61327cb5748a234c0320456e83dc8e42756c3a9856f15580a111493da47366fc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
-  - name: FP32-INT8/person-attributes-recognition-crossroad-0230.xml
-    size: 469747
-    sha256: 3cc456644788a8412ab660e7553c6e5eecd95cdf1bd6c9ef558e032f9f4831c3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.xml
-  - name: FP32-INT8/person-attributes-recognition-crossroad-0230.bin
-    size: 2967604
-    sha256: 40cd74f6b0f653d041750825990b2a2620202850f2d40754ae3229ee79c4bf33
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-attributes-recognition-crossroad-0230/FP32-INT8/person-attributes-recognition-crossroad-0230.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0005/model.yml
+++ b/models/intel/person-detection-action-recognition-0005/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0005.xml
-    size: 651604
-    sha256: f8e95345d1d532dc7a7765e7b3a74765d343b223276a6acb0248320976dabe59
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
+    size: 651605
+    sha256: 7978b641bbc5fb9676ef18e35bec14d3541595b27454c95fab9ede178da0cc06
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
   - name: FP32/person-detection-action-recognition-0005.bin
     size: 7800360
     sha256: 2982e6c2683229a450d674c362cc11abd640dce4e39e95925c7957a28011f147
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
   - name: FP16/person-detection-action-recognition-0005.xml
-    size: 651360
-    sha256: f58a1dc88aefa2a7021a8aa74e48da8633038c09be7e7407914ee4b8e1634268
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
+    size: 651362
+    sha256: 1d01cf1af48403eeb8f503e10416f94461e56dec2b3a038ae3a34da0807760b7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
   - name: FP16/person-detection-action-recognition-0005.bin
     size: 3900234
     sha256: 159f52fdd28bef5a3ef3edd998fe08fd4d51c4a3fb2b9134b82a09f6a252c378
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
   - name: FP32-INT8/person-detection-action-recognition-0005.xml
     size: 1697244
-    sha256: 86f01c4faac1373e6dfa46dbe1a0c40f65da19e7ac6c6093c54ea43f37e6bdc3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.xml
+    sha256: 0f8f73f28ab61f3a0a0ed8abb65ce341278e457647a6636d6ee7a8164b62b320
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.xml
   - name: FP32-INT8/person-detection-action-recognition-0005.bin
     size: 7972512
     sha256: cd8f809d2a6dfe12808a9a49c62fa3501c22fdff2c955961746a3c24e20d7db4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0005/FP32-INT8/person-detection-action-recognition-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0006/model.yml
+++ b/models/intel/person-detection-action-recognition-0006/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0006.xml
-    size: 756045
-    sha256: 9fd43747b5caf9911788b576b382d34e3a38737e83db964b752bc3c2310fab06
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.xml
+    size: 756047
+    sha256: 1ce4f689b91a2f6f7024faa25257c16ba3567e4aa437f3df3855892e1aa0336f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.xml
   - name: FP32/person-detection-action-recognition-0006.bin
     size: 7458352
     sha256: 888d01b994c58baa65ab20b948439620222512ee49d45e6f443f271d7637f603
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.bin
   - name: FP16/person-detection-action-recognition-0006.xml
-    size: 755767
-    sha256: 26a849634e4accd3522709334614a174aaebca55eb06fb9311c0ad8347b6c18d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.xml
+    size: 755769
+    sha256: bb994602aef093f7566c0a0a567f11b1e76180a7f6bd3e67139377e298543394
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.xml
   - name: FP16/person-detection-action-recognition-0006.bin
     size: 3729222
     sha256: 6752e639f4035582f77209a6030cded78ec4869b628ad9cdde1907d8cfd13368
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.bin
   - name: FP32-INT8/person-detection-action-recognition-0006.xml
-    size: 1897672
-    sha256: fc0f32b1b7038ad7ddbb583d50fcef5a132328aa86e304b943e3db2229bedddc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.xml
+    size: 1897659
+    sha256: 3f472adbeba1a9fd9ebaa552c9c07d32e5da32659467c5d6e4f330bfba0b5ddc
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.xml
   - name: FP32-INT8/person-detection-action-recognition-0006.bin
     size: 7652264
     sha256: 6ec864ac04c366c7bcfd77b8548b22d0d8797c4b6ad63bc759f10781aa573e7a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-0006/FP32-INT8/person-detection-action-recognition-0006.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-teacher-0002/model.yml
+++ b/models/intel/person-detection-action-recognition-teacher-0002/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-teacher-0002.xml
-    size: 651612
-    sha256: 4b81fc7c111fa119bdb229cd9e73474d06d649479d73117bee4e1db97ece7af9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
+    size: 651618
+    sha256: 0853dc3856c28ae2058a02db7522f7f5d66c49c82f60ff4b51d1377d5a322484
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
   - name: FP32/person-detection-action-recognition-teacher-0002.bin
     size: 7800360
     sha256: ebe9c7cdca28a408302b3b1f241afdc670abc251bd692c13a3140c78b08b0498
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
   - name: FP16/person-detection-action-recognition-teacher-0002.xml
-    size: 651368
-    sha256: 062b59018dffa6f6c2b27de36e61bcfcfdb2d454aacc666db9b11db107b76910
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
+    size: 651375
+    sha256: 36cd0bd99542386fd15c083e8325c37f920f95173d314d9406fd3ce41ac73df7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
   - name: FP16/person-detection-action-recognition-teacher-0002.bin
     size: 3900234
     sha256: 190e9b71ae02e022c6afe2dc9fb59939066e046234ff35f4ceab6ddfabab7883
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
   - name: FP32-INT8/person-detection-action-recognition-teacher-0002.xml
     size: 1697252
-    sha256: aefa562cc9f34d4546a594004ce9032f3cb40302deeac0d97113fa860038e626
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.xml
+    sha256: 1f363ddd0a09837c06d28b49514db1c81beafb2ba95ea40700a0b26688266d1e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.xml
   - name: FP32-INT8/person-detection-action-recognition-teacher-0002.bin
     size: 7972512
     sha256: 9423a50cb23b265d8862108a7ab88e1536c1b342276d792af56ff3d34d70553d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-action-recognition-teacher-0002/FP32-INT8/person-detection-action-recognition-teacher-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-asl-0001/model.yml
+++ b/models/intel/person-detection-asl-0001/model.yml
@@ -17,12 +17,12 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-asl-0001.xml
-    size: 437553
-    sha256: 097915163ad9af6c1d578ba3dc2899389ea96de3a4a3ab48cf9c14ac8e113f40
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-asl-0001/FP32/person-detection-asl-0001.xml
+    size: 569024
+    sha256: 642f7ee90b171a43c6af110f00a0bf514b275beff7ddebad1837eeae6143f885
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-asl-0001/FP32/person-detection-asl-0001.xml
   - name: FP32/person-detection-asl-0001.bin
-    size: 4026308
-    sha256: 06a95e62010880b9c02d34f1d71da081022ef0a97f91093425284d73d4ccb93d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-asl-0001/FP32/person-detection-asl-0001.bin
+    size: 4026864
+    sha256: d6ee1d8204f84f0f7ed9f7567dabaabad0b9c31db8113bdb5da82bfa66afaee8
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-asl-0001/FP32/person-detection-asl-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-raisinghand-recognition-0001/model.yml
+++ b/models/intel/person-detection-raisinghand-recognition-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-raisinghand-recognition-0001.xml
-    size: 651612
-    sha256: 7aa92bc4d83b04c4ac90adb01c6646993065aa1fed9f6a8afd989ad69a4e1999
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
+    size: 651616
+    sha256: a94101be18b2501395c355c7751750538b62bcff8692bdc7e812382a176f7c78
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
   - name: FP32/person-detection-raisinghand-recognition-0001.bin
     size: 7799848
     sha256: 5183cc9d4d71e208a2cc70db9ea98bf14657d07b2bfafd050aeae9687e4359c4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
   - name: FP16/person-detection-raisinghand-recognition-0001.xml
-    size: 651370
-    sha256: f93f4c5666c90091754a33cb19b84a7907868c54490a07c7c5bc9c26693e33ce
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
+    size: 651372
+    sha256: bae03b3a203b70ccdb39a77342d446642039522e7dae6e6a8b1efeedcf7a8582
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
   - name: FP16/person-detection-raisinghand-recognition-0001.bin
     size: 3899978
     sha256: 601543473374722d45eb56b3aa8f7f250f33e1bb548d63e392332441e97c87d8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
   - name: FP32-INT8/person-detection-raisinghand-recognition-0001.xml
     size: 1697233
-    sha256: 2fd7f01918a9b8742f739ba2180d20e5ce9c4c97ae8924b04f755e2181fd3803
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.xml
+    sha256: 31d964647910358bc31f4ce2a165a6dbce21812997ecb7bb166a8fb75a0f87b1
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.xml
   - name: FP32-INT8/person-detection-raisinghand-recognition-0001.bin
     size: 7971992
     sha256: 7d7e37fb6404d15a9adedbf89f62b7748043c0f7cb98fea907467c9e78609e9d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-raisinghand-recognition-0001/FP32-INT8/person-detection-raisinghand-recognition-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0002/model.yml
+++ b/models/intel/person-detection-retail-0002/model.yml
@@ -17,20 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-retail-0002.xml
-    size: 267908
-    sha256: ece1e74431e697ca5cbc29ee70478256e805a4835d61d858ba469f4ca8399f40
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
+    size: 267910
+    sha256: f320676380eaf3dacfceca934a52ce897889dec6fdcc10e7b99e51dd80912ded
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
   - name: FP32/person-detection-retail-0002.bin
     size: 12976100
     sha256: 8150eb7ea3352abb272276deb3ce64d0414464e9f4bf02739ec4f2770b8acb75
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
   - name: FP16/person-detection-retail-0002.xml
-    size: 267785
-    sha256: a432bc296615f9693d9595eeb432f71a5243785962e52f0dc46a2607a010bbc9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
+    size: 267787
+    sha256: 3f3960a9cc61bb1416e5e362e2133139be76b5db07ddf18b7b776e80cfe140c4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
   - name: FP16/person-detection-retail-0002.bin
     size: 6488130
     sha256: 32008b134ea50eb70a4f97d74562a0a2c542d3c30f19a5d7ef1b57e8615d7039
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
+  - name: FP32-INT8/person-detection-retail-0002.xml
+    size: 694526
+    sha256: 0251fad4e66e14133b9544d4bd9ac3096ff06d45efff3a3a63fe494bb3d37987
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0002/FP32-INT8/person-detection-retail-0002.xml
+  - name: FP32-INT8/person-detection-retail-0002.bin
+    size: 13051624
+    sha256: d700bd305d836b6f136043d71647f5f501edb0cf9251e60c6a25f4f239289403
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0002/FP32-INT8/person-detection-retail-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0013/model.yml
+++ b/models/intel/person-detection-retail-0013/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-retail-0013.xml
-    size: 354259
-    sha256: f89da9c8e4ffb7e923a76fc9d868b948a8323bb28f6f307b0d5e9c1711f3dabe
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
+    size: 354260
+    sha256: d83a9b8a82a9e6fb52c73f63c4ab6e71d57592c8b2068a85f14548df7cef8eae
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
   - name: FP32/person-detection-retail-0013.bin
     size: 2891364
     sha256: 6f09cb7061328942f9d5e9fc81631a4234be66a26daa50cd672d4077ee82ad44
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
   - name: FP16/person-detection-retail-0013.xml
-    size: 354105
-    sha256: f210747a932a580eb5a92c65c08fc6c4297a2f8a959c8ce9b0c8bcdbaf47b857
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
+    size: 354107
+    sha256: 603502ad82af0ee6b0ee9948257aece2599ac2b153df1691b3fe5b0c33fe3a88
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
   - name: FP16/person-detection-retail-0013.bin
     size: 1445736
     sha256: 56eeccbeb3f27144046edacb95b459d60f3930f54051ef5b9e5253923c07b672
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
   - name: FP32-INT8/person-detection-retail-0013.xml
-    size: 931278
-    sha256: b5e2c8981d807f909c2da53670c091b5a17a3ca36498b4d323b82679c3afea88
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.xml
+    size: 931279
+    sha256: 8f7e71c2db19f1f641346ff9cd99553e650b42c00a96c9bbfaf2bcbbd6daa49d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.xml
   - name: FP32-INT8/person-detection-retail-0013.bin
     size: 2969676
     sha256: 523b79294453845934e068f4a906b9bf88b4c70ab705f2137e089439f4555b92
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-detection-retail-0013/FP32-INT8/person-detection-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0031/model.yml
+++ b/models/intel/person-reidentification-retail-0031/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0031.xml
-    size: 136149
-    sha256: ef6d3ffbcd7eb38ccdcfb2f9394d35ee48f00363d60ea16658c4aae08301e6c1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
+    size: 136151
+    sha256: d4b9d09fd6acedb368a3c3dc1e61a1e1500ba51308fe7b03e369bc32810eadc1
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
   - name: FP32/person-reidentification-retail-0031.bin
     size: 1120216
     sha256: 8343531e60f2e36da8311bb768de42b9b03b51d848510da74cb5bf7cbb790823
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.bin
   - name: FP16/person-reidentification-retail-0031.xml
-    size: 136087
-    sha256: d3ce8f1e5680f0aeaf63232ef5be1c7d59d64b87eaafa266d05665724c4914c2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
+    size: 136089
+    sha256: 540e578f5aa87e85b5a25201cc7a6d389762e7f69b062acd88901275d398f592
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
   - name: FP16/person-reidentification-retail-0031.bin
     size: 560124
     sha256: 67e230352812b64ede186c62aaf7369a63fd6f5d8d9a8c98fb7138dac1dfd8bb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.bin
   - name: FP32-INT8/person-reidentification-retail-0031.xml
-    size: 299505
-    sha256: 036e65ac42e7003d7a3c274eb6256914cf6cdf384ec9e4d15a3fc97338e4285c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.xml
+    size: 385535
+    sha256: 9e77f629b83f0f3c09118b5c231d2f99ca806b0a6cc5942640198fd15f20b49e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.xml
   - name: FP32-INT8/person-reidentification-retail-0031.bin
-    size: 1140656
-    sha256: aa4458b93c5f5f25cb9716e0204fb41f4d5cb74da31d2ed61a02dbea810c593c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.bin
+    size: 1153352
+    sha256: 09c24cd2a8d7f0460d3f9b12dbb04c62198a9d1fe27df52ff75ceea72e046dbd
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP32-INT8/person-reidentification-retail-0031.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0103/model.yml
+++ b/models/intel/person-reidentification-retail-0103/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0103.xml
-    size: 429050
-    sha256: d65e2e090af3e81b7b295e400711aa3165ed4b020e38e8c5d03f11016425de0a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.xml
+    size: 429052
+    sha256: 850dbc1d53901c0e36c101fddfb8999647b588f791e55ca021b85963ce0e28e9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.xml
   - name: FP32/person-reidentification-retail-0103.bin
     size: 2365244
     sha256: 816f560505526a0c8d4b66d0629c0bd00f5df201fb76186e860851521bf14f91
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0103/FP32/person-reidentification-retail-0103.bin
   - name: FP16/person-reidentification-retail-0103.xml
-    size: 428744
-    sha256: 4382bcc012223d750f9b95aba73188fc0671cb225e682751ddf08d7cebf7fdd1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.xml
+    size: 428746
+    sha256: 2ffb7e9d60159f2cff0375a83362ce60131692f4835129c7debb3417425e5889
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.xml
   - name: FP16/person-reidentification-retail-0103.bin
     size: 1182656
     sha256: e17a3a323cf771918350d777d9398143e7ad8a6b404eb294b67ee2a837f36cae
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0103/FP16/person-reidentification-retail-0103.bin
   - name: FP32-INT8/person-reidentification-retail-0103.xml
     size: 1215718
-    sha256: 1d10e09c6e95303e3169caa1f7a681e221aaaa36a831a3f21a60db698d09f91c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.xml
+    sha256: 62fea19cd7ee93cbb3b2d262a09ce5a7ff3b801fead28e79de84f1bbfbcd18ce
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.xml
   - name: FP32-INT8/person-reidentification-retail-0103.bin
     size: 2462604
-    sha256: facec60e589283bc1a44cca6212435bdf46cdd5910296591617a1bc26c8b4a44
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.bin
+    sha256: 8f4f8e74a869847f2cdb2bea0fba6027977c16d6f4e259e14f3bb0a8060ba685
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0103/FP32-INT8/person-reidentification-retail-0103.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0107/model.yml
+++ b/models/intel/person-reidentification-retail-0107/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0107.xml
-    size: 428541
-    sha256: 809723f4aea3e9fbb691c19109e0fb2710f8a7dfc5726801002f1569bce8024e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.xml
+    size: 428538
+    sha256: 5e94d23e328ae8feb444e8ad472157a19ddc3ec7a5a0e6dd5ab3792b86d533cf
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.xml
   - name: FP32/person-reidentification-retail-0107.bin
     size: 728532
     sha256: 06c020c064a2659bf2e84319a1afbd1229a6493c31cb7d34d912f87637b18e9a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0107/FP32/person-reidentification-retail-0107.bin
   - name: FP16/person-reidentification-retail-0107.xml
-    size: 428330
-    sha256: 4ee1a995f96ef887c80db96b803400f6c7519b3fd54c3cc02d6e03cf9e1eb0e3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.xml
+    size: 428332
+    sha256: 30a3fe994ac4e1e2771d4baa96dc9c5d909ec169a44fcb1d5ceff1ffcda326b3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.xml
   - name: FP16/person-reidentification-retail-0107.bin
     size: 364300
     sha256: 1966e4681a747a7767e144780069de5bf9440579c8153cd1c1aead69e4da2242
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0107/FP16/person-reidentification-retail-0107.bin
   - name: FP32-INT8/person-reidentification-retail-0107.xml
     size: 1213621
-    sha256: 719829f289b07e733f99f3916525279dd58debd7172187dd444a5e0ea168a019
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.xml
+    sha256: c8ca6da82c4db09c46a0465628fd881f9d501fdc8d360d3b66a50f89c5affe48
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.xml
   - name: FP32-INT8/person-reidentification-retail-0107.bin
     size: 778660
-    sha256: 091509c01d8a91e9452a881913bf4fb615c141050f9567a1b66051c95de47421
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.bin
+    sha256: acd7448d3d3d87d799c2b428b673af89f621d4c7b5d915800cb577f8af57c080
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0107/FP32-INT8/person-reidentification-retail-0107.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0200/model.yml
+++ b/models/intel/person-reidentification-retail-0200/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0200.xml
-    size: 445425
-    sha256: 2d5c2c089aa5aae96b1dd0aa4569d0f1e4e469d3bf9aa9eb2d84882feb33d2fa
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.xml
+    size: 445391
+    sha256: 51dccbd3c345850029333f5031c4c671d29b8a78bea4f8e440dbcfe04d9558b3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.xml
   - name: FP32/person-reidentification-retail-0200.bin
     size: 18800388
-    sha256: c20933d02c015aa44f4f2c2675c2498d11c45b2c8031f4f533e6636814bdeeca
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.bin
+    sha256: 264f2cf6ea48bc412ffeaa55604a571214efaa9d177ee516a2f4ad5b01e4f2c5
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0200/FP32/person-reidentification-retail-0200.bin
   - name: FP16/person-reidentification-retail-0200.xml
-    size: 445275
-    sha256: cd392484c83d685664330a9299716ead935a10bf2b453536566174ff2d7b74b6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.xml
+    size: 445236
+    sha256: 6a5738d72d6a3521c1f9a27f4db95c89734921829fd587d2802ded63792e9420
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.xml
   - name: FP16/person-reidentification-retail-0200.bin
     size: 9400240
-    sha256: f3acdd8e8eed0b875ba35d31fd7a5b837eecc26b9b170e149d29fcafb329ca41
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.bin
+    sha256: f813b64ae75e329cce2a0193967a3554ca6f730c2a88e20cd150c2645880322a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0200/FP16/person-reidentification-retail-0200.bin
   - name: FP32-INT8/person-reidentification-retail-0200.xml
-    size: 1269251
-    sha256: dc1c416f4548504908926e3a53b2bd7e6ffd5bb6eae9d707cfb5f268c94cb011
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.xml
+    size: 1269200
+    sha256: be80869dcaefe1d267c3a09153bb9dbfe08c51e17e901799494c53322e9c3259
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.xml
   - name: FP32-INT8/person-reidentification-retail-0200.bin
     size: 19002500
-    sha256: 44de11d0f2a289c57c45808d308cfdadedf565ad1b1db25c513e230755afd713
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.bin
+    sha256: c58940b2e6e3e4dd18d9fad94aa4838137c5216afb978ad2a9f7c48533dce348
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-reidentification-retail-0200/FP32-INT8/person-reidentification-retail-0200.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
@@ -19,28 +19,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.xml
-    size: 354805
-    sha256: 1fd5b4107faa003ef6d1dec6d0e77b12cc23a64df02d7762f36ff1977a0ac6d1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
+    size: 354808
+    sha256: a5c9fe84fe9a2b463eddd5b14535824ada1f238459ef6a96ddd5660b986bed47
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.bin
     size: 4713980
     sha256: 178e05f0635b0ee35b577a9dd31ea6da2a2a842635793f1ad18907d00f3a966a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.xml
-    size: 354633
-    sha256: 57c5a43d8f1856e5a2a37b2f490df24d0fb43210480c5f65ca37f3c3d0a5c973
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
+    size: 354639
+    sha256: 153660e414e60ca83f08f8b955e0dd318210570106b43999f1d8a3fa0fa639fa
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.bin
     size: 2357042
     sha256: a074ff0cad298ed9c35d0ce6ed58e09ee05216b907c97e6bb50f1b77a046bcfd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-0078.xml
     size: 960289
-    sha256: f759eb05e5dfb07e2ad7d1fc8588294c2776380e6e7d31931eb3833b78b22876
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.xml
+    sha256: e9fca40ea26f33bc55646ae7c92baae95786f53914f11e40b8280a9e35b0a176
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-0078.bin
     size: 4796540
     sha256: a5c797b9d0a2202c7e574bae55c90ea4cca594510fdfa3a1800c9832f466d52c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-0078/FP32-INT8/person-vehicle-bike-detection-crossroad-0078.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.xml
-    size: 194329
-    sha256: a4581f31ebdc565c318a88e9f0dc82643c41427e47bcd92cf4ce8f998feae8d8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
+    size: 194333
+    sha256: 040bded9370548d6ca02286b764334291c4ce6edb3ca6facd1758490a6433230
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.bin
     size: 11548004
     sha256: 61c9deaca903bb107aecfc31faeb402c894e0d43ab3817db8d9d05d43dfa68cf
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.xml
-    size: 194216
-    sha256: f90bf5b3b9c85f746b07be5600128ae109f7ab372424aa70007ace271a5bc957
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
+    size: 194219
+    sha256: 3392a26b381ebbfa837cafb976a828fd8519ff58be08aac72cb54f4f40b58184
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.bin
     size: 5774054
     sha256: a0ba3bc9ca17330c731b395153651c22a666050cd06413c01059070681dc79a7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-1016.xml
     size: 510391
-    sha256: d89d8e072975764f6d47f09c84af954ddc916802d6d58be73cfab53ec2f5194d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.xml
+    sha256: 82d95cf77a1a5a4c2d0d8a6c364229700f293ccd8df883a081c2dc33f4025462
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP32-INT8/person-vehicle-bike-detection-crossroad-1016.bin
     size: 11777480
     sha256: 0abdc201405b2f910f3ddd49307afd89ee43ab80009f9827b4f16e7aa7274157
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/person-vehicle-bike-detection-crossroad-1016/FP32-INT8/person-vehicle-bike-detection-crossroad-1016.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/product-detection-0001/model.yml
+++ b/models/intel/product-detection-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/product-detection-0001.xml
-    size: 273200
-    sha256: 31b7c786f42432339faec5779b719017120944061805eafe78da190ac70a1fea
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32/product-detection-0001.xml
+    size: 273207
+    sha256: ec88b66d16f0899e7a833c5da5de0be3304062a926dd52662cbca4a2c68247bc
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/product-detection-0001/FP32/product-detection-0001.xml
   - name: FP32/product-detection-0001.bin
     size: 12850036
     sha256: 93f2ccd0ce7ba88f190f51b8a62d67fd5178444496f068dc33488fb1949e2726
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32/product-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/product-detection-0001/FP32/product-detection-0001.bin
   - name: FP16/product-detection-0001.xml
-    size: 273017
-    sha256: 302bcb7ef314f6eaa19951d6c62e39f640d7ffc107718bc4de27d27a71365953
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP16/product-detection-0001.xml
+    size: 273019
+    sha256: c6488db369f51c892172b9adc83f466553c7c36f9e4dac531891c1992c79051d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/product-detection-0001/FP16/product-detection-0001.xml
   - name: FP16/product-detection-0001.bin
     size: 6425070
     sha256: ecc6f6bdae9a49c1749a324e0e98320a0a9aae97cc0c2b536853ee46b9178690
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP16/product-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/product-detection-0001/FP16/product-detection-0001.bin
   - name: FP32-INT8/product-detection-0001.xml
     size: 674722
-    sha256: cea1c66540e4ec5187f9bc2450694db8931b9648863b95aa03334d1b2f9bc089
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32-INT8/product-detection-0001.xml
+    sha256: 8320116effb73fdca11adb7238b7dd95f93e37e359fc44ba08ac35aa35317dd3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/product-detection-0001/FP32-INT8/product-detection-0001.xml
   - name: FP32-INT8/product-detection-0001.bin
     size: 13101168
     sha256: 741f6bee9d617ca20a5c5813ed3defc240b4fdef84c4c2582e3e4bb586460d1f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/product-detection-0001/FP32-INT8/product-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/product-detection-0001/FP32-INT8/product-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: classification
 files:
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
-    size: 93588
-    sha256: 1454fca6b719e7ef59cd24f357cd83a847df465e6c0991c357a981a873c8094d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
+    size: 93590
+    sha256: 219cdef5a3cfb82ecc895983a9840def9145b717e6ce54327cfff47ca076e8e7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 4190944
     sha256: 69f0fef2a4373fb4a72a9fe99442f14e8d367470422f9068976284114193e833
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
-    size: 93562
-    sha256: 455ea2ead098934482d89dfb6c955e00017dfdcfe58d3b4d8408627d0caf1ead
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
+    size: 93564
+    sha256: 6b9226d527779f3528cafe97ce81350e0570b21e0c9c018faaed15e47bde8389
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 2782080
     sha256: 57a2767a0dd7eddb59830b93a01ce5f6ef0906abb252602f89f7dd28071a6dd5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/resnet50-binary-0001/model.yml
+++ b/models/intel/resnet50-binary-0001/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: classification
 files:
   - name: FP32-INT1/resnet50-binary-0001.xml
-    size: 227762
-    sha256: 750c212fd2f2626a3b9151c43c63939f89c5a3a95a02d1b3cc4d03ecdbfdcaea
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
+    size: 227764
+    sha256: 011296b3a0ef3311597f7425339a8b3d1aad6c9b3f5f4fd58c2a467a24271296
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
   - name: FP32-INT1/resnet50-binary-0001.bin
     size: 22112976
     sha256: 35c724a526d54d32badf20a5bf929925d333a4e67bcf493c854ce4d5a3e258cb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
   - name: FP16-INT1/resnet50-binary-0001.xml
-    size: 227668
-    sha256: 35a465039ca3d4bb5d85839e8110383fc9698d2408293f71ec237053e61ffbe2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
+    size: 227670
+    sha256: 4329f94b2c23852cfd946e75dd38c161a88d99590de99906d5648e03f259ea2d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
   - name: FP16-INT1/resnet50-binary-0001.bin
     size: 12348784
     sha256: cb98ba6a96cc46d1eae9786e964b1fad2b41d74470c2032a1961fb66ece91332
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/road-segmentation-adas-0001/model.yml
+++ b/models/intel/road-segmentation-adas-0001/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: semantic_segmentation
 files:
   - name: FP32/road-segmentation-adas-0001.xml
-    size: 357680
-    sha256: b862c63f6ad3abe344ec39db65537477e172681232b3a7bea96d97d74b911daa
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
+    size: 357682
+    sha256: 7c1fabbec883c4297e7b82037afd8262c8f1afba3bb23863bbcc6177fce91706
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
   - name: FP32/road-segmentation-adas-0001.bin
     size: 737200
     sha256: ae43e7d5dd1ad62cbe62a2d8aa5dd3721b7581f26763ba3c69660da2a91c3d87
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
   - name: FP16/road-segmentation-adas-0001.xml
-    size: 357525
-    sha256: ec08c6a8880ca77af329d37cfc5750c904a205c7b4561352422e8b152a04ed8c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
+    size: 357527
+    sha256: 0e90b547c84bdac869f5d9e227fc2df9da64f4de787886ac4d5c0d89b73344d7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
   - name: FP16/road-segmentation-adas-0001.bin
     size: 368632
     sha256: ddbc38aaee27ed8166d1190519380a91cdea8cf7f4bc71585d939fd6ead6b159
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
   - name: FP32-INT8/road-segmentation-adas-0001.xml
     size: 1057411
-    sha256: 005024bb7a8cfcd0a887d92f944b8329dcdb75484e76c916c9251d069c42f9d6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.xml
+    sha256: 44d6a4fac2f88498c465ebe83d2a2189e16e12f389f7fc4c33a564cc99836a0c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.xml
   - name: FP32-INT8/road-segmentation-adas-0001.bin
     size: 783048
     sha256: 6c6cb1de3831c294f79cc6d693edb5d36874608dd4bfd45b2ee88dc6df390b98
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/road-segmentation-adas-0001/FP32-INT8/road-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/semantic-segmentation-adas-0001/model.yml
+++ b/models/intel/semantic-segmentation-adas-0001/model.yml
@@ -19,28 +19,28 @@ description: >-
 task_type: semantic_segmentation
 files:
   - name: FP32/semantic-segmentation-adas-0001.xml
-    size: 182085
-    sha256: ed7a85e055a2f87dee81cd097a13d996f4d49d698b89c27cd76f70a7e30c8b14
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
+    size: 182087
+    sha256: c3fc63223316e68dc35d147661906a23e83a0655f72a6ca5dabc3251e98d9566
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
   - name: FP32/semantic-segmentation-adas-0001.bin
     size: 26743564
     sha256: 6d2592c07c91ed1de76c683a2c5753c89f0a61c215bc553f2a6b30faa05b37ba
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
   - name: FP16/semantic-segmentation-adas-0001.xml
-    size: 182004
-    sha256: 985a77b47dbae4a360176f64c6883aca463c169d649183da7232f0e63039ddfa
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
+    size: 182006
+    sha256: b446ba0eb6b0da3888b6052263f1c951abc5737966a8ed067f9cb912bce8d251
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
   - name: FP16/semantic-segmentation-adas-0001.bin
     size: 13371824
     sha256: a6366b6cd8e6456bdea4d2709e4d062c434a94cfabb62905dfbb4cd50b3df5d5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
   - name: FP32-INT8/semantic-segmentation-adas-0001.xml
     size: 506262
-    sha256: 6dc1efc337eb1cd6bf82801ec9e9d4a504ec8941f6e650530b7e1bcd32086de3
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.xml
+    sha256: feba4beb19e206bfa06017c13bc8eac4001a5863043ee2d87316039958323c85
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.xml
   - name: FP32-INT8/semantic-segmentation-adas-0001.bin
     size: 26858920
     sha256: 6a2362f6c06fe1d569699d82f461245e7233e4cbc99f729baba3acec3bf5207b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/semantic-segmentation-adas-0001/FP32-INT8/semantic-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1032/model.yml
+++ b/models/intel/single-image-super-resolution-1032/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1032.xml
-    size: 41192
-    sha256: 2ae653c1e2b4e8015c7a794e3de7166f027737ed3b7faec2b4074dfce0a2639d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
+    size: 41194
+    sha256: 5e68e407a9abd030ecb62d5f1e96f8b76c0fb81ec52fc8be2078886868d480fa
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
   - name: FP32/single-image-super-resolution-1032.bin
     size: 119556
     sha256: 82b5338155835d6b4307721e6a9b28775a4550b61c31d76aac1a8b5d5612d7dc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
   - name: FP16/single-image-super-resolution-1032.xml
-    size: 41166
-    sha256: 22d0d66d1e9d0781b017ef7004647deb86878ecbb526ef2cfb0fba1a045f5bcb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
+    size: 41171
+    sha256: 2a420d86b919aeb7eafb752b09b230b390044f35b6ba9709117594fe310f1ab7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
   - name: FP16/single-image-super-resolution-1032.bin
     size: 59882
     sha256: abae5907d40ef7e47d680435a99484b74076a985a6b8c3353b64fa77e6d3c149
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
   - name: FP32-INT8/single-image-super-resolution-1032.xml
     size: 122462
-    sha256: 6f6ca9fcbe53340ce1acbc5210b156f17517481de2cb7fc92c6d1770c35ac9ce
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.xml
+    sha256: f6aa087d5c7c43ddf7a0a4f63fc5f6c747ef7ecdd9fa6a7c953de063a5599547
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.xml
   - name: FP32-INT8/single-image-super-resolution-1032.bin
     size: 121724
     sha256: e14739375434b1645d0b6745947aae73fd9b915750b033ce08f25aab93b0b25e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1032/FP32-INT8/single-image-super-resolution-1032.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1033/model.yml
+++ b/models/intel/single-image-super-resolution-1033/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1033.xml
-    size: 36335
-    sha256: a5166b0f8582b25f300c7447ef81468f2db09bae734c1b31ee13333bb6039711
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
+    size: 36334
+    sha256: 1d51ca5a62c9b35532414cffd9c7b6dd874d1dfa8e728079161f748e9729ca0e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
   - name: FP32/single-image-super-resolution-1033.bin
     size: 121812
     sha256: 47b0c1d3b28c1193fdb7838cebdad29e010abfdc7664ef06257bd659f4f08474
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
   - name: FP16/single-image-super-resolution-1033.xml
-    size: 36316
-    sha256: a09e083c3ecb5f6987a97d517f6adda8a9a2279983e37c6c9a8580863b8d825f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
+    size: 36318
+    sha256: ede3cf9c574810450aeb6f14dfe7ddfbdfe5d1e47e277d7c5aea7987ca0bb802
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
   - name: FP16/single-image-super-resolution-1033.bin
     size: 60970
     sha256: 771dd5b865006aea3a04a6b5e858c34fe619913d8aa1279cd9b6a40c05ef0df7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
   - name: FP32-INT8/single-image-super-resolution-1033.xml
     size: 113556
-    sha256: 1c38a37a1462c95078c36b50d4d4e7f6b0adc7bfa1d5ed74207f37495555b0b2
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.xml
+    sha256: 8e1b65fd3cdcc6d016b1495e7f73f5f353446df71151619800dc5950b2c23ad8
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.xml
   - name: FP32-INT8/single-image-super-resolution-1033.bin
     size: 124040
     sha256: d066c186597ae2d74f42250945a8f0c315f284e4d1fd7126c263228cc94e8c13
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/single-image-super-resolution-1033/FP32-INT8/single-image-super-resolution-1033.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0003/model.yml
+++ b/models/intel/text-detection-0003/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/text-detection-0003.xml
-    size: 178392
-    sha256: fb6526724978d02c1c34f90e5f68ec27510acefae57d3ebc0489014257bd902b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32/text-detection-0003.xml
+    size: 178394
+    sha256: e63aae42d6d37fd4aab0bbf553554af20556aea218ad0465f2bfd721c5cba25d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0003/FP32/text-detection-0003.xml
   - name: FP32/text-detection-0003.bin
     size: 26986280
     sha256: 03430c799fa873e859eb0018318e741fd58b8ff6b9891949cb931876db3bf0e1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32/text-detection-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0003/FP32/text-detection-0003.bin
   - name: FP16/text-detection-0003.xml
-    size: 178312
-    sha256: a79db693edd5b9bb0ede95ca667ad07693fd586f51cdff90ab324eef77f5f91c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP16/text-detection-0003.xml
+    size: 178314
+    sha256: a24e90b48c701a6cce64ad279c8b00500deb308292f05852b732112474dba5e9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0003/FP16/text-detection-0003.xml
   - name: FP16/text-detection-0003.bin
     size: 13493056
     sha256: 84fc3ce490259047e3a48f2810f4cd2a38ad20c12a82f96e39f4ccb78b86b1f7
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP16/text-detection-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0003/FP16/text-detection-0003.bin
   - name: FP32-INT8/text-detection-0003.xml
     size: 557004
-    sha256: 8834507c02dabb0ac1ada2a59a4e9d2c05d9a54b7d84cdb7cf63ed1804b97205
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32-INT8/text-detection-0003.xml
+    sha256: cec8d7e41ed77e4b2b23b5119dc2f390781de266ef193ea9fb357d1c690d138b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0003/FP32-INT8/text-detection-0003.xml
   - name: FP32-INT8/text-detection-0003.bin
     size: 27219792
     sha256: 5eeffd8c051eba2661f87e43d08721576e0a346af569694a6859b748916233e1
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0003/FP32-INT8/text-detection-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0003/FP32-INT8/text-detection-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0004/model.yml
+++ b/models/intel/text-detection-0004/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/text-detection-0004.xml
-    size: 156936
-    sha256: 85ede4c0d469fb0ac0806f98b02e75485e351d4fa34fe1fab48869ab4a404120
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32/text-detection-0004.xml
+    size: 156938
+    sha256: 244f836e36d63c9bd45b2123f4b9e4672cae6be348c15cac857d75a8b9852dd7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0004/FP32/text-detection-0004.xml
   - name: FP32/text-detection-0004.bin
     size: 17312168
     sha256: 6da6456f27123be2d9a0e68bb73a7750f6aaee2f0af75d7f34ec6fa97f6727dc
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32/text-detection-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0004/FP32/text-detection-0004.bin
   - name: FP16/text-detection-0004.xml
-    size: 156835
-    sha256: 52b910fff9d5c88c58e8e0ac385e8695bffe33d136e3752de51430c17710aee5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP16/text-detection-0004.xml
+    size: 156841
+    sha256: a348b2b3adac52b92f15c21605f55fa75bf930ac1827871965c7eb9f71ad4a24
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0004/FP16/text-detection-0004.xml
   - name: FP16/text-detection-0004.bin
     size: 8656000
     sha256: 719639a52b46f94455ad8c2fb6d0e0bb98c485179f4321c558d5d88aacfbfd0e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP16/text-detection-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0004/FP16/text-detection-0004.bin
   - name: FP32-INT8/text-detection-0004.xml
-    size: 461339
-    sha256: bcec9ec2f95f1c7b46fa9a2296e36b33126b343c1c7e980443e6633beeebb80b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32-INT8/text-detection-0004.xml
+    size: 461347
+    sha256: 025f0b274e560189ba8a054dbbdef6ec09f0a697b5e79955472a5b142707ad0e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0004/FP32-INT8/text-detection-0004.xml
   - name: FP32-INT8/text-detection-0004.bin
     size: 17559056
     sha256: fa2e973387c7b8a1e8d3165dae15e72e0537ef8e55eeae98081b0fb2b88676c6
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-detection-0004/FP32-INT8/text-detection-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-detection-0004/FP32-INT8/text-detection-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-image-super-resolution-0001/model.yml
+++ b/models/intel/text-image-super-resolution-0001/model.yml
@@ -17,20 +17,28 @@ description: >-
 task_type: image_processing
 files:
   - name: FP32/text-image-super-resolution-0001.xml
-    size: 11356
-    sha256: fb51c561eafeec139c1736ab95e6972cf82980247d11a9e36e9237f32bc458b9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.xml
+    size: 11358
+    sha256: 2587a0ad10ea3fc04fb44d680d79662af6a2c9613c9c0e0c3107be9b1a96e18c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.xml
   - name: FP32/text-image-super-resolution-0001.bin
     size: 10836
     sha256: 033d58430a2744302a2729291d66d4c74ee6bce517b6ae36f1b5a0e8b27d82ff
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
   - name: FP16/text-image-super-resolution-0001.xml
-    size: 11346
-    sha256: bd2452d4e1968479c5537f4cad0ac4b7d15e7d7bba49608e06e9b96550fb3b63
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.xml
+    size: 11348
+    sha256: 3b99523e38d4a178448b7801d9483232bf9168ab183c681c8649d1f02ebc3920
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.xml
   - name: FP16/text-image-super-resolution-0001.bin
     size: 5418
     sha256: f203818d73b933e5004aff85aeb84783dbf0be9e5c296d2995fc0678ff719e9c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
+  - name: FP32-INT8/text-image-super-resolution-0001.xml
+    size: 27041
+    sha256: 1a1a41f0c325ca9befc70ba7e42170c5213a0474f755d3d56563b28f96b5ee19
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-image-super-resolution-0001/FP32-INT8/text-image-super-resolution-0001.xml
+  - name: FP32-INT8/text-image-super-resolution-0001.bin
+    size: 11228
+    sha256: f1680f577b003e5d6674d5b2d07277171487dac7707dbd18b686755e438127aa
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-image-super-resolution-0001/FP32-INT8/text-image-super-resolution-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-recognition-0012/model.yml
+++ b/models/intel/text-recognition-0012/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/text-recognition-0012.xml
-    size: 119137
-    sha256: 9fed384cca2aec53214fbff8f922608882f1f69868c1e07e869586b5612485e0
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32/text-recognition-0012.xml
+    size: 97700
+    sha256: 54fd8ae6ea5ae11fdeb85f5c6b701793c28883f1e3dd8c3a531c43db6c3713ea
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-recognition-0012/FP32/text-recognition-0012.xml
   - name: FP32/text-recognition-0012.bin
-    size: 47470864
-    sha256: 9d08734a7128e2099ba0c64ef347c0faf2470611ef627995f66343299473b14a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32/text-recognition-0012.bin
+    size: 47470852
+    sha256: b0d99549692baeea3e83709a671844a365b15bd40e36d9a5d3ef5368a69d2897
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-recognition-0012/FP32/text-recognition-0012.bin
   - name: FP16/text-recognition-0012.xml
-    size: 119105
-    sha256: 7f23f42a3e2c9207f68dd6716d8f3ffbb4e8f1d5a26147829cfae9b835f1321e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP16/text-recognition-0012.xml
+    size: 97668
+    sha256: dd971f01660f3395e51d7983f5b4d70ac99764efaa3db99a9c52cdac378ed2a0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-recognition-0012/FP16/text-recognition-0012.xml
   - name: FP16/text-recognition-0012.bin
-    size: 23735488
-    sha256: 6e3cd9139e9bfc32bd4ae7054e97d6050754552c78703df9bda96c313573cc8a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP16/text-recognition-0012.bin
+    size: 23735478
+    sha256: 33294d251264f6913f0cc1f8a6463318becb5b70757984b461e5a865921b8d65
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-recognition-0012/FP16/text-recognition-0012.bin
   - name: FP32-INT8/text-recognition-0012.xml
-    size: 153421
-    sha256: b148ce47f98a6a41c467274eeb5ad7330a29cf7e33b0126c6784bb8e0830e6fd
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32-INT8/text-recognition-0012.xml
+    size: 131724
+    sha256: 668efb97ddb90a8c8c6796b3d7d06eee49d4c9bf03f26be99ace5a263681a61b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-recognition-0012/FP32-INT8/text-recognition-0012.xml
   - name: FP32-INT8/text-recognition-0012.bin
-    size: 47489644
-    sha256: 0bac02a212d27677fbacc5f1535190eb05e633f49274f42d1e31c32f55dca17e
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-recognition-0012/FP32-INT8/text-recognition-0012.bin
+    size: 47489632
+    sha256: 9df4967adc31b20314ac140b3927e98d7c212abe257eaa697955052b8e7a3674
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-recognition-0012/FP32-INT8/text-recognition-0012.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0001-detector/model.yml
+++ b/models/intel/text-spotting-0001-detector/model.yml
@@ -17,20 +17,20 @@ description: >-
 task_type: detection
 files:
   - name: FP32/text-spotting-0001-detector.xml
-    size: 275848
-    sha256: 6027c81c80e93d2652157350bfecd80ef91546b14c902bf3ae078a4d3347fbae
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP32/text-spotting-0001-detector.xml
+    size: 275850
+    sha256: 850eeabbd8f371292fefc84132d37431efe4feb09fc1f437f05621b31cec344e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-detector/FP32/text-spotting-0001-detector.xml
   - name: FP32/text-spotting-0001-detector.bin
     size: 105906904
     sha256: 3a4e3e7c3d0673a778882f5e6aaa217128473e79c5cb90c614d77ad25a108d42
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP32/text-spotting-0001-detector.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-detector/FP32/text-spotting-0001-detector.bin
   - name: FP16/text-spotting-0001-detector.xml
-    size: 275734
-    sha256: 382031ffbef4a0931fd14813f085d3f294ad188fdc5291b7cf5e43148c977483
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP16/text-spotting-0001-detector.xml
+    size: 275736
+    sha256: f36f7bff89dfc4c35b76107453c665ddb3837c7b5ac10755107fffc0e29acec6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-detector/FP16/text-spotting-0001-detector.xml
   - name: FP16/text-spotting-0001-detector.bin
     size: 52953494
     sha256: 776648224b38f5023606b52f1782f4423b56ff588de8a7b7ea15c5e0fca15eb8
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-detector/FP16/text-spotting-0001-detector.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-detector/FP16/text-spotting-0001-detector.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0001-recognizer-decoder/model.yml
+++ b/models/intel/text-spotting-0001-recognizer-decoder/model.yml
@@ -18,20 +18,20 @@ description: >-
 task_type: optical_character_recognition
 files:
   - name: FP32/text-spotting-0001-recognizer-decoder.xml
-    size: 30543
-    sha256: 7a45447713c1b1cead9cfc7176dcbb3b356a1fc247ade055201e5697ac547b26
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.xml
+    size: 30545
+    sha256: c161afda8cd45ee21934c74aec49321855651c3286921f5b6909da0e0bc0b626
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.xml
   - name: FP32/text-spotting-0001-recognizer-decoder.bin
     size: 2707804
     sha256: 00cb0cef419a01661ca1c1b9977b1edebe581427dd28a593ba34505971544303
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-decoder/FP32/text-spotting-0001-recognizer-decoder.bin
   - name: FP16/text-spotting-0001-recognizer-decoder.xml
-    size: 30527
-    sha256: 01c2a7b426c91f195c45883b64a3a89b2276a4ecc2598f109820f3436e3f5d4c
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.xml
+    size: 30529
+    sha256: f4eb268b589327d7bdc22ea7c084aa88cc36dd1eec9855ec9f17890b9b26154a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.xml
   - name: FP16/text-spotting-0001-recognizer-decoder.bin
     size: 1354000
     sha256: 58fb88820edf08b2809f2f7d7c563c86082b13342f01206ffc98707ed2a66948
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-decoder/FP16/text-spotting-0001-recognizer-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0001-recognizer-encoder/model.yml
+++ b/models/intel/text-spotting-0001-recognizer-encoder/model.yml
@@ -18,20 +18,20 @@ description: >-
 task_type: feature_extraction
 files:
   - name: FP32/text-spotting-0001-recognizer-encoder.xml
-    size: 9906
-    sha256: e83d95fc0938ff3c4a40cff80fd2621114ac3d99d8d12942b5d2fb4693d9a002
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.xml
+    size: 9908
+    sha256: 2c088d1a1e3e21a31038022f4000f2604d34b53d0f3f84c7c99bca146890dfce
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.xml
   - name: FP32/text-spotting-0001-recognizer-encoder.bin
     size: 5311488
     sha256: df3b4d491c953b022afbed4e0492b8f41046da3a6d3c65054884ac15af135942
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-encoder/FP32/text-spotting-0001-recognizer-encoder.bin
   - name: FP16/text-spotting-0001-recognizer-encoder.xml
-    size: 9903
-    sha256: dce746a5d4a6b1b03b0da1c2cf1bba3623ab8faa2ecd60e46a6793c65bf1f94f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.xml
+    size: 9905
+    sha256: 8f9f51992f22d8d7b1588757cc1f71c712132d522bd439c38a298de980daf9ea
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.xml
   - name: FP16/text-spotting-0001-recognizer-encoder.bin
     size: 2655744
     sha256: e0a2315c344e2adf69c31b24faa16fdc9496f48a9ba98c25ecef640f23710517
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/text-spotting-0001-recognizer-encoder/FP16/text-spotting-0001-recognizer-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/vehicle-attributes-recognition-barrier-0039.xml
-    size: 33365
-    sha256: 0c61e77df8fbb5c6ede62410025d58413aaa60405af9a0da27a374057ff87aeb
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
+    size: 33367
+    sha256: b61160182cf8f3a67939d4d6cc837a1bcfd5cf0f443cea836ea23cc6bc0ec9d4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP32/vehicle-attributes-recognition-barrier-0039.bin
     size: 2504020
     sha256: 26594e8bfc4e8de30a2186f4c30cfd44b82a4f4b4656fb32aa12d4f4888c832a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP16/vehicle-attributes-recognition-barrier-0039.xml
-    size: 33347
-    sha256: fe601fdc8cce0d1ebcc95393b9d0397c52702288995a4da987a04f90558379e4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
+    size: 33349
+    sha256: 8eedb7bbec7d5dc514ed107ff47e316cf0b002d977141394871fb7b21fb32c93
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP16/vehicle-attributes-recognition-barrier-0039.bin
     size: 1252018
     sha256: aed57f9cfdfc7dbd8955c5f6b15966bd0131050129835e2046451f06e4bde7b9
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP32-INT8/vehicle-attributes-recognition-barrier-0039.xml
     size: 87151
-    sha256: 92ea62baa2689ead54c0d46e59463814112c9f4abf04459eeb0eb1e948216f60
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.xml
+    sha256: 0811f4541784e32f792e32b42e38c75ef202e16c0e9b5fd01122afb277763fce
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP32-INT8/vehicle-attributes-recognition-barrier-0039.bin
     size: 2512408
     sha256: 649ee0087b451d4d9099156452a2b80092b5af673fc457f0cdd6cd6fd1aa05a4
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-attributes-recognition-barrier-0039/FP32-INT8/vehicle-attributes-recognition-barrier-0039.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-adas-0002/model.yml
+++ b/models/intel/vehicle-detection-adas-0002/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/vehicle-detection-adas-0002.xml
-    size: 216037
-    sha256: f6563cc8625b5969807bf27b1a6bd5dc55515289fe4e7f897cbd77a52af631d5
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
+    size: 216043
+    sha256: b58c126cc2cf025442dd614159b0a6061c236eaecf8ae5f9d136b7b312499b31
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
   - name: FP32/vehicle-detection-adas-0002.bin
     size: 4314552
     sha256: 6d0e114769bed9c8bd6666e098f891d7c158508bd7db6ba2bd4d09de17db1b69
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
   - name: FP16/vehicle-detection-adas-0002.xml
-    size: 215991
-    sha256: 17896bbbc1914087df57b5ef356441c1cfaff1820d22888312b57d0f79dc5297
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
+    size: 215993
+    sha256: 3f68133b27949aae53f2fa118be8d980c91a87f8112f8fd84ab2dc0c77e13754
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
   - name: FP16/vehicle-detection-adas-0002.bin
     size: 2157328
     sha256: e119b3bec50bc836f2eb26a56a40a6d5e3c33bde819f3e6d00f829978092742b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
   - name: FP32-INT8/vehicle-detection-adas-0002.xml
     size: 438606
-    sha256: 28c2f7729561230b98b87c617da97b85d62029103195daed726fa3411f8abe6d
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.xml
+    sha256: b7b2531985b025f42e40251ae1151a204e38c8db83ae1d4b565a8ce729cf1156
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.xml
   - name: FP32-INT8/vehicle-detection-adas-0002.bin
     size: 4389736
     sha256: 9fe53648e0a377c00e8b985817cd25dad320008e8d0a1048af4ac88aabf1a929
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-0002/FP32-INT8/vehicle-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-adas-binary-0001/model.yml
+++ b/models/intel/vehicle-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/vehicle-detection-adas-binary-0001.xml
     size: 105969
     sha256: c98bf5984895b1309861597ec36181446877407cd985bb490e14461f41312670
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.xml
   - name: FP32-INT1/vehicle-detection-adas-binary-0001.bin
     size: 2160500
     sha256: afdd8a2f175b2f19c07083ff23b2e28105f3d1c7dc06a4b1a1d5c2c42b98294f
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
+++ b/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/vehicle-license-plate-detection-barrier-0106.xml
-    size: 204474
-    sha256: 8193604cbadd987d324691180f69fffd0b4c53bf466942995d4a8abda30b093a
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
+    size: 204476
+    sha256: 0c4abcf31945d04fc33459625988176ade8e0986a8e2b4499c1ec511177217a4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP32/vehicle-license-plate-detection-barrier-0106.bin
     size: 2573380
     sha256: 2a6f1cd0eb8731ef059a91299bce0be026d2cebb1ae42cbee37b6aef7da2764b
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
   - name: FP16/vehicle-license-plate-detection-barrier-0106.xml
-    size: 204406
-    sha256: 39e5bf4fccb20ccbe4dd89861f973d2532ce5efc25ec0c3af9a61c6f6c9f3086
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
+    size: 204408
+    sha256: 6fc62d36f52ccfa34eced7c8e3c260e9870a8b5c42fe413a76a1321f10a637dc
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP16/vehicle-license-plate-detection-barrier-0106.bin
     size: 1286758
     sha256: 57652e098f93ee712eb412267612cb7bf2713475f96ec1e18eca10e4bef69785
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
   - name: FP32-INT8/vehicle-license-plate-detection-barrier-0106.xml
     size: 519016
-    sha256: 092689a2ee9b5f6c089da2acc44ab07304106c1d9b6a5f2c0c07e1715067ed69
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.xml
+    sha256: 0037685af2cc25f569c7db066ab6e9673a0faae204d8f2f19a003b28bd21bb28
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP32-INT8/vehicle-license-plate-detection-barrier-0106.bin
     size: 2642612
     sha256: 2f81d5803d76e90f9000c17083536ece01e7127c407e5bec7a6caef07ac01082
-    source: https://download.01.org/opencv/2019/open_model_zoo/R4/20200117_150000_models_bin/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.1/open_model_zoo/models_bin/1/vehicle-license-plate-detection-barrier-0106/FP32-INT8/vehicle-license-plate-detection-barrier-0106.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE


### PR DESCRIPTION
Because of improvements in the quantization tools, the following models are
now available in FP32-INT8:

- `instance-segmentation-security-0050`
- `instance-segmentation-security-0083`
- `person-detection-retail-0002`
- `text-image-super-resolution-0001`

Because of a remaining quantization issue, `person-attributes-recognition-crossroad-0230`
is no longer available in FP32-INT8.