### PR TITLE
Add a note about OTE to instance_segmentation_demo's readme.md

### DIFF
--- a/demos/python_demos/instance_segmentation_demo/README.md
+++ b/demos/python_demos/instance_segmentation_demo/README.md
@@ -1,6 +1,7 @@
 # Instance Segmentation Python* Demo
 
 This demo shows how to run Instance Segmentation models from `Detectron` or `maskrcnn-benchmark` using OpenVINO&trade;.
+These models should be obtained through [OpenVINO&trade; Training Extensions (OTE)](https://github.com/opencv/openvino_training_extensions/tree/develop/pytorch_toolkit/instance_segmentation#get-pretrained-models).
 
 > **NOTE**: Only batch size of 1 is supported.
 


### PR DESCRIPTION
This is needed because some of the segmentation models may have inputs/outputs different than OTE segmentation models have, and so they are not compatible with current demo implementation.