### PR TITLE
mask_rcnn_demo: use the documented output of the models

### DIFF
--- a/demos/mask_rcnn_demo/README.md
+++ b/demos/mask_rcnn_demo/README.md
@@ -28,8 +28,8 @@ Options:
       -l "<absolute_path>"            Required for CPU custom layers. Absolute path to a shared library with the kernels implementations.
           Or
       -c "<absolute_path>"            Required for GPU custom kernels. Absolute path to the .xml file with the kernels descriptions.
-    -d "<device>"                     Optional. Specify the target device to infer on (the list of available devices is shown below). Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The demo will look for a suitable plugin for a specified device (CPU by default).
-    -detection_output_name "<string>" Optional. The name of detection output layer. Default value is "detection_output"
+    -d "<device>"                     Optional. Specify the target device to infer on (the list of available devices is shown below). Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The demo will look for a suitable plugin for a specified device (CPU by default)
+    -detection_output_name "<string>" Optional. The name of detection output layer. Default value is "reshape_do_2d"
     -masks_name "<string>"            Optional. The name of masks layer. Default value is "masks"
 ```
 

--- a/demos/mask_rcnn_demo/main.cpp
+++ b/demos/mask_rcnn_demo/main.cpp
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
         const float PROBABILITY_THRESHOLD = 0.2f;
         const float MASK_THRESHOLD = 0.5f;  // threshold used to determine whether mask pixel corresponds to object or to background
         // amount of elements in each detected box description (batch, label, prob, x1, y1, x2, y2)
-        IE_ASSERT(do_blob->getTensorDesc().getDims().size() == 4);
+        IE_ASSERT(do_blob->getTensorDesc().getDims().size() == 2);
         size_t BOX_DESCRIPTION_SIZE = do_blob->getTensorDesc().getDims().back();
 
         const TensorDesc& masksDesc = masks_blob->getTensorDesc();

--- a/demos/mask_rcnn_demo/mask_rcnn_demo.h
+++ b/demos/mask_rcnn_demo/mask_rcnn_demo.h
@@ -19,7 +19,7 @@ static const char custom_cldnn_message[] = "Required for GPU custom kernels. "\
                                            "Absolute path to the .xml file with the kernels descriptions.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. " \
                                                  "Absolute path to a shared library with the kernels implementations.";
-static const char detection_output_layer_name_message[] = "Optional. The name of detection output layer. Default value is \"detection_output\"";
+static const char detection_output_layer_name_message[] = "Optional. The name of detection output layer. Default value is \"reshape_do_2d\"";
 static const char masks_layer_name_message[] = "Optional. The name of masks layer. Default value is \"masks\"";
 
 DEFINE_string(c, "", custom_cldnn_message);
@@ -28,7 +28,7 @@ DEFINE_bool(h, false, help_message);
 DEFINE_string(i, "", image_message);
 DEFINE_string(m, "", model_message);
 DEFINE_string(d, "CPU", target_device_message);
-DEFINE_string(detection_output_name, "detection_output", detection_output_layer_name_message);
+DEFINE_string(detection_output_name, "reshape_do_2d", detection_output_layer_name_message);
 DEFINE_string(masks_name, "masks", masks_layer_name_message);
 
 /**


### PR DESCRIPTION
The documented output is `reshape_do_2d`, not `detection_output`. The current code has worked so far, because a layer named `detection_output` also exists in the network; however, it's an internal layer and we shouldn't be relying on it.

Note that currently, `detection_output` is also marked by MO as an output (unless you use IR v7). This might, however, be a bug. An internal report already exists for it.