### PR TITLE
AC: fix single class semantic segmentation adapter

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/segmentation.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/segmentation.py
@@ -95,7 +95,7 @@ class SegmentationOneClassAdapter(Adapter):
         raw_outputs = self._extract_predictions(raw, frame_meta)
         for identifier, output in zip(identifiers, raw_outputs[self.output_blob]):
             output = output > self.threshold
-            result.append(SegmentationPrediction(identifier, output))
+            result.append(SegmentationPrediction(identifier, output.astype(np.uint8)))
 
         return result
 


### PR DESCRIPTION
resize does not work with boolean values