### PR TITLE
Model converter: use a consistent naming convention for options

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -259,11 +259,11 @@ script. You can override this heuristic with the `--mo` option:
 ```
 
 You can add extra Model Optimizer arguments to the ones specified in the model
-configuration by using the `--add-mo-arg` option. The option can be repeated
+configuration by using the `--add_mo_arg` option. The option can be repeated
 to add multiple arguments:
 
 ```sh
-./converter.py --name=caffenet --add-mo-arg=--reverse_input_channels --add-mo-arg=--silent
+./converter.py --name=caffenet --add_mo_arg=--reverse_input_channels --add_mo_arg=--silent
 ```
 
 By default, the script will run Model Optimizer using the same Python executable
@@ -286,10 +286,10 @@ executed commands, or "auto", in which case the number of CPUs in the system is 
 By default, all commands are run sequentially.
 
 The script can print the conversion commands without actually running them.
-To do this, use the `--dry-run` option:
+To do this, use the `--dry_run` option:
 
 ```sh
-./converter.py --all --dry-run
+./converter.py --all --dry_run
 ```
 
 See the "Shared options" section for information on other options accepted by

--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -135,12 +135,17 @@ def main():
         help='Python executable to run Model Optimizer with')
     parser.add_argument('--mo', type=Path, metavar='MO.PY',
         help='Model Optimizer entry point script')
-    parser.add_argument('--add-mo-arg', dest='extra_mo_args', metavar='ARG', action='append',
+    parser.add_argument('--add_mo_arg', dest='extra_mo_args', metavar='ARG', action='append',
         help='Extra argument to pass to Model Optimizer')
-    parser.add_argument('--dry-run', action='store_true',
+    parser.add_argument('--dry_run', action='store_true',
         help='Print the conversion commands without running them')
     parser.add_argument('-j', '--jobs', type=num_jobs_arg, default=1,
         help='number of conversions to run concurrently')
+
+    # aliases for backwards compatibility
+    parser.add_argument('--add-mo-arg', dest='extra_mo_args', action='append', help=argparse.SUPPRESS)
+    parser.add_argument('--dry-run', action='store_true', help=argparse.SUPPRESS)
+
     args = parser.parse_args()
 
     mo_path = args.mo


### PR DESCRIPTION
I must've been careless when adding `--dry-run` and `--add-mo-arg`, and used dashes when all of the other options in the converter and in the downloader used underscores. Change them to use underscores too and provide compatibility aliases so old usages still work.

I'm sending this patch to `release` because, even though it's not too important by itself. The reason is that model quantizer (#1068) also has a dry run option, which I'd rather make use underscores from the start, and it would be nice if it was consistent between the quantizer and the converter.