### PR TITLE
pytorch_to_onnx.py: remove --from-torchvision

### DIFF
--- a/models/public/googlenet-v3-pytorch/model.yml
+++ b/models/public/googlenet-v3-pytorch/model.yml
@@ -33,7 +33,7 @@ framework: pytorch
 conversion_to_onnx_args:
   - --model-name=inception_v3
   - --weights=$dl_dir/inception_v3_google-1a9a5a14.pth
-  - --from-torchvision
+  - --import-module=torchvision.models
   - --input-shape=1,3,299,299
   - --output-file=$conv_dir/googlenet-v3.onnx
   - --input-names=data

--- a/models/public/resnet-18-pytorch/model.yml
+++ b/models/public/resnet-18-pytorch/model.yml
@@ -33,7 +33,7 @@ framework: pytorch
 conversion_to_onnx_args:
   - --model-name=resnet18
   - --weights=$dl_dir/resnet18-5c106cde.pth
-  - --from-torchvision
+  - --import-module=torchvision.models
   - --input-shape=1,3,224,224
   - --output-file=$conv_dir/resnet-18-pytorch.onnx
   - --input-names=data

--- a/models/public/resnet-50-pytorch/model.yml
+++ b/models/public/resnet-50-pytorch/model.yml
@@ -33,7 +33,7 @@ framework: pytorch
 conversion_to_onnx_args:
   - --model-name=resnet50
   - --weights=$dl_dir/resnet50-19c8e357.pth
-  - --from-torchvision
+  - --import-module=torchvision.models
   - --input-shape=1,3,224,224
   - --output-file=$conv_dir/resnet-v1-50.onnx
   - --input-names=data


### PR DESCRIPTION
This flag is redundant, as `--import-module=torchvision.models` has the same effect (with the only difference being a slightly less clear error message when the package is missing). Removing it simplifies the code.

As a side effect, this also allows using `--model-param` with torchvision models, although there is currently no reason to do so.