### PR TITLE
Temporarily restore the old ReID models

### DIFF
--- a/models/intel/person-reidentification-retail-0031/model.yml
+++ b/models/intel/person-reidentification-retail-0031/model.yml
@@ -1,0 +1,44 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  Single embedding-based person reidentification model (fastest person ReID model)
+task_type: object_attributes
+files:
+  - name: FP32/person-reidentification-retail-0031.xml
+    size: 136115
+    sha256: 791473e146c3178c4d2d4efefd0f0686c114222e75a05d8080c018b5604fa8fc
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.xml
+  - name: FP32/person-reidentification-retail-0031.bin
+    size: 1120216
+    sha256: 8343531e60f2e36da8311bb768de42b9b03b51d848510da74cb5bf7cbb790823
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP32/person-reidentification-retail-0031.bin
+  - name: FP16/person-reidentification-retail-0031.xml
+    size: 136053
+    sha256: e50ae80a8049394af366d4f644ec137982dd9d0deff7069cf8a9d2f2dab0e720
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.xml
+  - name: FP16/person-reidentification-retail-0031.bin
+    size: 560124
+    sha256: 67e230352812b64ede186c62aaf7369a63fd6f5d8d9a8c98fb7138dac1dfd8bb
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP16/person-reidentification-retail-0031.bin
+  - name: FP16-INT8/person-reidentification-retail-0031.xml
+    size: 411716
+    sha256: 35cdc8ee9ce0a62bf5e967d58fa2407d20f9f527735a3183dfdc4ef754dd5f41
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP16-INT8/person-reidentification-retail-0031.xml
+  - name: FP16-INT8/person-reidentification-retail-0031.bin
+    size: 300146
+    sha256: e3f185b30f3fcc9c55aa06e5b59230535808c97772e665172565e0bf51b0ec31
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0031/FP16-INT8/person-reidentification-retail-0031.bin
+framework: dldt
+license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0249/model.yml
+++ b/models/intel/person-reidentification-retail-0249/model.yml
@@ -1,0 +1,45 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  Single embedding-based person reidentification model (the model is trade-off between
+  performance and accuracy)
+task_type: object_attributes
+files:
+  - name: FP32/person-reidentification-retail-0249.xml
+    size: 429107
+    sha256: 7d1d9b2c7f5410c5607d35e683682993272ac4f299425602daf35152efbe8a6d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0249/FP32/person-reidentification-retail-0249.xml
+  - name: FP32/person-reidentification-retail-0249.bin
+    size: 2365244
+    sha256: 286798a55939ffbec14fa657f09718c24447fb2c853cea1b4f09e9b6bc2e88f4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0249/FP32/person-reidentification-retail-0249.bin
+  - name: FP16/person-reidentification-retail-0249.xml
+    size: 428801
+    sha256: 171589413212c9d8ad78d511518501da139fa2c072676b62fdfe17a4c92f2218
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0249/FP16/person-reidentification-retail-0249.xml
+  - name: FP16/person-reidentification-retail-0249.bin
+    size: 1182656
+    sha256: 88b31d97eae89ab2b28e3537ffadeacaade14f53013ff828e53c40085510d489
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0249/FP16/person-reidentification-retail-0249.bin
+  - name: FP16-INT8/person-reidentification-retail-0249.xml
+    size: 1293794
+    sha256: a38f57d10479ecb16f5e6fd5959bd555c50e93b9aabde062a119094437676d7f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0249/FP16-INT8/person-reidentification-retail-0249.xml
+  - name: FP16-INT8/person-reidentification-retail-0249.bin
+    size: 652968
+    sha256: 4161a1514e48c9fc64ac8a9d679b38610aa9258a2f7fbb1c67e973e21d9fb1db
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0249/FP16-INT8/person-reidentification-retail-0249.bin
+framework: dldt
+license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0300/model.yml
+++ b/models/intel/person-reidentification-retail-0300/model.yml
@@ -1,0 +1,44 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  High accuracy single embedding-based person reidentification model
+task_type: object_attributes
+files:
+  - name: FP32/person-reidentification-retail-0300.xml
+    size: 447830
+    sha256: 8703a68a7c36015a0d52eddc93239afd92a20020a8e4310384626c3fbd9c866b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0300/FP32/person-reidentification-retail-0300.xml
+  - name: FP32/person-reidentification-retail-0300.bin
+    size: 21059332
+    sha256: 396b43fe9ae7c10bb5b8e5b8b5a0d024f56b51b64561fe81e55053b5df01b6a3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0300/FP32/person-reidentification-retail-0300.bin
+  - name: FP16/person-reidentification-retail-0300.xml
+    size: 447699
+    sha256: 19f0414d4a3c9e271731caa02d9a158b95d529a0c7c8f13c8c090a9af90fb5f0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0300/FP16/person-reidentification-retail-0300.xml
+  - name: FP16/person-reidentification-retail-0300.bin
+    size: 10529712
+    sha256: 98ab444ac49800a07c59d4ca121f641b3f3b737451e27b675b6468dbf0450425
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0300/FP16/person-reidentification-retail-0300.bin
+  - name: FP16-INT8/person-reidentification-retail-0300.xml
+    size: 1362674
+    sha256: 7f99cf664f251e2bafa7b64e5c814e00c809568adc57258c28dd27c82b946b10
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0300/FP16-INT8/person-reidentification-retail-0300.xml
+  - name: FP16-INT8/person-reidentification-retail-0300.bin
+    size: 7743940
+    sha256: 768bc7d22d4dfbad8d7e9ce793fa5ea6a2185003793ce780ae0d83734f8dd2d0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.3/open_model_zoo/models_bin/1/person-reidentification-retail-0300/FP16-INT8/person-reidentification-retail-0300.bin
+framework: dldt
+license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE


### PR DESCRIPTION
They were deleted in #1167, but they're still used in demo tests. We can't use the new models yet, because their files haven't been published yet.

Restore them until the new models' files are published.