### PR TITLE
Bump the version on the release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [OpenVINO™ Toolkit](https://01.org/openvinotoolkit) - Open Model Zoo repository
-[![Stable release](https://img.shields.io/badge/version-2020.2-green.svg)](https://github.com/opencv/open_model_zoo/releases/tag/2020.2)
+[![Stable release](https://img.shields.io/badge/version-2020.3-green.svg)](https://github.com/opencv/open_model_zoo/releases/tag/2020.3)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/open_model_zoo/community)
 [![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE)
 


### PR DESCRIPTION
The `release` branch will now be used to develop 2020.3 while the `develop` branch will be used for 2020.4 (I will bump the version there separately).