### PR TITLE
Add a model quantizer script

### DIFF
--- a/models/public/alexnet/model.yml
+++ b/models/public/alexnet/model.yml
@@ -46,4 +46,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/alexnet.caffemodel
   - --input_proto=$dl_dir/alexnet.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_alexnet/readme.md

--- a/models/public/googlenet-v1/model.yml
+++ b/models/public/googlenet-v1/model.yml
@@ -47,4 +47,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/googlenet-v1.caffemodel
   - --input_proto=$dl_dir/googlenet-v1.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_googlenet/readme.md

--- a/models/public/googlenet-v3-pytorch/model.yml
+++ b/models/public/googlenet-v3-pytorch/model.yml
@@ -45,4 +45,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=prob
   - --input_model=$conv_dir/googlenet-v3.onnx
+quantizable: yes
 license: https://raw.githubusercontent.com/pytorch/vision/master/LICENSE

--- a/models/public/mobilenet-v1-1.0-224/model.yml
+++ b/models/public/mobilenet-v1-1.0-224/model.yml
@@ -37,4 +37,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/mobilenet-v1-1.0-224.caffemodel
   - --input_proto=$dl_dir/mobilenet-v1-1.0-224.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE

--- a/models/public/mobilenet-v2-pytorch/model.yml
+++ b/models/public/mobilenet-v2-pytorch/model.yml
@@ -52,4 +52,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=prob
   - --input_model=$conv_dir/mobilenet-v2.onnx
+quantizable: yes
 license: https://raw.githubusercontent.com/tonylins/pytorch-mobilenet-v2/master/LICENSE

--- a/models/public/mobilenet-v2/model.yml
+++ b/models/public/mobilenet-v2/model.yml
@@ -33,4 +33,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/mobilenet-v2.caffemodel
   - --input_proto=$dl_dir/mobilenet-v2.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/LICENSE

--- a/models/public/resnet-101/model.yml
+++ b/models/public/resnet-101/model.yml
@@ -32,4 +32,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/resnet-101.caffemodel
   - --input_proto=$dl_dir/resnet-101.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/KaimingHe/deep-residual-networks/master/LICENSE

--- a/models/public/resnet-152/model.yml
+++ b/models/public/resnet-152/model.yml
@@ -32,4 +32,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/resnet-152.caffemodel
   - --input_proto=$dl_dir/resnet-152.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/KaimingHe/deep-residual-networks/master/LICENSE

--- a/models/public/resnet-18-pytorch/model.yml
+++ b/models/public/resnet-18-pytorch/model.yml
@@ -45,4 +45,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=prob
   - --input_model=$conv_dir/resnet-18-pytorch.onnx
+quantizable: yes
 license: https://raw.githubusercontent.com/pytorch/vision/master/LICENSE

--- a/models/public/resnet-50-pytorch/model.yml
+++ b/models/public/resnet-50-pytorch/model.yml
@@ -45,4 +45,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=prob
   - --input_model=$conv_dir/resnet-v1-50.onnx
+quantizable: yes
 license: https://raw.githubusercontent.com/pytorch/vision/master/LICENSE

--- a/models/public/resnet-50/model.yml
+++ b/models/public/resnet-50/model.yml
@@ -32,4 +32,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/resnet-50.caffemodel
   - --input_proto=$dl_dir/resnet-50.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/KaimingHe/deep-residual-networks/master/LICENSE

--- a/models/public/squeezenet1.1-caffe2/model.yml
+++ b/models/public/squeezenet1.1-caffe2/model.yml
@@ -39,4 +39,5 @@ model_optimizer_args:
   - --input=data
   - --mean_values=data[103.96,116.78,123.68]
   - --input_model=$conv_dir/squeezenet1.1-caffe2.onnx
+quantizable: yes
 license: https://raw.githubusercontent.com/caffe2/models/master/LICENSE

--- a/models/public/squeezenet1.1/model.yml
+++ b/models/public/squeezenet1.1/model.yml
@@ -48,4 +48,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/squeezenet1.1.caffemodel
   - --input_proto=$dl_dir/squeezenet1.1.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/forresti/SqueezeNet/master/LICENSE

--- a/models/public/vgg16/model.yml
+++ b/models/public/vgg16/model.yml
@@ -45,4 +45,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/vgg16.caffemodel
   - --input_proto=$dl_dir/vgg16.prototxt
 framework: caffe
+quantizable: yes
 license: https://creativecommons.org/licenses/by/4.0/legalcode.txt

--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -67,16 +67,17 @@ The basic usage is to run the script like this:
 ./downloader.py --all
 ```
 
-This will download all models into a directory tree rooted in the current
-directory. To download into a different directory, use the `-o`/`--output_dir`
-option:
+This will download all models. The `--all` option can be replaced with
+other filter options to download only a subset of models. See the "Shared options"
+section.
+
+By default, the script will download models into a directory tree rooted
+in the current directory. To download into a different directory, use
+the `-o`/`--output_dir` option:
 
 ```sh
 ./downloader.py --all --output_dir my/download/directory
 ```
-
-The `--all` option can be replaced with other filter options to download only
-a subset of models. See the "Shared options" section.
 
 You may use `--precisions` flag to specify comma separated precisions of weights
 to be downloaded.
@@ -221,6 +222,9 @@ This will convert all models into the Inference Engine IR format. Models that
 were originally in that format are ignored. Models in PyTorch and Caffe2 formats will be
 converted in ONNX format first.
 
+The `--all` option can be replaced with other filter options to convert only
+a subset of models. See the "Shared options" section.
+
 The current directory must be the root of a download tree created by the model
 downloader. To specify a different download tree path, use the `-d`/`--download_dir`
 option:
@@ -236,9 +240,6 @@ into a different directory tree, use the `-o`/`--output_dir` option:
 ./converter.py --all --output_dir my/output/directory
 ```
 >Note: models in intermediate format are placed to this directory too.
-
-The `--all` option can be replaced with other filter options to convert only
-a subset of models. See the "Shared options" section.
 
 By default, the script will produce models in every precision that is supported
 for conversion. To only produce models in a specific precision, use the `--precisions`

--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -11,6 +11,9 @@ based on configuration files in the models' directories.
 * `converter.py` (model converter) converts the models that are not in the
   Inference Engine IR format into that format using Model Optimizer.
 
+* `quantizer.py` (model quantizer) quantizes full-precision models in the IR
+  format into low-precision versions using Post-Training Optimization Toolkit.
+
 * `info_dumper.py` (model information dumper) prints information about the models
   in a stable machine-readable format.
 
@@ -296,6 +299,100 @@ To do this, use the `--dry_run` option:
 See the "Shared options" section for information on other options accepted by
 the script.
 
+Model quantizer usage
+---------------------
+
+Before you run the model quantizer, you must prepare a directory with
+the datasets required for the quantization process. This directory will be
+referred to as `<DATASET_DIR>` below. See the "Dataset directory layout"
+section for information on the expected contents of that directory.
+
+The basic usage is to run the script like this:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR>
+```
+
+This will quantize all models for which quantization is supported. Other models
+are ignored.
+
+The `--all` option can be replaced with other filter options to quantize only
+a subset of models. See the "Shared options" section.
+
+The current directory must be the root of a tree of model files create by the model
+converter. To specify a different model tree path, use the `--model_dir` option:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR> --model_dir my/model/directory
+```
+
+By default, the quantized models are placed into the same model tree. To place them
+into a different directory tree, use the `-o`/`--output_dir` option:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR> --output_dir my/output/directory
+```
+
+By default, the script will produce models in every precision that is supported
+as a quantization output. To only produce models in a specific precision, use
+the `--precisions` option:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR> --precisions=FP16-INT8
+```
+
+The script will attempt to locate Post-Training Optimization Toolkit using
+the environment variables set by the OpenVINO&trade; toolkit's `setupvars.sh`/`setupvars.bat`
+script. You can override this heuristic with the `--pot` option:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR> --pot my/openvino/path/post_training_optimization_toolkit/main.py
+```
+
+By default, the script will run Post-Training Optimization Toolkit using the same
+Python executable that was used to run the script itself. To use a different
+Python executable, use the `-p`/`--python` option:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR> --python my/python
+```
+
+It's possible to specify a target device for Post-Training Optimization Toolkit
+to optimize for, by using the `--target_device` option:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR> --target_device VPU
+```
+
+The supported values are those accepted by the "target_device" option in
+Post-Training Optimization Toolkit's config files. If this option is unspecified,
+Post-Training Optimization Toolkit's default is used.
+
+The script can print the quantization commands without actually running them.
+To do this, use the `--dry_run` option:
+
+```sh
+./quantizer.py --all --dataset_dir <DATASET_DIR> --dry_run
+```
+
+With this option specified, the configuration file for Post-Training Optimization
+Toolkit will still be created, so that you can inspect it.
+
+See the "Shared options" section for information on other options accepted by
+the script.
+
+### Dataset directory layout
+
+Currently, all models for which quantization is supported require the
+[ILSVRC 2012](http://image-net.org/challenges/LSVRC/2012/index) validation
+dataset. This means that `<DATASET_DIR>` must contain the following entries:
+
+* A subdirectory named `ILSVRC2012_img_val` containing the ILSVRC 2012
+  validation images. To obtain these images, follow the
+  [instructions at the ILSVRC 2012 website](http://image-net.org/challenges/LSVRC/2012/signup).
+
+* `val.txt` from <http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz>.
+
 Model information dumper usage
 ------------------------------
 
@@ -364,7 +461,7 @@ describing a single model. Each such object has the following keys:
 Shared options
 --------------
 
-The are certain options that both tools accept.
+The are certain options that all tools accept.
 
 `-h`/`--help` can be used to print a help message:
 

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -16,6 +16,7 @@ import collections
 import contextlib
 import fnmatch
 import json
+import platform
 import re
 import shlex
 import shutil
@@ -482,3 +483,17 @@ def load_models_from_args(parser, args):
                 models[model.name] = model
 
         return list(models.values())
+
+def quote_arg_windows(arg):
+    if not arg: return '""'
+    if not re.search(r'\s|"', arg): return arg
+    # On Windows, only backslashes that precede a quote or the end of the argument must be escaped.
+    return '"' + re.sub(r'(\\+)$', r'\1\1', re.sub(r'(\\*)"', r'\1\1\\"', arg)) + '"'
+
+if platform.system() == 'Windows':
+    quote_arg = quote_arg_windows
+else:
+    quote_arg = shlex.quote
+
+def command_string(args):
+    return ' '.join(map(quote_arg, args))

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -62,6 +62,9 @@ KNOWN_TASK_TYPES = {
     'semantic_segmentation',
 }
 
+KNOWN_QUANTIZED_PRECISIONS = {p + '-INT8': p for p in ['FP16', 'FP32']}
+assert KNOWN_QUANTIZED_PRECISIONS.keys() <= KNOWN_PRECISIONS
+
 RE_MODEL_NAME = re.compile(r'[0-9a-zA-Z._-]+')
 RE_SHA256SUM = re.compile(r'[0-9a-fA-F]{64}')
 

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -308,13 +308,14 @@ class PostprocUnpackArchive(Postproc):
 Postproc.types['unpack_archive'] = PostprocUnpackArchive
 
 class Model:
-    def __init__(self, name, subdirectory, files, postprocessing, mo_args, framework,
+    def __init__(self, name, subdirectory, files, postprocessing, mo_args, quantizable, framework,
                  description, license_url, precisions, task_type, conversion_to_onnx_args):
         self.name = name
         self.subdirectory = subdirectory
         self.files = files
         self.postprocessing = postprocessing
         self.mo_args = mo_args
+        self.quantizable = quantizable
         self.framework = framework
         self.description = description
         self.license_url = license_url
@@ -390,13 +391,17 @@ class Model:
 
                 precisions = set(files_per_precision.keys())
 
+            quantizable = model.get('quantizable', False)
+            if not isinstance(quantizable, bool):
+                raise DeserializationError('"quantizable": expected a boolean, got {!r}'.format(quantizable))
+
             description = validate_string('"description"', model['description'])
 
             license_url = validate_string('"license"', model['license'])
 
             task_type = validate_string_enum('"task_type"', model['task_type'], KNOWN_TASK_TYPES)
 
-            return cls(name, subdirectory, files, postprocessing, mo_args, framework,
+            return cls(name, subdirectory, files, postprocessing, mo_args, quantizable, framework,
                 description, license_url, precisions, task_type, conversion_to_onnx_args)
 
 def load_models(args):

--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -17,10 +17,8 @@
 import argparse
 import concurrent.futures
 import os
-import platform
 import queue
 import re
-import shlex
 import string
 import subprocess
 import sys
@@ -77,17 +75,6 @@ class JobWithQueuedOutput():
         self._future.cancel()
 
 
-def quote_windows(arg):
-    if not arg: return '""'
-    if not re.search(r'\s|"', arg): return arg
-    # On Windows, only backslashes that precede a quote or the end of the argument must be escaped.
-    return '"' + re.sub(r'(\\+)$', r'\1\1', re.sub(r'(\\*)"', r'\1\1\\"', arg)) + '"'
-
-if platform.system() == 'Windows':
-    quote_arg = quote_windows
-else:
-    quote_arg = shlex.quote
-
 def convert_to_onnx(context, model, output_dir, args):
     context.printf('========= {}Converting {} to ONNX',
                    '(DRY RUN) ' if args.dry_run else '', model.name)
@@ -97,7 +84,7 @@ def convert_to_onnx(context, model, output_dir, args):
                                for arg in model.conversion_to_onnx_args]
     cmd = [str(args.python), str(Path(__file__).absolute().parent / model.converter_to_onnx), *conversion_to_onnx_args]
 
-    context.printf('Conversion to ONNX command: {}', ' '.join(map(quote_arg, cmd)))
+    context.printf('Conversion to ONNX command: {}', common.command_string(cmd))
     context.printf('')
 
     success = True if args.dry_run else context.subprocess(cmd)
@@ -206,7 +193,7 @@ def main():
             context.printf('========= {}Converting {} to IR ({})',
                 '(DRY RUN) ' if args.dry_run else '', model.name, model_precision)
 
-            context.printf('Conversion command: {}', ' '.join(map(quote_arg, mo_cmd)))
+            context.printf('Conversion command: {}', common.command_string(mo_cmd))
 
             if not args.dry_run:
                 context.printf('', flush=True)

--- a/tools/downloader/quantizer.py
+++ b/tools/downloader/quantizer.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+import re
+import string
+import subprocess
+import sys
+import tempfile
+
+from pathlib import Path
+
+import common
+
+OMZ_ROOT = Path(__file__).resolve().parents[2]
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model_dir', type=Path, metavar='DIR',
+        default=Path.cwd(), help='root of the directory tree with the full precision model files')
+    parser.add_argument('--dataset_dir', type=Path, help='root of the dataset directory tree')
+    parser.add_argument('-o', '--output_dir', type=Path, metavar='DIR',
+        help='root of the directory tree to place quantized model files into')
+    parser.add_argument('--name', metavar='PAT[,PAT...]',
+        help='quantize only models whose names match at least one of the specified patterns')
+    parser.add_argument('--list', type=Path, metavar='FILE.LST',
+        help='quantize only models whose names match at least one of the patterns in the specified file')
+    parser.add_argument('--all', action='store_true', help='quantize all available models')
+    parser.add_argument('--print_all', action='store_true', help='print all available models')
+    parser.add_argument('-p', '--python', type=Path, metavar='PYTHON', default=sys.executable,
+        help='Python executable to run Post-Training Optimization Toolkit with')
+    parser.add_argument('--pot', type=Path, help='Post-Training Optimization Toolkit entry point script')
+    parser.add_argument('--dry_run', action='store_true',
+        help='print the quantization commands without running them')
+    parser.add_argument('--target_device', help='target device for the quantized model')
+    args = parser.parse_args()
+
+    pot_path = args.pot
+    if pot_path is None:
+        try:
+            pot_path = Path(os.environ['INTEL_OPENVINO_DIR']) / 'deployment_tools/tools/post_training_optimization_toolkit/main.py'
+        except KeyError:
+            sys.exit('Unable to locate Post-Training Optimization Toolkit. '
+                + 'Use --pot or run setupvars.sh/setupvars.bat from the OpenVINO toolkit.')
+
+    models = common.load_models_from_args(parser, args)
+
+    # We can't mark it as required, because it's not required when --print_all is specified.
+    # So we have to check it manually.
+    if not args.dataset_dir:
+        sys.exit('--dataset_dir must be specified.')
+
+    output_dir = args.output_dir or args.model_dir
+
+    failed_models = []
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        annotation_dir = Path(temp_dir) / 'annotations'
+        annotation_dir.mkdir()
+
+        pot_env = {
+            'ANNOTATIONS_DIR': str(annotation_dir),
+            'DATA_DIR': str(args.dataset_dir),
+        }
+
+        for model in models:
+            if not model.quantizable:
+                print('========= Skipping {} (quantization not supported)'.format(model.name))
+                print('')
+                continue
+
+            input_precision = 'FP32'
+
+            pot_config = {
+                'compression': {
+                    'algorithms': [
+                        {
+                            'name': 'DefaultQuantization',
+                            'params': {
+                                'preset': 'performance',
+                                'stat_subset_size': 300,
+                            },
+                        },
+                    ],
+                },
+                'engine': {
+                    'config': str(OMZ_ROOT / 'tools/accuracy_checker/configs' / (model.name + '.yml')),
+                },
+                'model': {
+                    'model': str(args.model_dir / model.subdirectory / input_precision / (model.name + '.xml')),
+                    'weights': str(args.model_dir / model.subdirectory / input_precision / (model.name + '.bin')),
+                    'model_name': model.name,
+                }
+            }
+
+            if args.target_device:
+                pot_config['compression']['target_device'] = args.target_device
+
+            print('========= {}Quantizing {} from {}'.format(
+                '(DRY RUN) ' if args.dry_run else '', model.name, input_precision))
+
+            model_output_dir = output_dir / model.subdirectory / (input_precision + '-INT8')
+            pot_config_path = model_output_dir / 'pot-config.json'
+
+            print('Creating {}...'.format(pot_config_path))
+            pot_config_path.parent.mkdir(parents=True, exist_ok=True)
+            with pot_config_path.open('w') as pot_config_file:
+                json.dump(pot_config, pot_config_file, indent=4)
+                pot_config_file.write('\n')
+
+            pot_output_dir = model_output_dir / 'pot-output'
+            pot_output_dir.mkdir(parents=True, exist_ok=True)
+
+            pot_cmd = [str(args.python), '--', str(pot_path),
+                '--config={}'.format(pot_config_path),
+                '--direct-dump',
+                '--output-dir={}'.format(pot_output_dir),
+            ]
+
+            print('Quantization command: {}'.format(common.command_string(pot_cmd)))
+            print('Quantization environment: {}'.format(
+                ' '.join('{}={}'.format(k, common.quote_arg(v))
+                    for k, v in sorted(pot_env.items()))))
+
+            if not args.dry_run:
+                print('', flush=True)
+
+                if subprocess.run(pot_cmd, env={**os.environ, **pot_env}).returncode != 0:
+                    failed_models.append(model.name)
+
+            print('')
+
+            if not args.dry_run:
+                print('Moving quantized model to {}...'.format(model_output_dir))
+                for ext in ['.xml', '.bin']:
+                    (pot_output_dir / 'optimized' / (model.name + ext)).replace(
+                        model_output_dir / (model.name + ext))
+                print('')
+
+    if failed_models:
+        print('FAILED:')
+        print(*sorted(failed_models), sep='\n')
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script is akin to the model converter, but instead of converting, it quantizes full-precision models to INT8 using POT with a simple configuration. For now, only certain models (for which it's known that the resulting model has good accuracy) are marked as quantizable.

(This is a draft PR for now, because I'll be adding documentation later.)

