### PR TITLE
fix SSD models description

### DIFF
--- a/models/public/ssd300/model.yml
+++ b/models/public/ssd300/model.yml
@@ -14,7 +14,7 @@
 
 description: >-
   The "ssd300" model is a Single-Shot multibox Detection <SSD> <https://arxiv.org/abs/1512.02325>
-  network intended to perform face detection. This model is implemented using the
+  network intended to perform detection. This model is implemented using the
   Caffe* framework. For details about this model, check out the repository <https://github.com/weiliu89/caffe/tree/ssd>.
 
   The model input is a blob that consists of a single image of 1x3x300x300 in BGR

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The "ssd300" model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) network intended to perform face detection. This model is implemented using the Caffe\* framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
+The "ssd300" model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) network intended to perform detection. This model is implemented using the Caffe\* framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
 
 The model input is a blob that consists of a single image of 1x3x300x300 in BGR order.  The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 

--- a/models/public/ssd512/model.yml
+++ b/models/public/ssd512/model.yml
@@ -14,7 +14,7 @@
 
 description: >-
   The "ssd512" model is a Single-Shot multibox Detection <SSD> <https://arxiv.org/abs/1512.02325>
-  network intended to perform face detection. This model is implemented using the
+  network intended to perform detection. This model is implemented using the
   Caffe*framework. For details about this model, check out the repository <https://github.com/weiliu89/caffe/tree/ssd>.
 
   The model input is a blob that consists of a single image of 1x3x512x512 in BGR

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `ssd512` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) network intended to perform face detection. This model is implemented using the Caffe\*framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
+The `ssd512` model is a [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) network intended to perform detection. This model is implemented using the Caffe\*framework. For details about this model, check out the [repository](https://github.com/weiliu89/caffe/tree/ssd).
 
 The model input is a blob that consists of a single image of 1x3x512x512 in BGR order. The BGR mean values need to be subtracted as follows: [104.0,117.0,123.0] before passing the image blob into the network.
 


### PR DESCRIPTION
I believe that we already fixed this info, but these changes were overwritten.
public SSD are not face detectors.