### PR TITLE
ci/update-requirements.py: enable usage with pip-tools >=4.5.0

### DIFF
--- a/ci/update-requirements.py
+++ b/ci/update-requirements.py
@@ -9,7 +9,6 @@ before running it.
 """
 
 import argparse
-import functools
 import os
 import subprocess
 import sys
@@ -22,6 +21,16 @@ from pathlib import Path
 EXPECTED_PYTHON_VERSION = (3, 5)
 
 repo_root = Path(__file__).resolve().parent.parent
+script_name = Path(__file__).name
+
+def fixup_req_file(req_path, path_placeholders):
+    contents = req_path.read_text()
+
+    for path, placeholder in path_placeholders:
+        contents = contents.replace('-r {}/'.format(path), '-r ${{{}}}/'.format(placeholder))
+
+    contents = "# use {} to update this file\n\n".format(script_name) + contents
+    req_path.write_text(contents)
 
 def pip_compile(target, *sources, upgrade=False):
     print('updating {}...'.format(target), flush=True)
@@ -49,7 +58,9 @@ def main():
 
     openvino_dir = Path(os.environ['INTEL_OPENVINO_DIR'])
 
-    pc = functools.partial(pip_compile, upgrade=args.upgrade)
+    def pc(target, *sources):
+        pip_compile(target, *sources, upgrade=args.upgrade)
+        fixup_req_file(repo_root / target, [(openvino_dir, 'INTEL_OPENVINO_DIR')])
 
     pc('ci/requirements-ac.txt',
         'tools/accuracy_checker/requirements-core.in', 'tools/accuracy_checker/requirements.in')


### PR DESCRIPTION
pip-tools has recently changed the output format by adding the source file paths to the comments. This causes problems for us, because some of our source files are from the OpenVINO toolkit directory, whose path changes depending on the version and the install directory. Using that path as-is would mean leaking local file system paths, as well as meaningless diffs when upgrading to newer OpenVINO versions.

Fortunately, we already use a script, which means we can just postprocess the unwanted parts away.

I also used this postprocessing to add a comment directing developers to the update script.