### PR TITLE
Drop Python 2 support

### DIFF
--- a/demos/python_demos/3d_segmentation_demo/3d_segmentation_demo.py
+++ b/demos/python_demos/3d_segmentation_demo/3d_segmentation_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
 

--- a/demos/python_demos/action_recognition/action_recognition.py
+++ b/demos/python_demos/action_recognition/action_recognition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
 

--- a/demos/python_demos/action_recognition/action_recognition.py
+++ b/demos/python_demos/action_recognition/action_recognition.py
@@ -15,8 +15,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
-
 import sys
 from argparse import ArgumentParser, SUPPRESS
 

--- a/demos/python_demos/asl_recognition_demo/asl_recognition_demo.py
+++ b/demos/python_demos/asl_recognition_demo/asl_recognition_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
 

--- a/demos/python_demos/colorization_demo/colorization_demo.py
+++ b/demos/python_demos/colorization_demo/colorization_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2018 Intel Corporation
 

--- a/demos/python_demos/face_recognition_demo/face_recognition_demo.py
+++ b/demos/python_demos/face_recognition_demo/face_recognition_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2018 Intel Corporation
 

--- a/demos/python_demos/handwritten_japanese_recognition_demo/handwritten_japanese_recognition_demo.py
+++ b/demos/python_demos/handwritten_japanese_recognition_demo/handwritten_japanese_recognition_demo.py
@@ -11,7 +11,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
 import os
 import sys
 import time

--- a/demos/python_demos/human_pose_estimation_3d_demo/human_pose_estimation_3d_demo.py
+++ b/demos/python_demos/human_pose_estimation_3d_demo/human_pose_estimation_3d_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/demos/python_demos/human_pose_estimation_3d_demo/modules/draw.py
+++ b/demos/python_demos/human_pose_estimation_3d_demo/modules/draw.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/demos/python_demos/human_pose_estimation_3d_demo/modules/inference_engine.py
+++ b/demos/python_demos/human_pose_estimation_3d_demo/modules/inference_engine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/demos/python_demos/human_pose_estimation_3d_demo/modules/input_reader.py
+++ b/demos/python_demos/human_pose_estimation_3d_demo/modules/input_reader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/demos/python_demos/human_pose_estimation_3d_demo/modules/one_euro_filter.py
+++ b/demos/python_demos/human_pose_estimation_3d_demo/modules/one_euro_filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/demos/python_demos/human_pose_estimation_3d_demo/modules/parse_poses.py
+++ b/demos/python_demos/human_pose_estimation_3d_demo/modules/parse_poses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/demos/python_demos/human_pose_estimation_3d_demo/modules/pose.py
+++ b/demos/python_demos/human_pose_estimation_3d_demo/modules/pose.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/demos/python_demos/image_retrieval_demo/image_retrieval_demo.py
+++ b/demos/python_demos/image_retrieval_demo/image_retrieval_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
 

--- a/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo.py
+++ b/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
 

--- a/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo.py
+++ b/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo.py
@@ -15,8 +15,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
-
 import logging as log
 import os
 import sys

--- a/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo/visualizer.py
+++ b/demos/python_demos/instance_segmentation_demo/instance_segmentation_demo/visualizer.py
@@ -14,8 +14,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
-
 import cv2
 import numpy as np
 

--- a/demos/python_demos/monodepth_demo/monodepth_demo.py
+++ b/demos/python_demos/monodepth_demo/monodepth_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 from argparse import ArgumentParser

--- a/demos/python_demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.py
+++ b/demos/python_demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.py
@@ -15,7 +15,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
 import sys
 import os
 from argparse import ArgumentParser, SUPPRESS

--- a/demos/python_demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.py
+++ b/demos/python_demos/object_detection_demo_ssd_async/object_detection_demo_ssd_async.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (C) 2018-2019 Intel Corporation
 

--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (C) 2018-2019 Intel Corporation
 

--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -14,7 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from __future__ import print_function, division
 
 import logging
 import os

--- a/demos/python_demos/segmentation_demo/segmentation_demo.py
+++ b/demos/python_demos/segmentation_demo/segmentation_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (C) 2018-2019 Intel Corporation
 

--- a/demos/python_demos/segmentation_demo/segmentation_demo.py
+++ b/demos/python_demos/segmentation_demo/segmentation_demo.py
@@ -14,7 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-from __future__ import print_function
+
 import sys
 import os
 from argparse import ArgumentParser, SUPPRESS

--- a/demos/python_demos/text_spotting_demo/text_spotting_demo.py
+++ b/demos/python_demos/text_spotting_demo/text_spotting_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
  Copyright (c) 2019 Intel Corporation
 

--- a/demos/python_demos/text_spotting_demo/text_spotting_demo.py
+++ b/demos/python_demos/text_spotting_demo/text_spotting_demo.py
@@ -15,8 +15,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
-
 import logging as log
 import os
 import sys

--- a/demos/python_demos/text_spotting_demo/text_spotting_demo/visualizer.py
+++ b/demos/python_demos/text_spotting_demo/text_spotting_demo/visualizer.py
@@ -14,8 +14,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
-
 import cv2
 import numpy as np
 

--- a/demos/smart_classroom_demo/action_event_metrics.py
+++ b/demos/smart_classroom_demo/action_event_metrics.py
@@ -11,8 +11,6 @@
  limitations under the License.
 """
 
-from __future__ import print_function
-
 import json
 from argparse import ArgumentParser
 from collections import namedtuple

--- a/demos/smart_classroom_demo/create_list.py
+++ b/demos/smart_classroom_demo/create_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
  Copyright (C) 2018-2019 Intel Corporation
 

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/market1501.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/market1501.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import, print_function
-
 import re
 
 from ._reid_common import check_dirs, read_directory, ReIdentificationAnnotation

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/mars.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/mars.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import, print_function
-
 import re
 
 from ._reid_common import check_dirs, read_directory


### PR DESCRIPTION
It was never really supported in the first place, but now that the OpenVINO toolkit has dropped the Python 2 bindings, it's _definitely_ not supported.