### PR TITLE
AC: Fix coco_orig_metric

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/metrics/coco_orig_metrics.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/coco_orig_metrics.py
@@ -18,8 +18,8 @@ import os
 import tempfile
 import json
 import warnings
-import numpy as np
 from pathlib import Path
+import numpy as np
 try:
     from pycocotools.coco import COCO
 except ImportError:
@@ -254,7 +254,7 @@ class MSCOCOorigBaseMetric(FullDatasetEvaluationMetric):
                 'id': cat,
                 'name': cat_name
             })
-        for key,value in coco_images.items():
+        for value in coco_images.values():
             coco_image_to_store.append(value)
 
         coco_data_to_store = {
@@ -333,25 +333,21 @@ class MSCOCOorigBaseMetric(FullDatasetEvaluationMetric):
 
         return res
 
+    @property
     def _use_original_coco(self):
         subsample_size = self.dataset.config.get('subsample_size')
-        if subsample_size:
-            return False
-        else:
+        if not subsample_size:
             annotation_conversion_parameters = self.dataset.config.get('annotation_conversion')
             if annotation_conversion_parameters:
                 annotation_file = annotation_conversion_parameters.get('annotation_file')
-                if annotation_file.is_file():
-                    return True
-                else:
-                    return False
-            else:
-                return False
+                return annotation_file.is_file()
+
+        return False
 
     def compute_precision_recall(self, annotations, predictions):
-        if(self._use_original_coco()):
-            coco, map_coco_img_file_name_to_img_id, map_pred_label_id_to_coco_cat_id = \
-                self._prepare_original_coco_structures()
+        if self._use_original_coco:
+            structures = self._prepare_original_coco_structures()
+            coco, map_coco_img_file_name_to_img_id, map_pred_label_id_to_coco_cat_id = structures
 
             coco_data_to_store = self._convert_data_to_original_coco_format(
                 predictions, map_coco_img_file_name_to_img_id, map_pred_label_id_to_coco_cat_id

--- a/tools/accuracy_checker/accuracy_checker/metrics/coco_orig_metrics.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/coco_orig_metrics.py
@@ -72,6 +72,8 @@ class MSCOCOorigBaseMetric(FullDatasetEvaluationMetric):
         if not self.dataset.metadata.get('label_map'):
             raise ConfigError('coco_orig metrics require label_map providing in dataset_meta'
                               'Please provide dataset meta file or regenerated annotation')
+        if COCO is None:
+            raise ValueError('pycocotools is not installed, please install it')
 
     @staticmethod
     def _iou_type_data_to_coco(data_to_store, data):
@@ -98,8 +100,6 @@ class MSCOCOorigBaseMetric(FullDatasetEvaluationMetric):
         if self.dataset.metadata.get('background_label') is not None:
             label_map.pop(self.dataset.metadata.get('background_label'))
 
-        if COCO is None:
-            raise ValueError('pycocotools is not installed, please install it')
         coco_data_to_store = self._prepare_data_for_annotation_file(
             annotations, label_map)
 
@@ -125,8 +125,6 @@ class MSCOCOorigBaseMetric(FullDatasetEvaluationMetric):
 
         meta = self.dataset.metadata
 
-        if COCO is None:
-            raise ValueError('pycocotools is not installed, please install it')
         coco = COCO(str(annotation_file))
         assert 0 not in coco.cats.keys()
         coco_cat_name_to_id = {v['name']: k for k, v in coco.cats.items()}


### PR DESCRIPTION
Calculation of coco_orig_metric has been fixed.   AP has been reduced to 66.6% from 69%. After fix AP for mentioned model is 68.37%. 

In this PR usage of original and generated annotation file has been combined by condition. If there is annotation file, it is used when calculating the metric. If annotation file is missing or there is subsample_size option, use generated annotation file.