### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,27 @@
+name: lint_python
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    # strategy:
+    #  matrix:
+    #    os: [ubuntu-latest, macos-latest, windows-latest]
+    #    python-version: [2.7, 3.5, 3.6, 3.7, 3.8]  # , pypy3]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check .
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --recursive . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/demos/python_demos/face_recognition_demo/ie_module.py
+++ b/demos/python_demos/face_recognition_demo/ie_module.py
@@ -37,7 +37,7 @@ class InferenceContext:
             if len(not_supported_layers) != 0:
                 log.error("The following layers are not supported " \
                     "by the plugin for the specified device {}:\n {}" \
-                    .format(plugin.device, ', '.join(not_supported_layers)))
+                    .format(device, ', '.join(not_supported_layers)))
                 log.error("Please try to specify cpu extensions " \
                     "library path in the command line parameters using " \
                     "the '-l' parameter")


### PR DESCRIPTION
`plugin` is an _undefined name_.

https://github.com/cclauss/open_model_zoo/actions

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./demos/python_demos/face_recognition_demo/ie_module.py:40:29: F821 undefined name 'plugin'
                    .format(plugin.device, ', '.join(not_supported_layers)))
                            ^
1     F821 undefined name 'plugin'
1
```

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.