### PR TITLE
pytorch_to_onnx.py: work around an incompatibility with PyTorch 1.5

### DIFF
--- a/tools/downloader/pytorch_to_onnx.py
+++ b/tools/downloader/pytorch_to_onnx.py
@@ -101,14 +101,22 @@ def convert_to_onnx(model, input_shape, output_file, input_names, output_names):
     torch.onnx.export(model, dummy_input, str(output_file), verbose=False, opset_version=9,
                       input_names=input_names.split(','), output_names=output_names.split(','))
 
-    # Model check after conversion
     model = onnx.load(str(output_file))
+
+    # Model Optimizer takes output names from ONNX node names if they exist.
+    # However, the names PyTorch assigns to the ONNX nodes are generic and
+    # non-descriptive (e.g. "Gemm_151"). By deleting these names, we make
+    # MO fall back to the ONNX output names, which we can set to whatever we want.
+    for node in model.graph.node:
+        node.ClearField('name')
+
     try:
         onnx.checker.check_model(model)
         print('ONNX check passed successfully.')
     except onnx.onnx_cpp2py_export.checker.ValidationError as exc:
         sys.exit('ONNX check failed with error: ' + str(exc))
 
+    onnx.save(model, str(output_file))
 
 def main():
     args = parse_args()


### PR DESCRIPTION
PyTorch 1.5 started assigning names to ONNX nodes, which causes Model Optimizer to use those names as IR output names, rather than the ONNX output names. For us, this is backwards-incompatible (our existing `--output` options stop working) and just plain inconvenient (the PyTorch-generated names are much less descriptive than our hand-picked output names).

Work around it by deleting the ONNX node names after conversion (effectively, restoring the PyTorch 1.4 behavior).