### PR TITLE
pytorch_to_onnx.py: use importlib instead of __import__

### DIFF
--- a/tools/downloader/pytorch_to_onnx.py
+++ b/tools/downloader/pytorch_to_onnx.py
@@ -1,6 +1,8 @@
 import argparse
-from pathlib import Path
+import importlib
 import sys
+
+from pathlib import Path
 
 import onnx
 import torch
@@ -82,7 +84,7 @@ def load_model(model_name, weights, from_torchvision, model_path, module_name, m
     else:
         sys.path.append(model_path)
         try:
-            module = __import__(module_name)
+            module = importlib.import_module(module_name)
             creator = getattr(module, model_name)
             model = creator(**model_params)
         except ImportError as err:


### PR DESCRIPTION
`__import__` has surprising behavior when you try to import a submodule (e.g. `foo.bar`), where it returns the `foo` package instead of the `foo.bar` module. This prevents non-top-level modules from being used with the `--import-module` option. `importlib.import_module` does not have this problem.