### PR TITLE
gaze_estimation_demo: zero-initialize FaceInferenceResults members

### DIFF
--- a/demos/gaze_estimation_demo/include/face_inference_results.hpp
+++ b/demos/gaze_estimation_demo/include/face_inference_results.hpp
@@ -10,7 +10,7 @@
 
 namespace gaze_estimation {
 struct FaceInferenceResults {
-    float faceDetectionConfidence;
+    float faceDetectionConfidence{};
     cv::Rect faceBoundingBox;
 
     std::vector<cv::Point2i> faceLandmarks;
@@ -20,8 +20,8 @@ struct FaceInferenceResults {
     cv::Rect rightEyeBoundingBox;
     cv::Point2f leftEyeMidpoint;
     cv::Point2f rightEyeMidpoint;
-    bool leftEyeState;
-    bool rightEyeState;
+    bool leftEyeState{};
+    bool rightEyeState{};
 
     cv::Point3f gazeVector;
 


### PR DESCRIPTION
This works around a static analysis warning.