### PR TITLE
text-detection-????: fix output documentation

### DIFF
--- a/models/intel/text-detection-0003/description/text-detection-0003.md
+++ b/models/intel/text-detection-0003/description/text-detection-0003.md
@@ -33,9 +33,11 @@ Text detector based on [PixelLink](https://arxiv.org/pdf/1801.01315.pdf) archite
 
 ## Outputs
 
-1. The net outputs two blobs. Refer to [PixelLink](https://arxiv.org/pdf/1801.01315.pdf) and demos for details.
-    - [1x2x192x320] - logits related to text/no-text classification for each pixel.
-    - [1x16x192x320] - logits related to linkage between pixels and their neighbors.
+1. name: "model/link\_logits\_/add", shape: [1x16x192x320] - logits related to linkage between pixels and their neighbors.
+
+2. name: "model/segm\_logits/add", shape: [1x2x192x320] - logits related to text/no-text classification for each pixel.
+
+Refer to [PixelLink](https://arxiv.org/pdf/1801.01315.pdf) and demos for details.
 
 ## Legal Information
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/text-detection-0004/description/text-detection-0004.md
+++ b/models/intel/text-detection-0004/description/text-detection-0004.md
@@ -33,9 +33,11 @@ Text detector based on [PixelLink](https://arxiv.org/pdf/1801.01315.pdf) archite
 
 ## Outputs
 
-1. The net outputs two blobs. Refer to [PixelLink](https://arxiv.org/pdf/1801.01315.pdf) and demos for details.
-    - [1x2x192x320] - logits related to text/no-text classification for each pixel.
-    - [1x16x192x320] - logits related to linkage between pixels and their neighbors.
+1. name: "model/link\_logits\_/add", shape: [1x16x192x320] - logits related to linkage between pixels and their neighbors.
+
+2. name: "model/segm\_logits/add", shape: [1x2x192x320] - logits related to text/no-text classification for each pixel.
+
+Refer to [PixelLink](https://arxiv.org/pdf/1801.01315.pdf) and demos for details.
 
 ## Legal Information
 [*] Other names and brands may be claimed as the property of others.


### PR DESCRIPTION
The outputs are listed in the wrong order (IE returns them in alphabetical order). Fix the order and list the names too.

Fixes #880.