### PR TITLE
Model downloader: print progress even if zero time passed

### DIFF
--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -47,11 +47,14 @@ def process_download(reporter, chunk_iterable, size, file):
 
                 if duration != 0:
                     speed = int(progress_size / (1024 * duration))
-                    percent = str(progress_size * 100 // size)
+                else:
+                    speed = '?'
 
-                    reporter.print_progress('... {}%, {} KB, {} KB/s, {} seconds passed',
-                        percent, int(progress_size / 1024), speed, int(duration))
-                    reporter.emit_event('model_file_download_progress', size=progress_size)
+                percent = progress_size * 100 // size
+
+                reporter.print_progress('... {}%, {} KB, {} KB/s, {} seconds passed',
+                    percent, progress_size // 1024, speed, int(duration))
+                reporter.emit_event('model_file_download_progress', size=progress_size)
 
                 file.write(chunk)
 


### PR DESCRIPTION
It is possible for `duration` to be 0 if a chunk has already been received completely by the time we got to the chunk loop. In this case, we can't calculate the speed, but we can still output all the other progress information, so do so.

This is particularly important for very short files which entirely fit in one chunk, since previously there wouldn't be any progress information for them at all.

I also removed a couple of unnecessary casts in the affected code.