### PR TITLE
demos: fix the languages specified for code blocks in the docs

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -167,14 +167,14 @@ The recommended Windows* build environment is the following:
 
 To build the demo applications for Windows, go to the directory with the `build_demos_msvc.bat`
 batch file and run it:
-```sh
+```bat
 build_demos_msvc.bat
 ```
 
 By default, the script automatically detects the highest Microsoft Visual Studio version installed on the machine and uses it to create and build
 a solution for a demo code. Optionally, you can also specify the preffered Microsoft Visual Studio version to be used by the script. Supported
 versions are: `VS2015`, `VS2017`, `VS2019`. For example, to build the demos using the Microsoft Visual Studio 2017, use the following command:
-```sh
+```bat
 build_demos_msvc.bat VS2017
 ```
 
@@ -243,7 +243,7 @@ list above.
 Before running compiled binary files, make sure your application can find the Inference Engine and OpenCV libraries.
 If you use a [proprietary](https://software.intel.com/en-us/openvino-toolkit) distribution to build demos,
 run the `setupvars` script to set all necessary environment variables:
-```sh
+```bat
 <INSTALL_DIR>\bin\setupvars.bat
 ```
 If you use your own Inference Engine and OpenCV binaries to build the demos please make sure you have added
@@ -265,7 +265,7 @@ For example, for the **Debug** configuration, go to the project's
 **Configuration Properties** to the **Debugging** category and set the `PATH`
 variable in the **Environment** field to the following:
 
-```sh
+```
 PATH=<INSTALL_DIR>\deployment_tools\inference_engine\bin\intel64\Debug;<INSTALL_DIR>\opencv\bin;%PATH%
 ```
 where `<INSTALL_DIR>` is the directory in which the OpenVINO toolkit is installed.

--- a/demos/crossroad_camera_demo/README.md
+++ b/demos/crossroad_camera_demo/README.md
@@ -36,7 +36,7 @@ REID value is assigned. Otherwise, the vector is added to a global list, and new
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./crossroad_camera_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/gaze_estimation_demo/README.md
+++ b/demos/gaze_estimation_demo/README.md
@@ -27,7 +27,7 @@ Other demo objectives are:
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./gaze_estimation_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/human_pose_estimation_demo/README.md
+++ b/demos/human_pose_estimation_demo/README.md
@@ -21,7 +21,7 @@ On the start-up, the application reads command line parameters and loads human p
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./human_pose_estimation_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/interactive_face_detection_demo/README.md
+++ b/demos/interactive_face_detection_demo/README.md
@@ -37,7 +37,7 @@ The new Async API operates with a new notion of the Infer Request that encapsula
 
 Running the application with the `-h` option yields the following usage message:
 
-```sh
+```
 ./interactive_face_detection_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/mask_rcnn_demo/README.md
+++ b/demos/mask_rcnn_demo/README.md
@@ -13,7 +13,7 @@ Upon the start-up, the demo application reads command line parameters and loads 
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./mask_rcnn_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/multi_channel/face_detection_demo/README.md
+++ b/demos/multi_channel/face_detection_demo/README.md
@@ -22,7 +22,7 @@ On the start-up, the application reads command line parameters and loads the spe
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./multi_channel_face_detection_demo -h
 
 multi_channel_face_detection_demo [OPTION]
@@ -85,7 +85,7 @@ General parameter for input video source is `-i`. Use it to specify video files 
 
 To see all available web cameras, run the `ls /dev/video*` command. You will get output similar to the following:
 
-```sh
+```
 user@user-PC:~ $ ls /dev/video*
 /dev/video0  /dev/video1  /dev/video2
 ```

--- a/demos/multi_channel/human_pose_estimation_demo/README.md
+++ b/demos/multi_channel/human_pose_estimation_demo/README.md
@@ -22,7 +22,7 @@ On the start-up, the application reads command line parameters and loads the spe
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./multi_channel_human_pose_estimation_demo -h
 multi_channel_human_pose_estimation_demo [OPTION]
 Options:
@@ -85,7 +85,7 @@ General parameter for input video source is `-i`. Use it to specify video files 
 
 To see all available web cameras, run the `ls /dev/video*` command. You will get output similar to the following:
 
-```sh
+```
 user@user-PC:~ $ ls /dev/video*
 /dev/video0  /dev/video1  /dev/video2
 ```

--- a/demos/multi_channel/object_detection_demo_yolov3/README.md
+++ b/demos/multi_channel/object_detection_demo_yolov3/README.md
@@ -21,7 +21,7 @@ On the start-up, the application reads command line parameters and loads the spe
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 cd <samples_build_folder>/intel64/Release
 ./multi_channel_object_detection_demo_yolov3 -h
 
@@ -92,7 +92,7 @@ General parameter for input video source is `-i`. Use it to specify video files 
 
 To see all available web cameras, run the `ls /dev/video*` command. You will get output similar to the following:
 
-```sh
+```
 user@user-PC:~ $ ls /dev/video*
 /dev/video0  /dev/video1  /dev/video2
 ```

--- a/demos/object_detection_demo_faster_rcnn/README.md
+++ b/demos/object_detection_demo_faster_rcnn/README.md
@@ -29,7 +29,7 @@ output image and outputs data to the standard output stream.
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./object_detection_demo_faster_rcnn -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/object_detection_demo_ssd_async/README.md
+++ b/demos/object_detection_demo_ssd_async/README.md
@@ -99,7 +99,7 @@ For more details on the requests-based Inference Engine API, including the Async
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./object_detection_demo_ssd_async -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/object_detection_demo_yolov3_async/README.md
+++ b/demos/object_detection_demo_yolov3_async/README.md
@@ -25,7 +25,7 @@ Engine. Upon getting a frame from the OpenCV VideoCapture, it performs inference
 ## Running
 
 Running the application with the <code>-h</code> option yields the following usage message:
-```sh
+```
 ./object_detection_demo_yolov3_async -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/pedestrian_tracker_demo/README.md
+++ b/demos/pedestrian_tracker_demo/README.md
@@ -27,7 +27,7 @@ After that, the application displays the tracks and the latest detections on the
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./pedestrian_tracker_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/python_demos/colorization_demo/README.md
+++ b/demos/python_demos/colorization_demo/README.md
@@ -21,7 +21,7 @@ Having received the image, the program:
 
 Running the application with the `-h` option yields the following usage message:
 
-```sh
+```
 colorization_demo.py -h
 
 usage: colorization_demo.py [-h] -m MODEL --coeffs COEFFS [-d DEVICE] -i

--- a/demos/python_demos/face_recognition_demo/README.md
+++ b/demos/python_demos/face_recognition_demo/README.md
@@ -71,7 +71,7 @@ pip install -r requirements.txt
 Running the application with the `-h` option or without
 any arguments yields the following message:
 
-``` sh
+```
 python ./face_recognition_demo.py -h
 
 usage: face_recognition_demo.py [-h] [-i PATH] [-o PATH] [--no_show] [-tl]
@@ -185,7 +185,7 @@ python ./face_recognition_demo.py \
 
 Windows (`cmd`, `powershell`) (assuming OpenVINO installed in `C:/Intel/openvino`):
 
-``` powershell
+```bat
 # Set up the environment
 call C:/Intel/openvino/bin/setupvars.bat
 

--- a/demos/security_barrier_camera_demo/README.md
+++ b/demos/security_barrier_camera_demo/README.md
@@ -42,7 +42,7 @@ At the end of the sequence, the `VideoFrame` is destroyed and the sequence start
 ## Running
 
 Running the application with the <code>-h</code> option yields the following usage message:
-```sh
+```
 [ INFO ] InferenceEngine: <version>
 
 interactive_vehicle_detection [OPTION]
@@ -102,7 +102,7 @@ To do inference for two video inputs using two asynchronous infer request on FPG
 > * `tagLPR` for the License Plate Recognition network
 >
 > For example, to run the sample on one Intel® Vision Accelerator Design with Intel® Movidius™ VPUs Compact R card with eight Intel&reg; Movidius&trade; X VPUs:
-> ```sh
+> ```json
 > "service_settings":
 > {
 >  "graph_tag_map":{"tagDetect": 6, "tagAttr": 1, "tagLPR": 1}

--- a/demos/segmentation_demo/README.md
+++ b/demos/segmentation_demo/README.md
@@ -13,7 +13,7 @@ Upon the start-up the demo application reads command line parameters and loads a
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./segmentation_demo -h
 [ INFO ] InferenceEngine: <version>
 [ INFO ] Parsing input parameters

--- a/demos/smart_classroom_demo/README.md
+++ b/demos/smart_classroom_demo/README.md
@@ -29,7 +29,7 @@ To recognize faces on a frame, the demo needs a gallery of reference images. Eac
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./smart_classroom_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/super_resolution_demo/README.md
+++ b/demos/super_resolution_demo/README.md
@@ -21,7 +21,7 @@ performs upscale using super resolution model.
 ## Running
 
 Running the application with the `-h` option yields the following usage message:
-```sh
+```
 ./super_resolution_demo -h
 InferenceEngine:
     API version ............ <version>

--- a/demos/text_detection_demo/README.md
+++ b/demos/text_detection_demo/README.md
@@ -20,7 +20,7 @@ If text recognition model is provided, the demo prints recognized text as well.
 ## Running
 
 Running the application with the <code>-h</code> option yields the following usage message:
-```sh
+```
 ./text_detection_demo -h
 
 text_detection_demo [OPTION]


### PR DESCRIPTION
Mostly, just remove `sh` from blocks with help text, since they are not in any formal language. But there are also a few cases where a block was labeled with the wrong language.