### PR TITLE
demos: remove remnants of cpu_extension compatibility code

### DIFF
--- a/demos/gaze_estimation_demo/include/utils.hpp
+++ b/demos/gaze_estimation_demo/include/utils.hpp
@@ -14,9 +14,6 @@
 #include <inference_engine.hpp>
 
 #include <ie_iextension.h>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 #include <samples/ocv_common.hpp>
 #include <samples/slog.hpp>

--- a/demos/interactive_face_detection_demo/detectors.hpp
+++ b/demos/interactive_face_detection_demo/detectors.hpp
@@ -24,9 +24,6 @@
 #include <samples/slog.hpp>
 
 #include <ie_iextension.h>
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 #include <opencv2/opencv.hpp>
 

--- a/demos/multi_channel/common/graph.hpp
+++ b/demos/multi_channel/common/graph.hpp
@@ -27,9 +27,6 @@
 #include <samples/slog.hpp>
 #include "perf_timer.hpp"
 #include "input.hpp"
-#ifdef WITH_EXTENSIONS
-#include <ext_list.hpp>
-#endif
 
 void loadImageToIEGraph(cv::Mat img, void* ie_buffer);
 


### PR DESCRIPTION
Somehow I've missed these in #802.