### PR TITLE
models/public: round the scale values

### DIFF
--- a/models/public/googlenet-v3/model.yml
+++ b/models/public/googlenet-v3/model.yml
@@ -31,7 +31,7 @@ model_optimizer_args:
   - --input_shape=[1,299,299,3]
   - --input=input
   - --mean_values=input[127.5,127.5,127.5]
-  - --scale_values=input[127.50000414375013]
+  - --scale_values=input[127.5]
   - --output=InceptionV3/Predictions/Softmax
   - --input_model=$dl_dir/inception_v3_2016_08_28_frozen.pb
 framework: tf

--- a/models/public/inception-resnet-v2-tf/model.yml
+++ b/models/public/inception-resnet-v2-tf/model.yml
@@ -31,7 +31,7 @@ model_optimizer_args:
   - --input_shape=[1,299,299,3]
   - --input=input
   - --mean_values=input[127.5,127.5,127.5]
-  - --scale_values=input[127.50000414375013]
+  - --scale_values=input[127.5]
   - --output=InceptionResnetV2/AuxLogits/Logits/BiasAdd
   - --input_model=$dl_dir/inception_resnet_v2.pb
 framework: tf

--- a/models/public/license-plate-recognition-barrier-0007/model.yml
+++ b/models/public/license-plate-recognition-barrier-0007/model.yml
@@ -29,7 +29,7 @@ model_optimizer_args:
   - --reverse_input_channels
   - --input_shape=[1,24,94,3]
   - --input=input
-  - --scale_values=input[254.99997577500233]
+  - --scale_values=input[255.0]
   - --output=d_predictions
   - --input_model=$dl_dir/license-plate-recognition-barrier-0007/graph.pb.frozen
 framework: tf

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -37,7 +37,7 @@ Image, name - `prob`,  shape - `1,3,300,300`, format is `B,C,H,W` where:
 - `W` - width
 
 Channel order is `BGR`.
-Mean values - [127.5, 127.5, 127.5], scale value - 127.50223128904757.
+Mean values - [127.5, 127.5, 127.5], scale value - 127.5.
 
 ### Converted model
 

--- a/models/public/mobilenet-ssd/model.yml
+++ b/models/public/mobilenet-ssd/model.yml
@@ -40,7 +40,7 @@ model_optimizer_args:
   - --input_shape=[1,3,300,300]
   - --input=data
   - --mean_values=data[127.5,127.5,127.5]
-  - --scale_values=data[127.50223128904757]
+  - --scale_values=data[127.5]
   - --output=detection_out
   - --input_model=$dl_dir/mobilenet-ssd.caffemodel
   - --input_proto=$dl_dir/mobilenet-ssd.prototxt

--- a/models/public/mobilenet-v1-0.25-128/model.yml
+++ b/models/public/mobilenet-v1-0.25-128/model.yml
@@ -32,7 +32,7 @@ model_optimizer_args:
   - --input_shape=[1,128,128,3]
   - --input=input
   - --mean_values=input[127.5,127.5,127.5]
-  - --scale_values=input[127.50000414375013]
+  - --scale_values=input[127.5]
   - --output=MobilenetV1/Predictions/Reshape_1
   - --input_model=$dl_dir/mobilenet_v1_0.25_128_frozen.pb
 framework: tf

--- a/models/public/mobilenet-v1-0.50-160/model.yml
+++ b/models/public/mobilenet-v1-0.50-160/model.yml
@@ -32,7 +32,7 @@ model_optimizer_args:
   - --input_shape=[1,160,160,3]
   - --input=input
   - --mean_values=input[127.5,127.5,127.5]
-  - --scale_values=input[127.50000414375013]
+  - --scale_values=input[127.5]
   - --output=MobilenetV1/Predictions/Reshape_1
   - --input_model=$dl_dir/mobilenet_v1_0.5_160_frozen.pb
 framework: tf

--- a/models/public/mobilenet-v1-0.50-224/model.yml
+++ b/models/public/mobilenet-v1-0.50-224/model.yml
@@ -32,7 +32,7 @@ model_optimizer_args:
   - --input_shape=[1,224,224,3]
   - --input=input
   - --mean_values=input[127.5,127.5,127.5]
-  - --scale_values=input[127.50000414375013]
+  - --scale_values=input[127.5]
   - --output=MobilenetV1/Predictions/Reshape_1
   - --input_model=$dl_dir/mobilenet_v1_0.5_224_frozen.pb
 framework: tf

--- a/models/public/mobilenet-v1-1.0-224-tf/model.yml
+++ b/models/public/mobilenet-v1-1.0-224-tf/model.yml
@@ -32,7 +32,7 @@ model_optimizer_args:
   - --input_shape=[1,224,224,3]
   - --input=input
   - --mean_values=input[127.5,127.5,127.5]
-  - --scale_values=input[127.50000414375013]
+  - --scale_values=input[127.5]
   - --output=MobilenetV1/Predictions/Reshape_1
   - --input_model=$dl_dir/mobilenet_v1_1.0_224_frozen.pb
 framework: tf


### PR DESCRIPTION
The unnecessarily precise scale values were previously used for compatibility with the internal benchmarking infrastructure, but due to recent internal changes, they are no longer necessary.