### PR TITLE
Remove broken link

### DIFF
--- a/models/public/license-plate-recognition-barrier-0007/license-plate-recognition-barrier-0007.md
+++ b/models/public/license-plate-recognition-barrier-0007/license-plate-recognition-barrier-0007.md
@@ -33,7 +33,6 @@ Only "blue" license plates, which are common in public, were tested
 thoroughly. Other types of license plates may underperform.
 
 ## Performance
-Link to [performance table](https://software.intel.com/en-us/openvino-toolkit/benchmarks)
 
 ## Inputs
 


### PR DESCRIPTION
The "Performance Benchmarks" link on the OpenVINO toolkit home page now links to <https://docs.openvinotoolkit.org/latest/_docs_performance_benchmarks.html>, but that page doesn't mention this model at all, so it wouldn't make sense to link to it here.