### PR TITLE
AC: fix outputs

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/action_recognition.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/action_recognition.py
@@ -20,6 +20,7 @@ import numpy as np
 from ..adapters import Adapter
 from ..config import ConfigValidator, StringField, NumberField, BoolField, ListField
 from ..representation import DetectionPrediction, ActionDetectionPrediction, ContainerPrediction
+from ..utils import contains_all
 
 
 class ActionDetection(Adapter):
@@ -293,5 +294,8 @@ class ActionDetection(Adapter):
 
         self.loc_out = find_layer(loc_out_regex, 'loc', raw_outputs)
         self.main_conf_out = find_layer(main_conf_out_regex, 'main confidence', raw_outputs)
+        add_conf_with_bias = [layer_name + '/add_' for layer_name in self.add_conf_outs]
+        if not contains_all(raw_outputs, self.add_conf_outs) and contains_all(raw_outputs, add_conf_with_bias):
+            self.add_conf_outs = add_conf_with_bias
 
         self.outputs_verified = True

--- a/tools/accuracy_checker/accuracy_checker/adapters/pose_estimation.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/pose_estimation.py
@@ -23,6 +23,7 @@ import numpy as np
 from ..adapters import Adapter
 from ..config import ConfigValidator, StringField, ConfigError
 from ..representation import PoseEstimationPrediction
+from ..utils import contains_any
 
 
 class HumanPoseAdapter(Adapter):
@@ -67,15 +68,25 @@ class HumanPoseAdapter(Adapter):
                     'human_pose_estimation adapter should contains both: keypoints_heatmap_out '
                     'and part_affinity_fields_out or not contain them at all (in single output model case)'
                 )
+        self._keypoints_heatmap_bias = self.keypoints_heatmap + '/add_'
+        self._part_affinity_fileds_bias = self.part_affinity_fields + '/add_'
 
     def process(self, raw, identifiers=None, frame_meta=None):
         result = []
         raw_outputs = self._extract_predictions(raw, frame_meta)
         if not self.concat_out:
-            raw_output = zip(
-                identifiers, raw_outputs[self.keypoints_heatmap],
-                raw_outputs[self.part_affinity_fields], frame_meta
-            )
+            if not contains_any(raw_outputs, self.part_affinity_fields, self._part_affinity_fileds_bias):
+                raise ConfigError('part affinity fields output not found')
+            if not contains_any(raw_outputs, self.keypoints_heatmap, self._keypoints_heatmap_bias):
+                raise ConfigError('keypoints heatmap output not found')
+            keypoints_heatmap = raw_outputs[
+                self.keypoints_heatmap if self.keypoints_heatmap in raw_outputs else self._keypoints_heatmap_bias
+            ]
+            pafs = raw_outputs[
+                self.part_affinity_fields if self.part_affinity_fields in raw_outputs
+                else self._part_affinity_fileds_bias
+            ]
+            raw_output = zip(identifiers, keypoints_heatmap, pafs, frame_meta)
         else:
             concat_out = raw_outputs[self.output_blob]
             keypoints_num = concat_out.shape[1] // 3


### PR DESCRIPTION
quantization tool is able to add biases to output convolutions in runtime, it leads to temporal outputs renaming