### PR TITLE
Remove cpu_extension compatibility code

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -157,10 +157,6 @@ macro(ie_add_sample)
         endif()
     endif()
 
-    if(TARGET IE::ie_cpu_extension)
-        add_definitions(-DWITH_EXTENSIONS)
-    endif()
-
     # Create named folders for the sources within the .vcproj
     # Empty name lists them directly under the .vcproj
     source_group("src" FILES ${IE_SAMPLES_SOURCES})
@@ -179,10 +175,6 @@ macro(ie_add_sample)
         target_include_directories(${IE_SAMPLE_NAME} PRIVATE ${IE_SAMPLE_INCLUDE_DIRECTORIES})
     endif()
     target_include_directories(${IE_SAMPLE_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../common")
-
-    if(TARGET IE::ie_cpu_extension)
-        target_link_libraries(${IE_SAMPLE_NAME} PRIVATE IE::ie_cpu_extension)
-    endif()
 
     target_link_libraries(${IE_SAMPLE_NAME} PRIVATE ${OpenCV_LIBRARIES} ${InferenceEngine_LIBRARIES}
                                                     ${IE_SAMPLE_DEPENDENCIES} gflags)

--- a/demos/crossroad_camera_demo/main.cpp
+++ b/demos/crossroad_camera_demo/main.cpp
@@ -27,9 +27,6 @@
 #include <samples/slog.hpp>
 #include <samples/ocv_common.hpp>
 #include "crossroad_camera_demo.hpp"
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 using namespace InferenceEngine;
 
@@ -538,10 +535,6 @@ int main(int argc, char *argv[]) {
             std::cout << ie.GetVersions(flag) << std::endl;
 
             if ((flag.find("CPU") != std::string::npos)) {
-#ifdef WITH_EXTENSIONS
-                /** Load default extensions lib for the CPU device (e.g. SSD's DetectionOutput)**/
-                ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
                 if (!FLAGS_l.empty()) {
                     // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension
                     auto extension_ptr = make_so_pointer<IExtension>(FLAGS_l);

--- a/demos/gaze_estimation_demo/main.cpp
+++ b/demos/gaze_estimation_demo/main.cpp
@@ -50,9 +50,6 @@
 #include "utils.hpp"
 
 #include <ie_iextension.h>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 using namespace InferenceEngine;
 using namespace gaze_estimation;

--- a/demos/gaze_estimation_demo/src/utils.cpp
+++ b/demos/gaze_estimation_demo/src/utils.cpp
@@ -38,9 +38,6 @@ void initializeIEObject(InferenceEngine::Core& ie,
 
         /** Loading extensions for the CPU device **/
         if ((deviceName.find("CPU") != std::string::npos)) {
-#ifdef WITH_EXTENSIONS
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
             loadedDevices.insert(deviceName);
         }
     }

--- a/demos/interactive_face_detection_demo/detectors.cpp
+++ b/demos/interactive_face_detection_demo/detectors.cpp
@@ -22,9 +22,6 @@
 #include <samples/slog.hpp>
 
 #include <ie_iextension.h>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 #include "detectors.hpp"
 

--- a/demos/interactive_face_detection_demo/main.cpp
+++ b/demos/interactive_face_detection_demo/main.cpp
@@ -35,9 +35,6 @@
 #include "visualizer.hpp"
 
 #include <ie_iextension.h>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 using namespace InferenceEngine;
 
@@ -139,9 +136,6 @@ int main(int argc, char *argv[]) {
 
             /** Loading extensions for the CPU device **/
             if ((deviceName.find("CPU") != std::string::npos)) {
-#ifdef WITH_EXTENSIONS
-                ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
 
                 if (!FLAGS_l.empty()) {
                     // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension

--- a/demos/mask_rcnn_demo/main.cpp
+++ b/demos/mask_rcnn_demo/main.cpp
@@ -17,9 +17,6 @@
 #include <iomanip>
 
 #include <inference_engine.hpp>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 #include <samples/ocv_common.hpp>
 #include <samples/slog.hpp>
@@ -69,18 +66,6 @@ int main(int argc, char *argv[]) {
         // ---------------------Load inference engine------------------------------------------------
         slog::info << "Loading Inference Engine" << slog::endl;
         Core ie;
-
-#ifdef WITH_EXTENSIONS
-        /** Loading default extensions **/
-        if (FLAGS_d.find("CPU") != std::string::npos) {
-            /**
-             * cpu_extensions library is compiled from "extension" folder containing
-             * custom MKLDNNPlugin layer implementations. These layers are not supported
-             * by mkldnn, but they can be useful for inferring custom topologies.
-            **/
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-        }
-#endif
 
         if (!FLAGS_l.empty()) {
             // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension

--- a/demos/multi_channel/common/CMakeLists.txt
+++ b/demos/multi_channel/common/CMakeLists.txt
@@ -110,13 +110,7 @@ endif()
 
 target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if(TARGET IE::ie_cpu_extension)
-    add_definitions(-DWITH_EXTENSIONS)
-endif()
 target_link_libraries(${TARGET_NAME} ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES})
-if(TARGET IE::ie_cpu_extension)
-    target_link_libraries(${TARGET_NAME} IE::ie_cpu_extension)
-endif()
 
 if(UNIX)
     target_link_libraries( ${TARGET_NAME} pthread)

--- a/demos/multi_channel/common/graph.cpp
+++ b/demos/multi_channel/common/graph.cpp
@@ -41,9 +41,6 @@ void IEGraph::initNetwork(const std::string& deviceName) {
     auto cnnNetwork = ie.ReadNetwork(modelPath);
 
     if (deviceName.find("CPU") != std::string::npos) {
-#ifdef WITH_EXTENSIONS
-        ie.AddExtension(std::make_shared<InferenceEngine::Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
         ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_CPU_BIND_THREAD, "NO"}}, "CPU");
     }
     if (!cpuExtensionPath.empty()) {

--- a/demos/multi_channel/face_detection_demo/CMakeLists.txt
+++ b/demos/multi_channel/face_detection_demo/CMakeLists.txt
@@ -60,15 +60,7 @@ if(MULTICHANNEL_DEMO_USE_TBB)
     endif()
 endif()
 
-if(TARGET IE::ie_cpu_extension)
-    add_definitions(-DWITH_EXTENSIONS)
-endif()
-
 target_link_libraries(${TARGET_NAME} ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES} common)
-
-if(TARGET IE::ie_cpu_extension)
-    target_link_libraries(${TARGET_NAME} IE::ie_cpu_extension)
-endif()
 
 if(UNIX)
     target_link_libraries( ${TARGET_NAME} pthread)

--- a/demos/multi_channel/human_pose_estimation_demo/CMakeLists.txt
+++ b/demos/multi_channel/human_pose_estimation_demo/CMakeLists.txt
@@ -60,13 +60,7 @@ if(MULTICHANNEL_DEMO_USE_TBB)
     endif()
 endif()
 
-if(TARGET IE::ie_cpu_extension)
-    add_definitions(-DWITH_EXTENSIONS)
-endif()
 target_link_libraries(${TARGET_NAME} ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES} common)
-if(TARGET IE::ie_cpu_extension)
-    target_link_libraries(${TARGET_NAME} IE::ie_cpu_extension)
-endif()
 
 if(UNIX)
     target_link_libraries( ${TARGET_NAME} pthread)

--- a/demos/multi_channel/object_detection_demo_yolov3/CMakeLists.txt
+++ b/demos/multi_channel/object_detection_demo_yolov3/CMakeLists.txt
@@ -60,15 +60,7 @@ if(MULTICHANNEL_DEMO_USE_TBB)
     endif()
 endif()
 
-if(TARGET IE::ie_cpu_extension)
-    add_definitions(-DWITH_EXTENSIONS)
-endif()
-
 target_link_libraries(${TARGET_NAME} ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES} common)
-
-if(TARGET IE::ie_cpu_extension)
-    target_link_libraries(${TARGET_NAME} IE::ie_cpu_extension)
-endif()
 
 if(UNIX)
     target_link_libraries( ${TARGET_NAME} pthread)

--- a/demos/object_detection_demo_faster_rcnn/main.cpp
+++ b/demos/object_detection_demo_faster_rcnn/main.cpp
@@ -11,9 +11,6 @@
 #include <limits>
 
 #include <inference_engine.hpp>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgcodecs.hpp>
@@ -80,18 +77,6 @@ int main(int argc, char *argv[]) {
         if (FLAGS_p_msg) {
             ie.SetLogCallback(error_listener);
         }
-
-#ifdef WITH_EXTENSIONS
-        /*If CPU device, load default library with extensions that comes with the product*/
-        if (FLAGS_d.find("CPU") != std::string::npos) {
-            /**
-            * cpu_extensions library is compiled from "extension" folder containing
-            * custom MKLDNNPlugin layer implementations. These layers are not supported
-            * by mkldnn, but they can be useful for inferencing custom topologies.
-            **/
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-        }
-#endif
 
         if (!FLAGS_l.empty()) {
             // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension

--- a/demos/object_detection_demo_ssd_async/main.cpp
+++ b/demos/object_detection_demo_ssd_async/main.cpp
@@ -24,9 +24,6 @@
 #include <samples/slog.hpp>
 
 #include "object_detection_demo_ssd_async.hpp"
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 using namespace InferenceEngine;
 
@@ -100,18 +97,6 @@ int main(int argc, char *argv[]) {
         std::cout << ie.GetVersions(FLAGS_d);
 
         /** Load extensions for the plugin **/
-
-#ifdef WITH_EXTENSIONS
-        /** Loading default extensions **/
-        if (FLAGS_d.find("CPU") != std::string::npos) {
-            /**
-             * cpu_extensions library is compiled from "extension" folder containing
-             * custom MKLDNNPlugin layer implementations. These layers are not supported
-             * by mkldnn, but they can be useful for inferring custom topologies.
-            **/
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-        }
-#endif
 
         if (!FLAGS_l.empty()) {
             // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension

--- a/demos/object_detection_demo_yolov3_async/main.cpp
+++ b/demos/object_detection_demo_yolov3_async/main.cpp
@@ -27,10 +27,6 @@
 
 #include "object_detection_demo_yolov3_async.hpp"
 
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
-
 using namespace InferenceEngine;
 
 bool ParseAndCheckCommandLine(int argc, char *argv[]) {
@@ -206,17 +202,6 @@ int main(int argc, char *argv[]) {
         std::cout << ie.GetVersions(FLAGS_d);
 
         /**Loading extensions to the devices **/
-
-#ifdef WITH_EXTENSIONS
-        /** Loading default extensions **/
-        if (FLAGS_d.find("CPU") != std::string::npos) {
-            /**
-             * cpu_extensions library is compiled from the "extension" folder containing
-             * custom CPU layer implementations.
-            **/
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-        }
-#endif
 
         if (!FLAGS_l.empty()) {
             // CPU extensions are loaded as a shared library and passed as a pointer to the base extension

--- a/demos/pedestrian_tracker_demo/src/utils.cpp
+++ b/demos/pedestrian_tracker_demo/src/utils.cpp
@@ -14,9 +14,6 @@
 #include <string>
 #include <set>
 #include <memory>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 using namespace InferenceEngine;
 
@@ -85,9 +82,6 @@ LoadInferenceEngine(const std::vector<std::string>& devices,
 
         /** Load extensions for the CPU device **/
         if ((device.find("CPU") != std::string::npos)) {
-#ifdef WITH_EXTENSIONS
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
             if (!custom_cpu_library.empty()) {
                 // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension
                 auto extension_ptr = make_so_pointer<IExtension>(custom_cpu_library);

--- a/demos/security_barrier_camera_demo/main.cpp
+++ b/demos/security_barrier_camera_demo/main.cpp
@@ -16,9 +16,6 @@
 #include <cldnn/cldnn_config.hpp>
 #include <inference_engine.hpp>
 #include <vpu/vpu_plugin_config.hpp>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 #include <monitors/presenter.h>
 #include <samples/ocv_common.hpp>
 #include <samples/args_helper.hpp>
@@ -720,11 +717,6 @@ int main(int argc, char* argv[]) {
             std::cout << ie.GetVersions(device) << std::endl;
 
             if ("CPU" == device) {
-#ifdef WITH_EXTENSIONS
-                /** Load default extensions lib for the CPU device (e.g. SSD's DetectionOutput)**/
-                ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
-
                 if (!FLAGS_l.empty()) {
                     // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension
                     auto extension_ptr = make_so_pointer<IExtension>(FLAGS_l);

--- a/demos/segmentation_demo/main.cpp
+++ b/demos/segmentation_demo/main.cpp
@@ -11,9 +11,6 @@
 #include <iomanip>
 
 #include <inference_engine.hpp>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 #include <format_reader_ptr.h>
 
@@ -79,18 +76,6 @@ int main(int argc, char *argv[]) {
         // --------------------------- 1. Load inference engine -------------------------------------
         slog::info << "Loading Inference Engine" << slog::endl;
         Core ie;
-
-#ifdef WITH_EXTENSIONS
-        /** Loading default extensions **/
-        if (FLAGS_d.find("CPU") != std::string::npos) {
-            /**
-             * cpu_extensions library is compiled from "extension" folder containing
-             * custom MKLDNNPlugin layer implementations. These layers are not supported
-             * by mkldnn, but they can be useful for inferring custom topologies.
-            **/
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-        }
-#endif
 
         if (!FLAGS_l.empty()) {
             // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -8,9 +8,6 @@
 #include <monitors/presenter.h>
 #include <samples/ocv_common.hpp>
 #include <samples/slog.hpp>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 #include <string>
 #include <memory>
 #include <limits>
@@ -614,10 +611,6 @@ int main(int argc, char* argv[]) {
 
             /** Load extensions for the CPU device **/
             if ((device.find("CPU") != std::string::npos)) {
-#ifdef WITH_EXTENSIONS
-                ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
-
                 if (!FLAGS_l.empty()) {
                     // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension
                     auto extension_ptr = make_so_pointer<IExtension>(FLAGS_l);

--- a/demos/super_resolution_demo/main.cpp
+++ b/demos/super_resolution_demo/main.cpp
@@ -13,9 +13,6 @@
 #include <memory>
 
 #include <inference_engine.hpp>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 #include <samples/slog.hpp>
 #include <samples/args_helper.hpp>
@@ -68,18 +65,6 @@ int main(int argc, char *argv[]) {
         /** Printing device version **/
         slog::info << "Device info: " << slog::endl;
         std::cout << ie.GetVersions(FLAGS_d) << std::endl;
-
-#ifdef WITH_EXTENSIONS
-        /** Loading default extensions **/
-        if (FLAGS_d.find("CPU") != std::string::npos) {
-            /**
-             * cpu_extensions library is compiled from "extension" folder containing
-             * custom MKLDNNPlugin layer implementations. These layers are not supported
-             * by mkldnn, but they can be useful for inferring custom topologies.
-            **/
-            ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-        }
-#endif
 
         if (!FLAGS_l.empty()) {
             // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension

--- a/demos/text_detection_demo/main.cpp
+++ b/demos/text_detection_demo/main.cpp
@@ -18,9 +18,6 @@
 #include <gflags/gflags.h>
 #include <opencv2/opencv.hpp>
 
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 #include <inference_engine.hpp>
 
 #include <monitors/presenter.h>
@@ -112,10 +109,6 @@ int main(int argc, char *argv[]) {
 
             /** Load extensions for the CPU device **/
             if ((device.find("CPU") != std::string::npos)) {
-#ifdef WITH_EXTENSIONS
-                ie.AddExtension(std::make_shared<Extensions::Cpu::CpuExtensions>(), "CPU");
-#endif
-
                 if (!FLAGS_l.empty()) {
                     // CPU(MKLDNN) extensions are loaded as a shared library and passed as a pointer to base extension
                     auto extension_ptr = make_so_pointer<IExtension>(FLAGS_l);


### PR DESCRIPTION
It's no longer needed with the current Inference Engine.