### PR TITLE
Revert "object_detection_demo_yolov3_async: Work around a bug in the GPU plugin"

### DIFF
--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -319,10 +319,6 @@ def main():
     log.info("Loading network")
     net = ie.read_network(args.model, os.path.splitext(args.model)[0] + ".bin")
 
-    # Workaround for a bug in the GPU plugin: if we don't access this now,
-    # it won't be accessible after the network is loaded to the device.
-    getattr(net, 'layers')
-
     # ---------------------------------- 3. Load CPU extension for support specific layer ------------------------------
     if "CPU" in args.device:
         supported_layers = ie.query_network(net, "CPU")


### PR DESCRIPTION
The bug was fixed, so we don't need this anymore.

This reverts commit cad9bd1fbe781299173eddefc40fa659a32789e7.