### PR TITLE
Updates in AC configs

### DIFF
--- a/tools/accuracy_checker/configs/alexnet.yml
+++ b/tools/accuracy_checker/configs/alexnet.yml
@@ -31,6 +31,20 @@ models:
         weights: public/alexnet/FP16/alexnet.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/alexnet/FP32-INT8/alexnet.xml
+        weights: public/alexnet/FP32-INT8/alexnet.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/alexnet/FP16-INT8/alexnet.xml
+        weights: public/alexnet/FP16-INT8/alexnet.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/asl-recognition-0004.yml
+++ b/tools/accuracy_checker/configs/asl-recognition-0004.yml
@@ -24,17 +24,6 @@ models:
             name: input
             layout: NCDHW
 
-      - framework: dlsdk
-        tags:
-          - FP16-INT8
-        model:   intel/asl-recognition-0004/FP16-INT8/asl-recognition-0004.xml
-        weights: intel/asl-recognition-0004/FP16-INT8/asl-recognition-0004.bin
-        adapter: classification
-        inputs:
-          - type: INPUT
-            name: input
-            layout: NCDHW
-
     datasets:
       - name: msasl-100
 

--- a/tools/accuracy_checker/configs/face-detection-0100.yml
+++ b/tools/accuracy_checker/configs/face-detection-0100.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/face-detection-0100/FP16/face-detection-0100.bin
         adapter: ssd
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   intel/face-detection-0100/FP16-INT8/face-detection-0100.xml
+        weights: intel/face-detection-0100/FP16-INT8/face-detection-0100.bin
+        adapter: ssd
+
     datasets:
       - name: wider
 

--- a/tools/accuracy_checker/configs/face-detection-0102.yml
+++ b/tools/accuracy_checker/configs/face-detection-0102.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/face-detection-0102/FP16/face-detection-0102.bin
         adapter: ssd
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   intel/face-detection-0102/FP16-INT8/face-detection-0102.xml
+        weights: intel/face-detection-0102/FP16-INT8/face-detection-0102.bin
+        adapter: ssd
+
     datasets:
       - name: wider
 

--- a/tools/accuracy_checker/configs/face-detection-0104.yml
+++ b/tools/accuracy_checker/configs/face-detection-0104.yml
@@ -16,6 +16,13 @@ models:
         weights: intel/face-detection-0104/FP16/face-detection-0104.bin
         adapter: ssd
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   intel/face-detection-0104/FP16-INT8/face-detection-0104.xml
+        weights: intel/face-detection-0104/FP16-INT8/face-detection-0104.bin
+        adapter: ssd
+
     datasets:
       - name: wider
 

--- a/tools/accuracy_checker/configs/face-detection-0105.yml
+++ b/tools/accuracy_checker/configs/face-detection-0105.yml
@@ -20,6 +20,15 @@ models:
           type: class_agnostic_detection
           scale: 0.00240384615
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   intel/face-detection-0105/FP16-INT8/face-detection-0105.xml
+        weights: intel/face-detection-0105/FP16-INT8/face-detection-0105.bin
+        adapter:
+          type: class_agnostic_detection
+          scale: 0.00240384615
+
     datasets:
       - name: wider
 

--- a/tools/accuracy_checker/configs/face-detection-0106.yml
+++ b/tools/accuracy_checker/configs/face-detection-0106.yml
@@ -20,6 +20,15 @@ models:
           type: class_agnostic_detection
           scale: 0.0015625
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   intel/face-detection-0106/FP16-INT8/face-detection-0106.xml
+        weights: intel/face-detection-0106/FP16-INT8/face-detection-0106.bin
+        adapter:
+          type: class_agnostic_detection
+          scale: 0.0015625
+
     datasets:
       - name: wider
 

--- a/tools/accuracy_checker/configs/face-recognition-resnet100-arcface.yml
+++ b/tools/accuracy_checker/configs/face-recognition-resnet100-arcface.yml
@@ -33,6 +33,13 @@ models:
         weights: public/face-recognition-resnet100-arcface/FP32/face-recognition-resnet100-arcface.bin
         adapter: reid
 
+      - framework: dlsdk
+        tags:
+          - FP16
+        model:   public/face-recognition-resnet100-arcface/FP16/face-recognition-resnet100-arcface.xml
+        weights: public/face-recognition-resnet100-arcface/FP16/face-recognition-resnet100-arcface.bin
+        adapter: reid
+
     datasets:
       - name: lfw
 

--- a/tools/accuracy_checker/configs/googlenet-v1.yml
+++ b/tools/accuracy_checker/configs/googlenet-v1.yml
@@ -32,6 +32,20 @@ models:
         weights: public/googlenet-v1/FP16/googlenet-v1.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/googlenet-v1/FP32-INT8/googlenet-v1.xml
+        weights: public/googlenet-v1/FP32-INT8/googlenet-v1.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/googlenet-v1/FP16-INT8/googlenet-v1.xml
+        weights: public/googlenet-v1/FP16-INT8/googlenet-v1.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/googlenet-v3-pytorch.yml
+++ b/tools/accuracy_checker/configs/googlenet-v3-pytorch.yml
@@ -48,6 +48,20 @@ models:
         weights: public/googlenet-v3-pytorch/FP16/googlenet-v3-pytorch.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/googlenet-v3-pytorch/FP32-INT8/googlenet-v3-pytorch.xml
+        weights: public/googlenet-v3-pytorch/FP32-INT8/googlenet-v3-pytorch.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/googlenet-v3-pytorch/FP16-INT8/googlenet-v3-pytorch.xml
+        weights: public/googlenet-v3-pytorch/FP16-INT8/googlenet-v3-pytorch.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         # images read with Pillow

--- a/tools/accuracy_checker/configs/handwritten-japanese-recognition-0001.yml
+++ b/tools/accuracy_checker/configs/handwritten-japanese-recognition-0001.yml
@@ -18,9 +18,9 @@ models:
 
       - framework: dlsdk
         tags:
-          - FP32-INT8
-        model:   intel/handwritten-japanese-recognition-0001/FP32-INT8/handwritten-japanese-recognition-0001.xml
-        weights: intel/handwritten-japanese-recognition-0001/FP32-INT8/handwritten-japanese-recognition-0001.bin
+          - FP16-INT8
+        model:   intel/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.xml
+        weights: intel/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.bin
         adapter: ctc_greedy_search_decoder
 
     datasets:

--- a/tools/accuracy_checker/configs/instance-segmentation-security-1025.yml
+++ b/tools/accuracy_checker/configs/instance-segmentation-security-1025.yml
@@ -32,6 +32,21 @@ models:
           - name: im_info
             type: IMAGE_INFO
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   intel/instance-segmentation-security-1025/FP16-INT8/instance-segmentation-security-1025.xml
+        weights: intel/instance-segmentation-security-1025/FP16-INT8/instance-segmentation-security-1025.bin
+        adapter:
+          type: mask_rcnn
+          classes_out: classes
+          scores_out: scores
+          boxes_out: boxes
+          raw_masks_out: raw_masks
+        inputs:
+          - name: im_info
+            type: IMAGE_INFO
+
     datasets:
       - name: ms_coco_mask_rcnn_short_80_classes
 

--- a/tools/accuracy_checker/configs/mobilenet-v1-1.0-224.yml
+++ b/tools/accuracy_checker/configs/mobilenet-v1-1.0-224.yml
@@ -32,6 +32,20 @@ models:
         weights: public/mobilenet-v1-1.0-224/FP16/mobilenet-v1-1.0-224.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/mobilenet-v1-1.0-224/FP32-INT8/mobilenet-v1-1.0-224.xml
+        weights: public/mobilenet-v1-1.0-224/FP32-INT8/mobilenet-v1-1.0-224.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/mobilenet-v1-1.0-224/FP16-INT8/mobilenet-v1-1.0-224.xml
+        weights: public/mobilenet-v1-1.0-224/FP16-INT8/mobilenet-v1-1.0-224.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/mobilenet-v2-pytorch.yml
+++ b/tools/accuracy_checker/configs/mobilenet-v2-pytorch.yml
@@ -57,6 +57,20 @@ models:
         weights: public/mobilenet-v2-pytorch/FP16/mobilenet-v2-pytorch.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/mobilenet-v2-pytorch/FP32-INT8/mobilenet-v2-pytorch.xml
+        weights: public/mobilenet-v2-pytorch/FP32-INT8/mobilenet-v2-pytorch.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/mobilenet-v2-pytorch/FP16-INT8/mobilenet-v2-pytorch.xml
+        weights: public/mobilenet-v2-pytorch/FP16-INT8/mobilenet-v2-pytorch.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         reader: pillow_imread

--- a/tools/accuracy_checker/configs/mobilenet-v2.yml
+++ b/tools/accuracy_checker/configs/mobilenet-v2.yml
@@ -32,6 +32,20 @@ models:
         weights: public/mobilenet-v2/FP16/mobilenet-v2.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/mobilenet-v2/FP32-INT8/mobilenet-v2.xml
+        weights: public/mobilenet-v2/FP32-INT8/mobilenet-v2.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/mobilenet-v2/FP16-INT8/mobilenet-v2.xml
+        weights: public/mobilenet-v2/FP16-INT8/mobilenet-v2.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/person-attributes-recognition-crossroad-0230.yml
+++ b/tools/accuracy_checker/configs/person-attributes-recognition-crossroad-0230.yml
@@ -20,16 +20,6 @@ models:
           type: person_attributes
           attributes_recognition_out: "453"
 
-      - framework: dlsdk
-        tags:
-          - FP16-INT8
-        model:   intel/person-attributes-recognition-crossroad-0230/FP16-INT8/person-attributes-recognition-crossroad-0230.xml
-        weights: intel/person-attributes-recognition-crossroad-0230/FP16-INT8/person-attributes-recognition-crossroad-0230.bin
-        adapter:
-          type: person_attributes
-          attributes_recognition_out: "453"
-
-
     datasets:
       - name: person_8_attributes
 

--- a/tools/accuracy_checker/configs/person-detection-asl-0001.yml
+++ b/tools/accuracy_checker/configs/person-detection-asl-0001.yml
@@ -20,6 +20,15 @@ models:
           type: class_agnostic_detection
           scale: 0.003125
 
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   intel/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.xml
+        weights: intel/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.bin
+        adapter:
+          type: class_agnostic_detection
+          scale: 0.003125
+
     datasets:
       - name: mscoco_person_detection
 

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0248.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0248.yml
@@ -18,13 +18,6 @@ models:
 
       - framework: dlsdk
         tags:
-          - FP32-INT8
-        model:   intel/person-reidentification-retail-0248/FP32-INT8/person-reidentification-retail-0248.xml
-        weights: intel/person-reidentification-retail-0248/FP32-INT8/person-reidentification-retail-0248.bin
-        adapter: reid
-
-      - framework: dlsdk
-        tags:
           - FP16-INT8
         model:   intel/person-reidentification-retail-0248/FP16-INT8/person-reidentification-retail-0248.xml
         weights: intel/person-reidentification-retail-0248/FP16-INT8/person-reidentification-retail-0248.bin

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0249.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0249.yml
@@ -18,13 +18,6 @@ models:
 
       - framework: dlsdk
         tags:
-          - FP32-INT8
-        model:   intel/person-reidentification-retail-0249/FP32-INT8/person-reidentification-retail-0249.xml
-        weights: intel/person-reidentification-retail-0249/FP32-INT8/person-reidentification-retail-0249.bin
-        adapter: reid
-
-      - framework: dlsdk
-        tags:
           - FP16-INT8
         model:   intel/person-reidentification-retail-0249/FP16-INT8/person-reidentification-retail-0249.xml
         weights: intel/person-reidentification-retail-0249/FP16-INT8/person-reidentification-retail-0249.bin

--- a/tools/accuracy_checker/configs/person-reidentification-retail-0300.yml
+++ b/tools/accuracy_checker/configs/person-reidentification-retail-0300.yml
@@ -18,13 +18,6 @@ models:
 
       - framework: dlsdk
         tags:
-          - FP32-INT8
-        model:   intel/person-reidentification-retail-0300/FP32-INT8/person-reidentification-retail-0300.xml
-        weights: intel/person-reidentification-retail-0300/FP32-INT8/person-reidentification-retail-0300.bin
-        adapter: reid
-
-      - framework: dlsdk
-        tags:
           - FP16-INT8
         model:   intel/person-reidentification-retail-0300/FP16-INT8/person-reidentification-retail-0300.xml
         weights: intel/person-reidentification-retail-0300/FP16-INT8/person-reidentification-retail-0300.bin

--- a/tools/accuracy_checker/configs/resnet-101.yml
+++ b/tools/accuracy_checker/configs/resnet-101.yml
@@ -32,6 +32,20 @@ models:
         weights: public/resnet-101/FP16/resnet-101.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/resnet-101/FP32-INT8/resnet-101.xml
+        weights: public/resnet-101/FP32-INT8/resnet-101.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/resnet-101/FP16-INT8/resnet-101.xml
+        weights: public/resnet-101/FP16-INT8/resnet-101.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/resnet-152.yml
+++ b/tools/accuracy_checker/configs/resnet-152.yml
@@ -32,6 +32,20 @@ models:
         weights: public/resnet-152/FP16/resnet-152.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/resnet-152/FP32-INT8/resnet-152.xml
+        weights: public/resnet-152/FP32-INT8/resnet-152.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/resnet-152/FP16-INT8/resnet-152.xml
+        weights: public/resnet-152/FP16-INT8/resnet-152.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/resnet-18-pytorch.yml
+++ b/tools/accuracy_checker/configs/resnet-18-pytorch.yml
@@ -55,6 +55,19 @@ models:
         weights: public/resnet-18-pytorch/FP16/resnet-18-pytorch.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/resnet-18-pytorch/FP32-INT8/resnet-18-pytorch.xml
+        weights: public/resnet-18-pytorch/FP32-INT8/resnet-18-pytorch.bin
+        adapter: classification
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/resnet-18-pytorch/FP16-INT8/resnet-18-pytorch.xml
+        weights: public/resnet-18-pytorch/FP16-INT8/resnet-18-pytorch.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         reader: pillow_imread

--- a/tools/accuracy_checker/configs/resnet-50-pytorch.yml
+++ b/tools/accuracy_checker/configs/resnet-50-pytorch.yml
@@ -56,6 +56,20 @@ models:
         weights: public/resnet-50-pytorch/FP16/resnet-50-pytorch.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/resnet-50-pytorch/FP32-INT8/resnet-50-pytorch.xml
+        weights: public/resnet-50-pytorch/FP32-INT8/resnet-50-pytorch.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/resnet-50-pytorch/FP16-INT8/resnet-50-pytorch.xml
+        weights: public/resnet-50-pytorch/FP16-INT8/resnet-50-pytorch.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         reader: pillow_imread

--- a/tools/accuracy_checker/configs/resnet-50.yml
+++ b/tools/accuracy_checker/configs/resnet-50.yml
@@ -32,6 +32,20 @@ models:
         weights: public/resnet-50/FP16/resnet-50.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/resnet-50/FP32-INT8/resnet-50.xml
+        weights: public/resnet-50/FP32-INT8/resnet-50.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/resnet-50/FP16-INT8/resnet-50.xml
+        weights: public/resnet-50/FP16-INT8/resnet-50.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/squeezenet1.1-caffe2.yml
+++ b/tools/accuracy_checker/configs/squeezenet1.1-caffe2.yml
@@ -32,6 +32,20 @@ models:
         weights: public/squeezenet1.1-caffe2/FP16/squeezenet1.1-caffe2.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/squeezenet1.1-caffe2/FP32-INT8/squeezenet1.1-caffe2.xml
+        weights: public/squeezenet1.1-caffe2/FP32-INT8/squeezenet1.1-caffe2.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/squeezenet1.1-caffe2/FP16-INT8/squeezenet1.1-caffe2.xml
+        weights: public/squeezenet1.1-caffe2/FP16-INT8/squeezenet1.1-caffe2.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/squeezenet1.1.yml
+++ b/tools/accuracy_checker/configs/squeezenet1.1.yml
@@ -31,6 +31,20 @@ models:
         weights: public/squeezenet1.1/FP16/squeezenet1.1.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/squeezenet1.1/FP32-INT8/squeezenet1.1.xml
+        weights: public/squeezenet1.1/FP32-INT8/squeezenet1.1.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/squeezenet1.1/FP16-INT8/squeezenet1.1.xml
+        weights: public/squeezenet1.1/FP16-INT8/squeezenet1.1.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:

--- a/tools/accuracy_checker/configs/vgg16.yml
+++ b/tools/accuracy_checker/configs/vgg16.yml
@@ -32,6 +32,20 @@ models:
         weights: public/vgg16/FP16/vgg16.bin
         adapter: classification
 
+      - framework: dlsdk
+        tags:
+          - FP32-INT8
+        model:   public/vgg16/FP32-INT8/vgg16.xml
+        weights: public/vgg16/FP32-INT8/vgg16.bin
+        adapter: classification
+
+      - framework: dlsdk
+        tags:
+          - FP16-INT8
+        model:   public/vgg16/FP16-INT8/vgg16.xml
+        weights: public/vgg16/FP16-INT8/vgg16.bin
+        adapter: classification
+
     datasets:
       - name: imagenet_1000_classes
         preprocessing:


### PR DESCRIPTION
AC configs have been updated according to information from info_dumper. Also launchers for FP32-INT8 and FP16-INT8 have been added for models with quantizable: yes in model.yml
