### PR TITLE
Replace the link to the Biwi Kinect Head Pose Database

### DIFF
--- a/models/intel/head-pose-estimation-adas-0001/description/head-pose-estimation-adas-0001.md
+++ b/models/intel/head-pose-estimation-adas-0001/description/head-pose-estimation-adas-0001.md
@@ -8,7 +8,7 @@ one output.
 
 ## Validation Dataset
 
-[Biwi Kinect Head Pose Database](https://data.vision.ee.ethz.ch/cvl/gfanelli/head_pose/head_forest.html)
+[Biwi Kinect Head Pose Database](https://www.vision.ee.ethz.ch/en/datasets/)
 
 ## Example
 


### PR DESCRIPTION
Sadly, it appears that ETH Zürich took this dataset down. The best thing we can do now is to point to the dataset index page.