### PR TITLE
AC: fix encode segm mask

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/postprocessor/encode_segmentation_mask.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/encode_segmentation_mask.py
@@ -50,7 +50,7 @@ class EncodeSegMask(PostprocessorWithSpecificTargets):
                 encoded_mask[np.where(
                     np.all(mask == color, axis=-1) if num_channels >= 3 else mask == color
                 )[:2]] = label
-            annotation_.mask = encoded_mask
+            annotation_.mask = encoded_mask.astype(np.int8)
 
         for prediction_ in prediction:
             mask = prediction_.mask
@@ -64,6 +64,6 @@ class EncodeSegMask(PostprocessorWithSpecificTargets):
 
             updated_mask[saved_mask >= len(prediction_to_gt_label)] = 255
 
-            prediction_.mask = updated_mask
+            prediction_.mask = updated_mask.astype(np.int8)
 
         return annotation, prediction


### PR DESCRIPTION
if not convert, default type is int16, if resize operation will be called, that byte scaling will be applied and we got wrong annotation mask labels