### PR TITLE
AC: Add data mapping to CPU for PyTorch launcher when no CUDA available

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
@@ -98,7 +98,7 @@ class PyTorchLauncher(Launcher):
             module = model_cls(*module_args, **module_kwargs)
             if checkpoint:
                 checkpoint = self._torch.load(checkpoint, 
-                    map_location=None if self.cuda else self._torch.device('cpu'))
+                                              map_location=None if self.cuda else self._torch.device('cpu'))
                 state = checkpoint if not state_key else checkpoint[state_key]
                 module.load_state_dict(state, strict=False)
             if self.cuda:

--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
@@ -97,7 +97,8 @@ class PyTorchLauncher(Launcher):
             model_cls = importlib.import_module(model_path).__getattribute__(model_cls)
             module = model_cls(*module_args, **module_kwargs)
             if checkpoint:
-                checkpoint = self._torch.load(checkpoint)
+                checkpoint = self._torch.load(checkpoint, 
+                    map_location=None if self.cuda else self._torch.device('cpu'))
                 state = checkpoint if not state_key else checkpoint[state_key]
                 module.load_state_dict(state, strict=False)
             if self.cuda:

--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
@@ -97,7 +97,7 @@ class PyTorchLauncher(Launcher):
             model_cls = importlib.import_module(model_path).__getattribute__(model_cls)
             module = model_cls(*module_args, **module_kwargs)
             if checkpoint:
-                checkpoint = self._torch.load(checkpoint, 
+                checkpoint = self._torch.load(checkpoint,
                                               map_location=None if self.cuda else self._torch.device('cpu'))
                 state = checkpoint if not state_key else checkpoint[state_key]
                 module.load_state_dict(state, strict=False)


### PR DESCRIPTION
When trying to launch a PyTorch model with Accuracy Checker in a non-CUDA environment, there is an error can happen:

```
2020-06-08 17:08:17,929 INFO: Checking the model
2020-06-08 17:08:18,191 ERROR: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
Traceback (most recent call last):
...
"/opt/intel/openvino_2020.1.023/deployment_tools/open_model_zoo/tools/accuracy_checker/accuracy_checker/launcher/launcher.py", line 198, in create_launcher
    return Launcher.provide(config_framework, launcher_config, delayed_model_loading=delayed_model_loading)
  File "/opt/intel/openvino_2020.1.023/deployment_tools/open_model_zoo/tools/accuracy_checker/accuracy_checker/dependency.py", line 67, in provide
    return root_provider(*args, **kwargs)
  File "/opt/intel/openvino_2020.1.023/deployment_tools/open_model_zoo/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py", line 62, in __init__
    config_entry.get("python_path")
  File "/opt/intel/openvino_2020.1.023/deployment_tools/open_model_zoo/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py", line 108, in load_module
    return module
  File "/usr/lib/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/opt/intel/openvino_2020.1.023/deployment_tools/open_model_zoo/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py", line 144, in append_to_path
    yield
  File "/opt/intel/openvino_2020.1.023/deployment_tools/open_model_zoo/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py", line 100, in load_module
    checkpoint = self._torch.load(checkpoint)
  File "/usr/local/lib/python3.5/dist-packages/torch/serialization.py", line 593, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
  File "/usr/local/lib/python3.5/dist-packages/torch/serialization.py", line 773, in _legacy_load
    result = unpickler.load()
  File "/usr/local/lib/python3.5/dist-packages/torch/serialization.py", line 729, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "/usr/local/lib/python3.5/dist-packages/torch/serialization.py", line 178, in default_restore_location
    result = fn(storage, location)
  File "/usr/local/lib/python3.5/dist-packages/torch/serialization.py", line 154, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/usr/local/lib/python3.5/dist-packages/torch/serialization.py", line 138, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```