### PR TITLE
Bump the version for the next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [OpenVINO™ Toolkit](https://01.org/openvinotoolkit) - Open Model Zoo repository
-[![Stable release](https://img.shields.io/badge/version-2020.1-green.svg)](https://github.com/opencv/open_model_zoo/releases/tag/2020.1)
+[![Stable release](https://img.shields.io/badge/version-2020.2-green.svg)](https://github.com/opencv/open_model_zoo/releases/tag/2020.2)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/open_model_zoo/community)
 [![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE)
 


### PR DESCRIPTION
We have merged everything that was intended for the 2020.1 release, so even though the release isn't out yet, I think it makes sense to open the branch to changes for the next one. If it turns out we need to fix something for the current release after all, I'll just create a `release` branch and we'll merge it there.

