### PR TITLE
Model downloader: implement parallel downloading

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -126,6 +126,13 @@ human-readable format.
 You can also set this option to `text` to explicitly request the default text
 format.
 
+The script can download files for multiple models concurrently. To enable this,
+use the `-j`/`--jobs` option:
+
+```sh
+./downloader.py --all -j8 # download up to 8 models at a time
+```
+
 See the "Shared options" section for information on other options accepted by
 the script.
 
@@ -209,8 +216,9 @@ In particular:
   (unless specified otherwise above) or will only occur once.
 
 * Tools should not assume that events will occur in a certain order beyond
-  the ordering constraints specified above. Note that future versions of the script
-  may interleave the downloading of different files or models.
+  the ordering constraints specified above. In particular, when the `--jobs` option
+  is set to a value greater than 1, event sequences for different files or models
+  may get interleaved.
 
 Model converter usage
 ---------------------

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -24,6 +24,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 import traceback
 
 from pathlib import Path
@@ -74,19 +75,19 @@ RE_SHA256SUM = re.compile(r'[0-9a-fA-F]{64}')
 
 
 class JobContext:
-    def print(self, value, *, end='\n', flush=False):
+    def print(self, value, *, end='\n', file=sys.stdout, flush=False):
         raise NotImplementedError
 
-    def printf(self, format, *args, flush=False):
-        self.print(format.format(*args), flush=flush)
+    def printf(self, format, *args, file=sys.stdout, flush=False):
+        self.print(format.format(*args), file=file, flush=flush)
 
     def subprocess(self, args, **kwargs):
         raise NotImplementedError
 
 
 class DirectOutputContext(JobContext):
-    def print(self, value, *, end='\n', flush=False):
-        print(value, end=end, flush=flush)
+    def print(self, value, *, end='\n', file=sys.stdout, flush=False):
+        print(value, end=end, file=file, flush=flush)
 
     def subprocess(self, args, **kwargs):
         return subprocess.run(args, **kwargs).returncode == 0
@@ -96,14 +97,14 @@ class QueuedOutputContext(JobContext):
     def __init__(self, output_queue):
         self._output_queue = output_queue
 
-    def print(self, value, *, end='\n', flush=False):
-        self._output_queue.put(value + end)
+    def print(self, value, *, end='\n', file=sys.stdout, flush=False):
+        self._output_queue.put((file, value + end))
 
     def subprocess(self, args, **kwargs):
         with subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 universal_newlines=True, **kwargs) as p:
             for line in p.stdout:
-                self._output_queue.put(line)
+                self._output_queue.put((sys.stdout, line))
             return p.wait() == 0
 
 
@@ -114,8 +115,8 @@ class JobWithQueuedOutput():
         self._future.add_done_callback(lambda future: self._output_queue.put(None))
 
     def complete(self):
-        for fragment in iter(self._output_queue.get, None):
-            print(fragment, end='', flush=True) # for simplicity, flush every fragment
+        for file, fragment in iter(self._output_queue.get, None):
+            print(fragment, end='', file=file, flush=True) # for simplicity, flush every fragment
 
         return self._future.result()
 
@@ -138,6 +139,7 @@ def run_in_parallel(num_jobs, f, work_items):
             for job in jobs: job.cancel()
             raise
 
+EVENT_EMISSION_LOCK = threading.Lock()
 
 class Reporter:
     GROUP_DECORATION = '#' * 16 + '||'
@@ -175,21 +177,28 @@ class Reporter:
 
     def log_warning(self, format, *args, exc_info=False):
         if exc_info:
-            traceback.print_exc(file=sys.stderr)
-        print(self.ERROR_DECORATION, "Warning:", format.format(*args), file=sys.stderr)
+            self.job_context.print(traceback.format_exc(), file=sys.stderr, end='')
+        self.job_context.printf("{} Warning: {}", self.ERROR_DECORATION, format.format(*args), file=sys.stderr)
 
     def log_error(self, format, *args, exc_info=False):
         if exc_info:
-            traceback.print_exc(file=sys.stderr)
-        print(self.ERROR_DECORATION, "Error:", format.format(*args), file=sys.stderr)
+            self.job_context.print(traceback.format_exc(), file=sys.stderr, end='')
+        self.job_context.printf("{} Error: {}", self.ERROR_DECORATION, format.format(*args), file=sys.stderr)
 
     def log_details(self, format, *args):
         print(self.ERROR_DECORATION, '    ', format.format(*args), file=sys.stderr)
 
     def emit_event(self, type, **kwargs):
         if not self.enable_json_output: return
-        json.dump({'$type': type, **self.event_context, **kwargs}, sys.stdout, indent=None)
-        print()
+
+        # We don't print machine-readable output through the job context, because
+        # we don't want it to be serialized. If we serialize it, then the consumer
+        # will lose information about the order of events, and we don't want that to happen.
+        # Instead, we emit events directly to stdout, but use a lock to ensure that
+        # JSON texts don't get interleaved.
+        with EVENT_EMISSION_LOCK:
+            json.dump({'$type': type, **self.event_context, **kwargs}, sys.stdout, indent=None)
+            print()
 
     def with_event_context(self, **kwargs):
         return Reporter(

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import collections
+import concurrent.futures
 import contextlib
 import fnmatch
 import json
 import platform
+import queue
 import re
 import shlex
 import shutil
@@ -88,6 +90,53 @@ class DirectOutputContext(JobContext):
 
     def subprocess(self, args, **kwargs):
         return subprocess.run(args, **kwargs).returncode == 0
+
+
+class QueuedOutputContext(JobContext):
+    def __init__(self, output_queue):
+        self._output_queue = output_queue
+
+    def print(self, value, *, end='\n', flush=False):
+        self._output_queue.put(value + end)
+
+    def subprocess(self, args, **kwargs):
+        with subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                universal_newlines=True, **kwargs) as p:
+            for line in p.stdout:
+                self._output_queue.put(line)
+            return p.wait() == 0
+
+
+class JobWithQueuedOutput():
+    def __init__(self, output_queue, future):
+        self._output_queue = output_queue
+        self._future = future
+        self._future.add_done_callback(lambda future: self._output_queue.put(None))
+
+    def complete(self):
+        for fragment in iter(self._output_queue.get, None):
+            print(fragment, end='', flush=True) # for simplicity, flush every fragment
+
+        return self._future.result()
+
+    def cancel(self):
+        self._future.cancel()
+
+
+def run_in_parallel(num_jobs, f, work_items):
+    with concurrent.futures.ThreadPoolExecutor(num_jobs) as executor:
+        def start(work_item):
+            output_queue = queue.Queue()
+            return JobWithQueuedOutput(
+                output_queue, executor.submit(f, QueuedOutputContext(output_queue), work_item))
+
+        jobs = list(map(start, work_items))
+
+        try:
+            return [job.complete() for job in jobs]
+        except:
+            for job in jobs: job.cancel()
+            raise
 
 
 class Reporter:

--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -43,6 +43,8 @@ def process_download(reporter, chunk_iterable, size, file):
 
     try:
         for chunk in chunk_iterable:
+            reporter.job_context.check_interrupted()
+
             if chunk:
                 duration = time.monotonic() - start_time
                 progress_size += len(chunk)
@@ -77,7 +79,9 @@ def try_download(reporter, file, num_attempts, start_download, size):
             time.sleep(retry_delay)
 
         try:
+            reporter.job_context.check_interrupted()
             chunk_iterable = start_download()
+
             file.seek(0)
             file.truncate()
             actual_size, hash = process_download(reporter, chunk_iterable, size, file)
@@ -150,6 +154,8 @@ def try_retrieve_from_cache(reporter, cache, files):
     try:
         if all(cache.has(file[0]) for file in files):
             for hash, destination in files:
+                reporter.job_context.check_interrupted()
+
                 reporter.print_section_heading('Retrieving {} from the cache', destination)
                 cache.get(hash, destination)
             reporter.print()

--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -17,6 +17,8 @@
 """
 
 import argparse
+import concurrent.futures
+import contextlib
 import hashlib
 import re
 import requests
@@ -25,6 +27,7 @@ import shutil
 import ssl
 import sys
 import tempfile
+import threading
 import time
 
 from pathlib import Path
@@ -183,6 +186,37 @@ def try_retrieve(reporter, destination, model_file, cache, num_attempts, start_d
     reporter.print()
     return success
 
+def download_model(reporter, args, cache, session_factory, requested_precisions, model):
+    session = session_factory()
+    reporter.emit_event('model_download_begin', model=model.name, num_files=len(model.files))
+
+    output = args.output_dir / model.subdirectory
+    output.mkdir(parents=True, exist_ok=True)
+
+    for model_file in model.files:
+        if len(model_file.name.parts) == 2:
+            p = model_file.name.parts[0]
+            if p in common.KNOWN_PRECISIONS and p not in requested_precisions:
+                continue
+
+        model_file_reporter = reporter.with_event_context(model=model.name, model_file=model_file.name.as_posix())
+        model_file_reporter.emit_event('model_file_download_begin', size=model_file.size)
+
+        destination = output / model_file.name
+
+        if not try_retrieve(model_file_reporter, destination, model_file, cache, args.num_attempts,
+                lambda: model_file.source.start_download(session, CHUNK_SIZE)):
+            shutil.rmtree(str(output))
+            model_file_reporter.emit_event('model_file_download_end', successful=False)
+            reporter.emit_event('model_download_end', model=model.name, successful=False)
+            return False
+
+        model_file_reporter.emit_event('model_file_download_end', successful=True)
+
+    reporter.emit_event('model_download_end', model=model.name, successful=True)
+    return True
+
+
 class DownloaderArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         sys.stderr.write('error: %s\n' % message)
@@ -197,6 +231,26 @@ def positive_int_arg(value_str):
         pass
 
     raise argparse.ArgumentTypeError('must be a positive integer (got {!r})'.format(value_str))
+
+
+# There is no evidence that the requests.Session class is thread-safe,
+# so for safety, we use one Session per thread. This class ensures that
+# each thread gets its own Session.
+class ThreadSessionFactory:
+    def __init__(self, exit_stack):
+        self._lock = threading.Lock()
+        self._thread_local = threading.local()
+        self._exit_stack = exit_stack
+
+    def __call__(self):
+        try:
+            session = self._thread_local.session
+        except AttributeError:
+            with self._lock: # ExitStack might not be thread-safe either
+                session = self._exit_stack.enter_context(requests.Session())
+            self._thread_local.session = session
+        return session
+
 
 def main():
     parser = DownloaderArgumentParser()
@@ -216,12 +270,19 @@ def main():
         help='attempt each download up to N times')
     parser.add_argument('--progress_format', choices=('text', 'json'), default='text',
         help='which format to use for progress reporting')
+    # unlike Model Converter, -jauto is not supported here, because CPU count has no
+    # relation to the optimal number of concurrent downloads
+    parser.add_argument('-j', '--jobs', type=positive_int_arg, metavar='N', default=1,
+        help='how many downloads to perform concurrently')
 
     args = parser.parse_args()
 
-    reporter = common.Reporter(common.DirectOutputContext(),
-        enable_human_output=args.progress_format == 'text',
-        enable_json_output=args.progress_format == 'json')
+    def make_reporter(context):
+        return common.Reporter(context,
+            enable_human_output=args.progress_format == 'text',
+            enable_json_output=args.progress_format == 'json')
+
+    reporter = make_reporter(common.DirectOutputContext())
 
     cache = NullCache() if args.cache_dir is None else DirCache(args.cache_dir)
     models = common.load_models_from_args(parser, args)
@@ -237,35 +298,18 @@ def main():
             sys.exit('Unknown precisions specified: {}.'.format(', '.join(sorted(unknown_precisions))))
 
     reporter.print_group_heading('Downloading models')
-    with requests.Session() as session:
-        for model in models:
-            reporter.emit_event('model_download_begin', model=model.name, num_files=len(model.files))
+    with contextlib.ExitStack() as exit_stack:
+        session_factory = ThreadSessionFactory(exit_stack)
+        if args.jobs == 1:
+            results = [download_model(reporter, args, cache, session_factory, requested_precisions, model)
+                for model in models]
+        else:
+            results = common.run_in_parallel(args.jobs,
+                lambda context, model: download_model(
+                    make_reporter(context), args, cache, session_factory, requested_precisions, model),
+                models)
 
-            output = args.output_dir / model.subdirectory
-            output.mkdir(parents=True, exist_ok=True)
-
-            for model_file in model.files:
-                if len(model_file.name.parts) == 2:
-                    p = model_file.name.parts[0]
-                    if p in common.KNOWN_PRECISIONS and p not in requested_precisions:
-                        continue
-
-                model_file_reporter = reporter.with_event_context(model=model.name, model_file=model_file.name.as_posix())
-                model_file_reporter.emit_event('model_file_download_begin', size=model_file.size)
-
-                destination = output / model_file.name
-
-                if not try_retrieve(model_file_reporter, destination, model_file, cache, args.num_attempts,
-                        lambda: model_file.source.start_download(session, CHUNK_SIZE)):
-                    shutil.rmtree(str(output))
-                    failed_models.add(model.name)
-                    model_file_reporter.emit_event('model_file_download_end', successful=False)
-                    reporter.emit_event('model_download_end', model=model.name, successful=False)
-                    break
-
-                model_file_reporter.emit_event('model_file_download_end', successful=True)
-            else:
-                reporter.emit_event('model_download_end', model=model.name, successful=True)
+    failed_models = {model.name for model, successful in zip(models, results) if not successful}
 
     reporter.print_group_heading('Post-processing')
     for model in models:


### PR DESCRIPTION
This adds a `-j` option to the model downloader, which will tell it to download multiple models at the same time, similarly to the model converter. Also similarly to the converter, the output from the concurrent downloading jobs will be serialized, so that it'll be indistinguishable from downloading all models sequentially. This, I will admit, is not ideal, but it's better than just having the jobs chaotically writer over each other's output. Ideally, we should have multiple progress bars updating at the same time, but that seems quite tricky to implement.

See the individual commits for more details (and easier-to-review diffs :-) ).