### PR TITLE
AC; support non-ordered yaml reading for device config

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -723,7 +723,7 @@ class DLSDKLauncher(Launcher):
                 print_info('    {} - {}'.format(device, nreq))
 
     def _set_device_config(self, device_config):
-        device_specific_configuration = read_yaml(device_config)
+        device_specific_configuration = read_yaml(device_config, ordered=False)
         if not isinstance(device_specific_configuration, dict):
             raise ConfigError('device configuration should be a dict-like')
         self.ie_core.set_config(device_specific_configuration, self.device)

--- a/tools/accuracy_checker/accuracy_checker/utils.py
+++ b/tools/accuracy_checker/accuracy_checker/utils.py
@@ -294,10 +294,10 @@ def read_pickle(file: Union[str, Path], *args, **kwargs):
         return pickle.load(content, *args, **kwargs)
 
 
-def read_yaml(file: Union[str, Path], *args, **kwargs):
+def read_yaml(file: Union[str, Path], *args, ordered=True, **kwargs):
     with get_path(file).open() as content:
-        loader = orddict_loader or yaml.SafeLoader
-        if not orddict_loader:
+        loader = orddict_loader or yaml.SafeLoader if ordered else yaml.SafeLoader
+        if not orddict_loader and ordered:
             warn('yamlloader is not installed. YAML files order is not preserved. it can be sufficient for some cases')
         return yaml.load(content, *args, Loader=loader, **kwargs)
 


### PR DESCRIPTION
IE raises error if it got OrderedDict instead of dict as plugin config