### PR TITLE
AC: support explicit output layer name in classification adapter

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/classification.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from ..topology_types import ImageClassification
 from ..adapters import Adapter
-from ..config import BoolField
+from ..config import BoolField, StringField
 from ..representation import ClassificationPrediction, ArgMaxClassificationPrediction
 
 
@@ -37,12 +37,14 @@ class ClassificationAdapter(Adapter):
             'argmax_output': BoolField(
                 optional=True, default=False, description="identifier that model output is ArgMax layer"
             ),
+            'classification_output': StringField(optional=True, description='otarget output layer name')
         })
 
         return parameters
 
     def configure(self):
         self.argmax_output = self.get_value_from_config('argmax_output')
+        self.classification_out = self.get_value_from_config('classification_output')
 
     def process(self, raw, identifiers=None, frame_meta=None):
         """
@@ -53,6 +55,8 @@ class ClassificationAdapter(Adapter):
         Returns:
             list of ClassificationPrediction objects
         """
+        if self.classification_out is not None:
+            self.output_blob = self.classification_out
         multi_infer = frame_meta[-1].get('multi_infer', False) if frame_meta else False
         prediction = self._extract_predictions(raw, frame_meta)[self.output_blob]
         if multi_infer:

--- a/tools/accuracy_checker/configs/hbonet-0.25.yml
+++ b/tools/accuracy_checker/configs/hbonet-0.25.yml
@@ -21,6 +21,7 @@ models:
             size: 256
             aspect_ratio_scale: greater
             interpolation: BILINEAR
+            use_pillow: True
 
           - type: crop
             size: 224
@@ -40,14 +41,18 @@ models:
           - FP32
         model:   public/hbonet-0.25/FP32/hbonet-0.25.xml
         weights: public/hbonet-0.25/FP32/hbonet-0.25.bin
-        adapter: classification
+        adapter:
+          type: classification
+          classification_output: output
 
       - framework: dlsdk
         tags:
           - FP16
         model:   public/hbonet-0.25/FP16/hbonet-0.25.xml
         weights: public/hbonet-0.25/FP16/hbonet-0.25.bin
-        adapter: classification
+        adapter:
+          type: classification
+          classification_output: output
 
     datasets:
       - name: imagenet_1000_classes
@@ -58,6 +63,7 @@ models:
             size: 256
             aspect_ratio_scale: greater
             interpolation: BILINEAR
+            use_pillow: True
 
           - type: crop
             size: 224

--- a/tools/accuracy_checker/configs/hbonet-0.5.yml
+++ b/tools/accuracy_checker/configs/hbonet-0.5.yml
@@ -21,6 +21,7 @@ models:
             size: 256
             aspect_ratio_scale: greater
             interpolation: BILINEAR
+            use_pillow: True
 
           - type: crop
             size: 224
@@ -40,14 +41,18 @@ models:
           - FP32
         model:   public/hbonet-0.5/FP32/hbonet-0.5.xml
         weights: public/hbonet-0.5/FP32/hbonet-0.5.bin
-        adapter: classification
+        adapter:
+          type: classification
+          classification_output: output
 
       - framework: dlsdk
         tags:
           - FP16
         model:   public/hbonet-0.5/FP16/hbonet-0.5.xml
         weights: public/hbonet-0.5/FP16/hbonet-0.5.bin
-        adapter: classification
+        adapter:
+          type: classification
+          classification_output: output
 
     datasets:
       - name: imagenet_1000_classes
@@ -58,6 +63,7 @@ models:
             size: 256
             aspect_ratio_scale: greater
             interpolation: BILINEAR
+            use_pillow: True
 
           - type: crop
             size: 224

--- a/tools/accuracy_checker/configs/hbonet-1.0.yml
+++ b/tools/accuracy_checker/configs/hbonet-1.0.yml
@@ -21,6 +21,7 @@ models:
             size: 256
             aspect_ratio_scale: greater
             interpolation: BILINEAR
+            use_pillow: True
 
           - type: crop
             size: 224
@@ -40,14 +41,18 @@ models:
           - FP32
         model:   public/hbonet-1.0/FP32/hbonet-1.0.xml
         weights: public/hbonet-1.0/FP32/hbonet-1.0.bin
-        adapter: classification
+        adapter:
+          type: classification
+          classification_output: output
 
       - framework: dlsdk
         tags:
           - FP16
         model:   public/hbonet-1.0/FP16/hbonet-1.0.xml
         weights: public/hbonet-1.0/FP16/hbonet-1.0.bin
-        adapter: classification
+        adapter:
+          type: classification
+          classification_output: output
 
     datasets:
       - name: imagenet_1000_classes
@@ -58,6 +63,7 @@ models:
             size: 256
             aspect_ratio_scale: greater
             interpolation: BILINEAR
+            use_pillow: True
 
           - type: crop
             size: 224


### PR DESCRIPTION
in some cases, MO create some artefacts layers to output (split parts), it can be useful to be able manually set output layer name