### PR TITLE
revert icnet name

### DIFF
--- a/models/intel/icnet-camvid-ava-tf-0001/description/icnet-camvid-ava-tf-0001.md
+++ b/models/intel/icnet-camvid-ava-tf-0001/description/icnet-camvid-ava-tf-0001.md
@@ -1,4 +1,4 @@
-# icnet-camvid-tf-ava-0001
+# icnet-camvid-ava-tf-0001
 
 ## Use Case and High-Level Description
 
@@ -6,7 +6,7 @@ A trained model of ICNet for fast semantic segmentation, trained on the CamVid\*
 
 The model input is a blob that consists of a single image of "1x3x720x960" in BGR order. The pixel values are integers in the [0, 255] range.
 
-The model output for `icnet-camvid-tf-ava-0001` is the predicted class index of each input pixel belonging to one of the 12 classes of the CamVid dataset.
+The model output for `icnet-camvid-ava-tf-0001` is the predicted class index of each input pixel belonging to one of the 12 classes of the CamVid dataset.
 
 ## Specification
 

--- a/models/intel/icnet-camvid-ava-tf-sparse-30-0001/description/icnet-camvid-ava-tf-sparse-30-0001.md
+++ b/models/intel/icnet-camvid-ava-tf-sparse-30-0001/description/icnet-camvid-ava-tf-sparse-30-0001.md
@@ -1,4 +1,4 @@
-# icnet-camvid-tf-ava-sparse-30-0001
+# icnet-camvid-ava-tf-sparse-30-0001
 
 ## Use Case and High-Level Description
 
@@ -6,7 +6,7 @@ A trained model of ICNet for fast semantic segmentation, trained on the CamVid\*
 
 The model input is a blob that consists of a single image of "1x3x720x960" in BGR order. The pixel values are integers in the [0, 255] range.
 
-The model output for `icnet-camvid-tf-ava-0001` is the predicted class index of each input pixel belonging to one of the 12 classes of the CamVid dataset.
+The model output for `icnet-camvid-ava-tf-sparse-30-0001` is the predicted class index of each input pixel belonging to one of the 12 classes of the CamVid dataset.
 
 ## Specification
 

--- a/models/intel/icnet-camvid-ava-tf-sparse-60-0001/description/icnet-camvid-tf-ava-sparse-60-0001.md
+++ b/models/intel/icnet-camvid-ava-tf-sparse-60-0001/description/icnet-camvid-tf-ava-sparse-60-0001.md
@@ -1,4 +1,4 @@
-# icnet-camvid-tf-ava-sparse-60-0001
+# icnet-camvid-ava-tf-sparse-60-0001
 
 ## Use Case and High-Level Description
 
@@ -6,7 +6,7 @@ A trained model of ICNet for fast semantic segmentation, trained on the CamVid\*
 
 The model input is a blob that consists of a single image of "1x3x720x960" in BGR order. The pixel values are integers in the [0, 255] range.
 
-The model output for `icnet-camvid-tf-ava-0001` is the predicted class index of each input pixel belonging to one of the 12 classes of the CamVid dataset.
+The model output for `icnet-camvid-ava-tf-sparse-60-0001` is the predicted class index of each input pixel belonging to one of the 12 classes of the CamVid dataset.
 
 ## Specification
 

--- a/models/intel/index.md
+++ b/models/intel/index.md
@@ -110,9 +110,9 @@ detect areas with complex shape (for example, free space on the road).
 | [road-segmentation-adas-0001](./road-segmentation-adas-0001/description/road-segmentation-adas-0001.md)                                        | 4.770                | 0.184      |
 | [semantic-segmentation-adas-0001](./semantic-segmentation-adas-0001/description/semantic-segmentation-adas-0001.md)                            | 58.572               | 6.686      |
 | [unet-camvid-onnx-0001](./unet-camvid-onnx-0001/description/unet-camvid-onnx-0001.md)                                                          | 260.1                | 31.03      |
-| [icnet-camvid-tf-ava-0001](./icnet-camvid-tf-ava-0001/description/icnet-camvid-tf-ava-0001.md)                                                   | 151.82                | 25.45       |
-| [icnet-camvid-tf-ava-sparse-30-0001](./icnet-camvid-tf-ava-sparse-30-0001/description/icnet-camvid-tf-ava-sparse-30-0001.md)                     | 151.82                | 25.45       |
-| [icnet-camvid-tf-ava-sparse-60-0001](./icnet-camvid-tf-ava-sparse-60-0001/description/icnet-camvid-tf-ava-sparse-60-0001.md)                     | 151.82                | 25.45       |
+| [icnet-camvid-ava-tf-0001](./icnet-camvid-ava-tf-0001/description/icnet-camvid-ava-tf-0001.md)                                                   | 151.82                | 25.45       |
+| [icnet-camvid-ava-tf-sparse-30-0001](./icnet-camvid-ava-tf-sparse-30-0001/description/icnet-camvid-ava-tf-sparse-30-0001.md)                     | 151.82                | 25.45       |
+| [icnet-camvid-ava-tf-sparse-60-0001](./icnet-camvid-ava-tf-sparse-60-0001/description/icnet-camvid-ava-tf-sparse-60-0001.md)                     | 151.82                | 25.45       |
 
 ## Instance Segmentation Models
 


### PR DESCRIPTION
revert icname back, no need to play with ava-tf or tf-ava