### PR TITLE
Replace the link to the Biwi Kinect Head Pose Database... again

### DIFF
--- a/models/intel/head-pose-estimation-adas-0001/description/head-pose-estimation-adas-0001.md
+++ b/models/intel/head-pose-estimation-adas-0001/description/head-pose-estimation-adas-0001.md
@@ -8,7 +8,7 @@ one output.
 
 ## Validation Dataset
 
-[Biwi Kinect Head Pose Database](https://www.vision.ee.ethz.ch/en/datasets/)
+[Biwi Kinect Head Pose Database](https://icu.ee.ethz.ch/research/datsets.html)
 
 ## Example
 


### PR DESCRIPTION
Literally hours after I submitted #912, ETHZ removed the page I linked to. Fortunately, it looks like it was just moved to a different location.