### PR TITLE
AC: fix a divide-by-zero warning in AverageMeter

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/metrics/average_meter.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/average_meter.py
@@ -41,7 +41,7 @@ class AverageMeter:
             loss = float(loss)
         else:
             loss = loss.astype(float)
-        return np.divide(loss, increment, out=np.zeros_like(loss), where=self.total_count != 0)
+        return np.divide(loss, increment, out=np.zeros_like(loss), where=increment != 0)
 
     def evaluate(self):
         if self.total_count is None:


### PR DESCRIPTION
We're dividing by `increment`, so that's what we should be checking. This was probably a copy-paste error from `evaluate`.