### PR TITLE
AC: add resize meta for autoresize

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/config/config_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_reader.py
@@ -389,7 +389,7 @@ class ConfigReader:
     @staticmethod
     def _provide_cmd_arguments(arguments, config, mode):
         def _add_subsample_size_arg(dataset_entry):
-            if 'subsample_size' in arguments:
+            if 'subsample_size' in arguments and arguments.subsample_size is not None:
                 dataset_entry['subsample_size'] = arguments.subsample_size
 
         def merge_models(config, arguments, update_launcher_entry):

--- a/tools/accuracy_checker/accuracy_checker/preprocessor/resize.py
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/resize.py
@@ -380,6 +380,7 @@ class AutoResize(Preprocessor):
             self.set_input_shape(self.input_shapes)
 
         def process_data(data):
+            image_h, image_w = data.shape[:2]
             data = cv2.resize(data, (self.dst_width, self.dst_height)).astype(np.float32)
             if len(data.shape) == 2:
                 data = np.expand_dims(data, axis=-1)
@@ -389,6 +390,16 @@ class AutoResize(Preprocessor):
                 image.metadata.setdefault('geometric_operations', []).append(
                     GeometricOperationMetadata('auto_resize', {})
                 )
+                resize_meta = {
+                    'preferable_width': self.dst_width,
+                    'preferable_height': self.dst_height,
+                    'image_info': [self.dst_height, self.dst_width, 1],
+                    'scale_x': float(self.dst_width) / image_w,
+                    'scale_y': float(self.dst_height) / image_h,
+                    'original_width': image_w,
+                    'original_height': image_h
+                }
+                image.metadata.update(resize_meta)
 
             return data
 

--- a/tools/accuracy_checker/tests/test_preprocessor.py
+++ b/tools/accuracy_checker/tests/test_preprocessor.py
@@ -189,12 +189,25 @@ class TestAutoResize:
         resize = Preprocessor.provide('auto_resize', {'type': 'auto_resize'})
         resize.set_input_shape({'data': (1, 3, 200, 200)})
 
-        input_mock = mocker.Mock()
-        resize(DataRepresentation(input_mock))
+        input_data = np.zeros((100, 100, 3))
+        input_rep = DataRepresentation(input_data)
+        expoected_meta = {
+                    'preferable_width': 200,
+                    'preferable_height':200,
+                    'image_info': [200, 200, 1],
+                    'scale_x': 2.0,
+                    'scale_y': 2.0,
+                    'original_width': 100,
+                    'original_height': 100,
+                }
+        resize(input_rep)
 
         assert resize.dst_width == 200
         assert resize.dst_height == 200
-        cv2_resize_mock.assert_called_once_with(input_mock, (200, 200))
+        cv2_resize_mock.assert_called_once_with(input_data, (200, 200))
+        for key, value in expoected_meta.items():
+            assert key in input_rep.metadata
+            assert input_rep.metadata[key] == value
 
     def test_auto_resize_input_shape_not_provided_raise_config_error(self, mocker):
         input_mock = mocker.Mock()


### PR DESCRIPTION
fixed wrong postprocessing in mask rcnn adapter, which lead to 0% metric if auto_resize used as preprocessing