### PR TITLE
pytorch_to_onnx.py: explicitly specify the ONNX opset

### DIFF
--- a/tools/downloader/pytorch_to_onnx.py
+++ b/tools/downloader/pytorch_to_onnx.py
@@ -98,7 +98,7 @@ def convert_to_onnx(model, input_shape, output_file, input_names, output_names):
     model.eval()
     dummy_input = torch.randn(input_shape)
     model(dummy_input)
-    torch.onnx.export(model, dummy_input, str(output_file), verbose=False,
+    torch.onnx.export(model, dummy_input, str(output_file), verbose=False, opset_version=9,
                       input_names=input_names.split(','), output_names=output_names.split(','))
 
     # Model check after conversion


### PR DESCRIPTION
PyTorch might change the default opset in a future release to one that is unsupported by Model Optimizer. To prevent surprises, it's better to set the opset explicitly.