### PR TITLE
Fix links with broken syntax in the model documentation

### DIFF
--- a/models/public/brain-tumor-segmentation-0001/brain-tumor-segmentation-0001.md
+++ b/models/public/brain-tumor-segmentation-0001/brain-tumor-segmentation-0001.md
@@ -19,7 +19,7 @@ Each input modality has its own encoder which are later fused together to produc
 
 ## Accuracy
 
-See [https://github.com/lachinov/brats2018-graphlabunn]()
+See [the original repository](https://github.com/lachinov/brats2018-graphlabunn).
 
 
 ## Performance

--- a/models/public/densenet-121/densenet-121.md
+++ b/models/public/densenet-121/densenet-121.md
@@ -22,7 +22,7 @@ models, check out the [repository](https://github.com/shicai/DenseNet-Caffe).
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]()
+See [the original repository](https://github.com/shicai/DenseNet-Caffe).
 
 ## Performance
 

--- a/models/public/densenet-161/densenet-161.md
+++ b/models/public/densenet-161/densenet-161.md
@@ -31,7 +31,7 @@ the 1000 different classifications matching those in the ImageNet database.
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]().
+See [the original repository](https://github.com/shicai/DenseNet-Caffe).
 
 ## Performance
 

--- a/models/public/densenet-169/densenet-169.md
+++ b/models/public/densenet-169/densenet-169.md
@@ -31,7 +31,7 @@ the 1000 different classifications matching those in the ImageNet database.
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]().
+See [the original repository](https://github.com/shicai/DenseNet-Caffe).
 
 ## Performance
 

--- a/models/public/densenet-201/densenet-201.md
+++ b/models/public/densenet-201/densenet-201.md
@@ -31,7 +31,7 @@ the 1000 different classifications matching those in the ImageNet database.
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]().
+See [the original repository](https://github.com/shicai/DenseNet-Caffe).
 
 ## Performance
 

--- a/models/public/resnet-101/resnet-101.md
+++ b/models/public/resnet-101/resnet-101.md
@@ -17,6 +17,8 @@
 
 ## Accuracy
 
+See [the original repository](https://github.com/KaimingHe/deep-residual-networks).
+
 ## Performance
 
 ## Input

--- a/models/public/resnet-152/resnet-152.md
+++ b/models/public/resnet-152/resnet-152.md
@@ -17,7 +17,7 @@
 
 ## Accuracy
 
-See [https://github.com/shicai/DenseNet-Caffe]()
+See [the original repository](https://github.com/KaimingHe/deep-residual-networks).
 
 ## Performance
 

--- a/models/public/resnet-50/resnet-50.md
+++ b/models/public/resnet-50/resnet-50.md
@@ -17,6 +17,8 @@
 
 ## Accuracy
 
+See [the original repository](https://github.com/KaimingHe/deep-residual-networks).
+
 ## Performance
 
 ## Input


### PR DESCRIPTION
These links point to the parent directory of the file they're in. Fix them so that they point to the intended destination.

Note about `resnet-*`: the link in `resnet-152` originally pointed to the wrong repository. I fixed it and added it to the other ResNet models for consistency.