### PR TITLE
Corrected filtering on basis of IoU

### DIFF
--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -245,6 +245,9 @@ def filter_objects(objects, iou_threshold, prob_threshold):
         if objects[i]['confidence'] == 0:
             continue
         for j in range(i + 1, len(objects)):
+            # We perform IOU only on objects of same class 
+            if(objects[i]['class_id'] != objects[j]['class_id']): continue
+
             if intersection_over_union(objects[i], objects[j]) > iou_threshold:
                 objects[j]['confidence'] = 0
 

--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -246,7 +246,8 @@ def filter_objects(objects, iou_threshold, prob_threshold):
             continue
         for j in range(i + 1, len(objects)):
             # We perform IOU only on objects of same class 
-            if(objects[i]['class_id'] != objects[j]['class_id']): continue
+            if objects[i]['class_id'] != objects[j]['class_id']: 
+                continue
 
             if intersection_over_union(objects[i], objects[j]) > iou_threshold:
                 objects[j]['confidence'] = 0


### PR DESCRIPTION
The IOU filtering process aims to remove duplicate predictions of the same **objects** and ends up choosing the box with highest probablity. To validate this Pull Request, kindly run prediction on this 
[sample image](https://unsplash.com/photos/Tzz4XrrdPUE) at the confidence threshold of 0.1. 

Using the earlier code, you will notice that though the person was detected, but on comparing its IOU with cycle, led to ignoring it in the final results. This is because it makes no sense to compare a cycle with a man or any different object.