### PR TITLE
AC: support ssd-resnet34 TF

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -53,7 +53,8 @@ AccuracyChecker supports following set of adapters:
   * `confidence_threshold` - lower bound for valid boxes scores (optional, default 0.05).
   * `nms_threshold` - overlap threshold for NMS (optional, default 0.5).
   * `keep_top_k ` - maximal number of boxes which should be kept (optional, default 200).
-  * `feat_size` - features size in format [[feature_width, feature_height], ...] (Optional, deafult values got from [MLPerf](https://github.com/mlperf/inference/blob/0691366473fd4fbbc4eb432fad990683a5a87099/v0.5/classification_and_detection/python/models/ssd_r34.py#L208))
+  * `feat_size` - features size in format [[feature_width, feature_height], ...] (Optional, default values got from [MLPerf](https://github.com/mlperf/inference/blob/0691366473fd4fbbc4eb432fad990683a5a87099/v0.5/classification_and_detection/python/models/ssd_r34.py#L208))
+  * `do_softmax` - boolean flag which says should be softmax applied to detection scores or not. (Optional, default True)
 * `ssd_onnx` - converting output of SSD-based model from PyTorch with NonMaxSuppression layer.
   * `labels_out` - name of output layer with labels or regular expression for it searching.
   * `scores_out`- name of output layer with scores or regular expression for it searching.

--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -53,6 +53,7 @@ AccuracyChecker supports following set of adapters:
   * `confidence_threshold` - lower bound for valid boxes scores (optional, default 0.05).
   * `nms_threshold` - overlap threshold for NMS (optional, default 0.5).
   * `keep_top_k ` - maximal number of boxes which should be kept (optional, default 200).
+  * `feat_size` - features size in format [[feature_width, feature_height], ...] (Optional, deafult values got from [MLPerf](https://github.com/mlperf/inference/blob/0691366473fd4fbbc4eb432fad990683a5a87099/v0.5/classification_and_detection/python/models/ssd_r34.py#L208))
 * `ssd_onnx` - converting output of SSD-based model from PyTorch with NonMaxSuppression layer.
   * `labels_out` - name of output layer with labels or regular expression for it searching.
   * `scores_out`- name of output layer with scores or regular expression for it searching.


### PR DESCRIPTION
model from [IntelAI zoo](https://github.com/IntelAI/models/tree/master/benchmarks/object_detection/tensorflow/ssd-resnet34)
has a difference in feature size and layout of outputs in comparision with pytorch implementation