### PR TITLE
Unify the reporting mechanisms used by the model tools

### DIFF
--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -78,7 +78,7 @@ class JobContext:
     def printf(self, format, *args, flush=False):
         self.print(format.format(*args), flush=flush)
 
-    def subprocess(self, args):
+    def subprocess(self, args, **kwargs):
         raise NotImplementedError
 
 
@@ -86,8 +86,8 @@ class DirectOutputContext(JobContext):
     def print(self, value, *, end='\n', flush=False):
         print(value, end=end, flush=flush)
 
-    def subprocess(self, args):
-        return subprocess.run(args).returncode == 0
+    def subprocess(self, args, **kwargs):
+        return subprocess.run(args, **kwargs).returncode == 0
 
 
 class Reporter:

--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -36,9 +36,9 @@ class QueuedOutputContext(common.JobContext):
     def print(self, value, *, end='\n', flush=False):
         self._output_queue.put(value + end)
 
-    def subprocess(self, args):
+    def subprocess(self, args, **kwargs):
         with subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                universal_newlines=True) as p:
+                universal_newlines=True, **kwargs) as p:
             for line in p.stdout:
                 self._output_queue.put(line)
             return p.wait() == 0

--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -216,7 +216,7 @@ def main():
 
     args = parser.parse_args()
 
-    reporter = common.Reporter(
+    reporter = common.Reporter(common.DirectOutputContext(),
         enable_human_output=args.progress_format == 'text',
         enable_json_output=args.progress_format == 'json')
 

--- a/tools/downloader/quantizer.py
+++ b/tools/downloader/quantizer.py
@@ -29,7 +29,7 @@ import common
 
 OMZ_ROOT = Path(__file__).resolve().parents[2]
 
-def quantize(model, precision, args, output_dir, pot_path, pot_env):
+def quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
     input_precision = common.KNOWN_QUANTIZED_PRECISIONS[precision]
 
     pot_config = {
@@ -57,13 +57,13 @@ def quantize(model, precision, args, output_dir, pot_path, pot_env):
     if args.target_device:
         pot_config['compression']['target_device'] = args.target_device
 
-    print('========= {}Quantizing {} from {} to {}'.format(
-        '(DRY RUN) ' if args.dry_run else '', model.name, input_precision, precision))
+    reporter.print_section_heading('{}Quantizing {} from {} to {}',
+        '(DRY RUN) ' if args.dry_run else '', model.name, input_precision, precision)
 
     model_output_dir = output_dir / model.subdirectory / precision
     pot_config_path = model_output_dir / 'pot-config.json'
 
-    print('Creating {}...'.format(pot_config_path))
+    reporter.print('Creating {}...', pot_config_path)
     pot_config_path.parent.mkdir(parents=True, exist_ok=True)
     with pot_config_path.open('w') as pot_config_file:
         json.dump(pot_config, pot_config_file, indent=4)
@@ -78,27 +78,27 @@ def quantize(model, precision, args, output_dir, pot_path, pot_env):
         '--output-dir={}'.format(pot_output_dir),
     ]
 
-    print('Quantization command: {}'.format(common.command_string(pot_cmd)))
-    print('Quantization environment: {}'.format(
+    reporter.print('Quantization command: {}', common.command_string(pot_cmd))
+    reporter.print('Quantization environment: {}',
         ' '.join('{}={}'.format(k, common.quote_arg(v))
-            for k, v in sorted(pot_env.items()))))
+            for k, v in sorted(pot_env.items())))
 
     success = True
 
     if not args.dry_run:
-        print('', flush=True)
+        reporter.print(flush=True)
 
-        success = subprocess.run(pot_cmd, env={**os.environ, **pot_env}).returncode == 0
+        success = reporter.job_context.subprocess(pot_cmd, env={**os.environ, **pot_env})
 
-    print('')
+    reporter.print()
     if not success: return False
 
     if not args.dry_run:
-        print('Moving quantized model to {}...'.format(model_output_dir))
+        reporter.print('Moving quantized model to {}...', model_output_dir)
         for ext in ['.xml', '.bin']:
             (pot_output_dir / 'optimized' / (model.name + ext)).replace(
                 model_output_dir / (model.name + ext))
-        print('')
+        reporter.print()
 
     return True
 
@@ -148,6 +148,8 @@ def main():
         if unknown_precisions:
             sys.exit('Unknown precisions specified: {}.'.format(', '.join(sorted(unknown_precisions))))
 
+    reporter = common.Reporter(common.DirectOutputContext())
+
     output_dir = args.output_dir or args.model_dir
 
     failed_models = []
@@ -163,19 +165,20 @@ def main():
 
         for model in models:
             if not model.quantizable:
-                print('========= Skipping {} (quantization not supported)'.format(model.name))
-                print('')
+                reporter.print_section_heading('Skipping {} (quantization not supported)', model.name)
+                reporter.print()
                 continue
 
             for precision in sorted(requested_precisions):
-                if not quantize(model, precision, args, output_dir, pot_path, pot_env):
+                if not quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
                     failed_models.append(model.name)
                     break
 
 
     if failed_models:
-        print('FAILED:')
-        print(*sorted(failed_models), sep='\n')
+        reporter.print('FAILED:')
+        for failed_model_name in failed_models:
+            reporter.print(failed_model_name)
         sys.exit(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The main reason I'm doing this is to prepare for implementing parallel downloading in the downloader, but as a side benefit, this also enforces consistent formatting in the converter and quantizer.

The info dumper only has machine-readable output, so it has no use for these mechanisms and is thus unaffected.

See the commit messages for more details.