### PR TITLE
demos/multi_channel: don't crash if input files don't exist

### DIFF
--- a/demos/multi_channel/face_detection_demo/main.cpp
+++ b/demos/multi_channel/face_detection_demo/main.cpp
@@ -252,6 +252,10 @@ int main(int argc, char* argv[]) {
         const auto duplicateFactor = (1 + FLAGS_duplicate_num);
         size_t numberOfInputs = (FLAGS_nc + files.size()) * duplicateFactor;
 
+        if (numberOfInputs == 0) {
+            throw std::runtime_error("No valid inputs were supplied");
+        }
+
         DisplayParams params = prepareDisplayParams(numberOfInputs);
 
         slog::info << "\tNumber of input channels:    " << numberOfInputs << slog::endl;

--- a/demos/multi_channel/human_pose_estimation_demo/main.cpp
+++ b/demos/multi_channel/human_pose_estimation_demo/main.cpp
@@ -250,6 +250,10 @@ int main(int argc, char* argv[]) {
         const auto duplicateFactor = (1 + FLAGS_duplicate_num);
         size_t numberOfInputs = (FLAGS_nc + files.size()) * duplicateFactor;
 
+        if (numberOfInputs == 0) {
+            throw std::runtime_error("No valid inputs were supplied");
+        }
+
         DisplayParams params = prepareDisplayParams(numberOfInputs);
 
         slog::info << "\tNumber of input channels:    " << numberOfInputs << slog::endl;

--- a/demos/multi_channel/object_detection_demo_yolov3/main.cpp
+++ b/demos/multi_channel/object_detection_demo_yolov3/main.cpp
@@ -417,6 +417,10 @@ int main(int argc, char* argv[]) {
         const auto duplicateFactor = (1 + FLAGS_duplicate_num);
         size_t numberOfInputs = (FLAGS_nc + files.size()) * duplicateFactor;
 
+        if (numberOfInputs == 0) {
+            throw std::runtime_error("No valid inputs were supplied");
+        }
+
         DisplayParams params = prepareDisplayParams(numberOfInputs);
 
         slog::info << "\tNumber of input channels:    " << numberOfInputs << slog::endl;


### PR DESCRIPTION
`parseInputFilesArguments` removes any files that don't exist, so it's possible for `numberOfInputs` to be 0. In this case, `prepareDisplayParams` will divide by 0. Don't let that happen.