### PR TITLE
AC: remove durty hack for channels alignment in launcher

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -528,9 +528,6 @@ class DLSDKLauncher(Launcher):
             filled_part = [data[-1]] * diff_number
             data = np.concatenate([data, filled_part])
 
-        if len(data.shape) > 1 and len(input_shape) > 1 and data.shape[1] != input_shape[1]:
-            data = data[:, :input_shape[1]]
-
         return data.reshape(input_shape)
 
     def create_ie_plugin(self, log=True):

--- a/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
@@ -59,6 +59,8 @@ Accuracy Checker supports following set of preprocessors:
 * `bgr_to_gray` - converting image in BGR to gray scale color space.
 * `rgb_to_bgr` - reversing image channels. Convert image in RGB format to BGR.
 * `rgb_to_gray` - converting image in RGB to gray scale color space.
+* `select_channel` - select channel only one specified channel from multichannel image.
+  * `channel` - channel id in image (e.g. if you read image in RGB and want to select green channel, you need to specify 1 as channel)
 * `flip` - image mirroring around specified axis.
   * `mode` specifies the axis for flipping (`vertical` or `horizontal`).
 * `crop` - central cropping for image.

--- a/tools/accuracy_checker/accuracy_checker/preprocessor/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/__init__.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from .preprocessing_executor import PreprocessingExecutor
 from .preprocessor import Preprocessor
-from .color_space_conversion import BgrToRgb, RgbToBgr, BgrToGray, RgbToGray, TfConvertImageDType
+from .color_space_conversion import BgrToRgb, RgbToBgr, BgrToGray, RgbToGray, TfConvertImageDType, SelectInputChannel
 from .normalization import Normalize, Normalize3d
 from .geometric_transformations import (
     GeometricOperationMetadata,
@@ -54,11 +54,13 @@ __all__ = [
     'CropBraTS',
     'TransformedCropWithAutoScale',
     'ImagePyramid',
+
     'BgrToGray',
     'BgrToRgb',
     'RgbToGray',
     'RgbToBgr',
     'TfConvertImageDType',
+    'SelectInputChannel',
 
     'Normalize3d',
     'Normalize',


### PR DESCRIPTION
for unet2d where used only single channel was implemented functional for getting specified channel inside the launcher. It is wrong solution, because make a lot of inconvenience for working with non-default layout and lead to unexpected behaviour for models working with grayscale images.
Necessary logic moved to preprocessor.