### PR TITLE
AC: add adaptor and metrics for attribute classification models

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -237,3 +237,5 @@ AccuracyChecker supports following set of adapters:
     * `window_lengths` - Window lengths for each base output layer.
 * `face_detection_refinement` - converts output of face detection refinement model to `DetectionPrediction` representation. Adapter refines candidates generated in previous stage model.
     * `threshold` - Score threshold to determine as valid face candidate.
+* `attribute_classification` - converts output of attributes classifcation model to `ContainerPrediction` which contains multiple `ClassificationPrediction` for attributes with their scores.
+    * `output_layer_map` - dictionary where keys are output layer names of attribute classification model and values are the names of attributes.

--- a/tools/accuracy_checker/accuracy_checker/adapters/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/__init__.py
@@ -77,6 +77,8 @@ from .mono_depth import MonoDepthAdapter
 from .image_inpainting import ImageInpaintingAdapter
 from .style_transfer import StyleTransferAdapter
 
+from .attribute_classification import AttributeClassificationAdapter
+
 __all__ = [
     'Adapter',
     'AdapterField',
@@ -139,5 +141,7 @@ __all__ = [
     'MonoDepthAdapter',
 
     'ImageInpaintingAdapter',
-    'StyleTransferAdapter'
+    'StyleTransferAdapter',
+
+    'AttributeClassificationAdapter'
 ]

--- a/tools/accuracy_checker/accuracy_checker/adapters/attribute_classification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/attribute_classification.py
@@ -1,0 +1,67 @@
+"""
+Copyright (c) 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from ..adapters import Adapter
+from ..config import ConfigValidator, DictField
+from ..representation import ClassificationPrediction, ContainerPrediction
+
+
+class AttributeClassificationAdapter(Adapter):
+    """
+    Class for converting output of attributes classification model to
+    multiple ClassificationPrediction representations which are contained
+    in ContainerPrediction representation
+    """
+    __provider__ = 'attribute_classification'
+    prediction_types = (ClassificationPrediction, )
+
+    @classmethod
+    def parameters(cls):
+        parameters = super().parameters()
+        parameters.update({
+            'output_layer_map': DictField(
+                allow_empty=False,
+                description="Output layer in map (Key: output layer name, Value: attribute)"
+            )
+        })
+        return parameters
+
+    def configure(self):
+        super().configure()
+        self.output_layers = self.get_value_from_config('output_layer_map')
+
+    def validate_config(self):
+        super().validate_config(on_extra_argument=ConfigValidator.ERROR_ON_EXTRA_ARGUMENT)
+
+    def process(self, raw, identifiers=None, frame_meta=None):
+        """
+        Args:
+            identifiers: list of input data identifiers
+            raw: output of model
+            frame_meta: list of meta information about each frame
+        Returns:
+            list of ContainerPrediction objects
+        """
+        result = []
+        if isinstance(raw, dict):
+            raw = [raw]
+        for identifier, raw_output in zip(identifiers, raw):
+            container_dict = {}
+            for layer_name, attribute in self.output_layers.items():
+                container_dict[attribute] = ClassificationPrediction(
+                    identifier, raw_output[layer_name].reshape(-1))
+            result.append(ContainerPrediction(container_dict))
+        return result

--- a/tools/accuracy_checker/accuracy_checker/metrics/README.md
+++ b/tools/accuracy_checker/accuracy_checker/metrics/README.md
@@ -184,3 +184,12 @@ More detailed information about calculation segmentation metrics you can find [h
 * `youtube_faces_accuracy` - accuracy for face detection models calculated based on IOU values of ground truth bounding boxes and model-detected bounding boxes. Supported representations: `DetectionAnnotation`, `DetectionPrediction`.
   * `overlap` - minimum IOU threshold to consider as a true positive candidate face.
   * `relative_size` - size of detected face candidate\'s area in proportion to the size of ground truth\'s face size. This value is set to filter candidates that have high IOU but have a relatively smaller face size than ground truth face size.
+* `attribute_accuracy` - accuracy for attributes in attribute classification models. Supported representations: `ContainerAnnotation` with `ClassificationAnnotation` and `ContainerPrediction` with `ClassificationPrediction`.
+  * `attributes`: names of attributes.
+  * `calculate_average` - allows calculation of average accuracy (default value: `True`).
+* `attribute_recall` - recall for attributes in attribute classification models. Supported representations: `ContainerAnnotation` with `ClassificationAnnotation` and `ContainerPrediction` with `ClassificationPrediction`.
+  * `attributes`: names of attributes.
+  * `calculate_average` - allows calculation of average recall (default value: `True`).
+* `attribute_precision` - precision for attributes in attribute classification models. Supported representations: `ContainerAnnotation` with `ClassificationAnnotation` and `ContainerPrediction` with `ClassificationPrediction`.
+  * `attributes`: names of attributes.
+  * `calculate_average` - allows calculation of average precision (default value: `True`).

--- a/tools/accuracy_checker/accuracy_checker/metrics/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/__init__.py
@@ -71,6 +71,12 @@ from .question_answering import ExactMatchScore, ScoreF1
 from .mpjpe_multiperson import MpjpeMultiperson
 from .language_modeling import ScorePerplexity
 
+from .attribute_classification import (
+    AttributeClassificationRecall,
+    AttributeClassificationPrecision,
+    AttributeClassificationAccuracy
+)
+
 __all__ = [
     'Metric',
     'MetricsExecutor',
@@ -146,4 +152,8 @@ __all__ = [
     'MpjpeMultiperson',
 
     'ScorePerplexity',
+
+    'AttributeClassificationRecall',
+    'AttributeClassificationPrecision',
+    'AttributeClassificationAccuracy'
 ]

--- a/tools/accuracy_checker/accuracy_checker/metrics/attribute_classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/attribute_classification.py
@@ -1,0 +1,154 @@
+"""
+Copyright (c) 2019 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+from sklearn.metrics import accuracy_score, precision_score, recall_score
+
+from accuracy_checker.config import BoolField, ListField
+from accuracy_checker.metrics.metric import FullDatasetEvaluationMetric
+from accuracy_checker.representation import ClassificationAnnotation, ClassificationPrediction
+
+
+class AttributeClassificationMetric(FullDatasetEvaluationMetric):
+    """
+    Base metric class for evaluating metrics of attribute classification models.
+    """
+
+    annotation_types = (ClassificationAnnotation, )
+    prediction_types = (ClassificationPrediction, )
+
+    is_annotation_prediction_dict_computed = False
+    annotation_prediction_dict = {}
+
+    @classmethod
+    def parameters(cls):
+        parameters = super().parameters()
+        parameters.update({
+            'attributes': ListField(
+                optional=False,
+                description="List of attribute names."
+            ),
+            'calculate_average': BoolField(
+                optional=True, default=True, description="Allows calculation of average metric."
+            )
+        })
+        return parameters
+
+    def configure(self):
+        self.attributes = self.get_value_from_config('attributes')
+        self.calculate_average = self.get_value_from_config('calculate_average')
+        self.meta = self.__create_meta()
+        super().configure()
+
+    def evaluate(self, annotations, predictions):
+        pass
+
+    def submit_all(self, annotations, predictions):
+        return self.evaluate(annotations, predictions)
+
+    def compute_annotation_prediction_dict(self, annotations, predictions):
+        if self.is_annotation_prediction_dict_computed:
+            return
+        self.is_annotation_prediction_dict_computed = True
+        if len(annotations) != len(predictions):
+            raise ValueError(
+                "different lengths of annotations and predictions")
+        ret = {}
+        for attr in self.attributes:
+            ret[attr] = {
+                'annotation': np.zeros_like(annotations),
+                'prediction': np.zeros_like(predictions)
+            }
+        for i, (annotation, prediction) in enumerate(zip(annotations, predictions)):
+            for attr in self.attributes:
+                ret[attr]['prediction'][i] = prediction[attr].label
+                if isinstance(annotation[attr], int):
+                    ret[attr]['annotation'][i] = annotation[attr].label
+                elif hasattr(annotation[attr].label, '__contains__'):
+                    if prediction[attr].label in annotation[attr].label:
+                        ret[attr]['annotation'][i] = prediction[attr].label
+                    else:
+                        ret[attr]['annotation'][i] = annotation[attr].label[0]
+        self.annotation_prediction_dict = ret
+        self.is_annotation_prediction_dict_computed = True
+
+
+    def __create_meta(self):
+        meta = {
+            'calculate_mean': self.calculate_average
+        }
+        meta['names'] = self.attributes
+        return meta
+
+class AttributeClassificationAccuracy(AttributeClassificationMetric):
+    """
+    Class for evaluating accuracy for classification attribute models.
+    """
+
+    __provider__ = 'attribute_accuracy'
+
+    def evaluate(self, annotations, predictions):
+        self.compute_annotation_prediction_dict(annotations, predictions)
+        per_attr_accuracy = []
+        for attr in self.attributes:
+            per_attr_accuracy.append(
+                accuracy_score(
+                    self.annotation_prediction_dict[attr]['annotation'].astype(
+                        np.int32),
+                    self.annotation_prediction_dict[attr]['prediction'].astype(np.int32)))
+        return per_attr_accuracy
+
+
+class AttributeClassificationRecall(AttributeClassificationMetric):
+    """
+    Class for evaluating recall for classification attribute models.
+    """
+
+    __provider__ = 'attribute_recall'
+
+    def evaluate(self, annotations, predictions):
+        self.compute_annotation_prediction_dict(annotations, predictions)
+        per_attr_recall = []
+        for attr in self.attributes:
+            per_attr_recall.append(
+                recall_score(
+                    self.annotation_prediction_dict[attr]['annotation'].astype(
+                        np.int32),
+                    self.annotation_prediction_dict[attr]['prediction'].astype(
+                        np.int32),
+                    average='macro'))
+        return per_attr_recall
+
+
+class AttributeClassificationPrecision(AttributeClassificationMetric):
+    """
+    Class for evaluating precision for classification attribute models.
+    """
+
+    __provider__ = 'attribute_precision'
+
+    def evaluate(self, annotations, predictions):
+        self.compute_annotation_prediction_dict(annotations, predictions)
+        per_attr_precision = []
+        for attr in self.attributes:
+            per_attr_precision.append(
+                precision_score(
+                    self.annotation_prediction_dict[attr]['annotation'].astype(
+                        np.int32),
+                    self.annotation_prediction_dict[attr]['prediction'].astype(
+                        np.int32),
+                    average='macro'))
+        return per_attr_precision

--- a/tools/accuracy_checker/accuracy_checker/metrics/attribute_classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/attribute_classification.py
@@ -19,7 +19,7 @@ from sklearn.metrics import accuracy_score, precision_score, recall_score
 
 from accuracy_checker.config import BoolField, ListField
 from accuracy_checker.metrics.metric import FullDatasetEvaluationMetric
-from accuracy_checker.representation import ClassificationAnnotation, ClassificationPrediction
+from accuracy_checker.representation import ContainerAnnotation, ContainerPrediction
 
 
 class AttributeClassificationMetric(FullDatasetEvaluationMetric):
@@ -27,8 +27,8 @@ class AttributeClassificationMetric(FullDatasetEvaluationMetric):
     Base metric class for evaluating metrics of attribute classification models.
     """
 
-    annotation_types = (ClassificationAnnotation, )
-    prediction_types = (ClassificationPrediction, )
+    annotation_types = (ContainerAnnotation, )
+    prediction_types = (ContainerPrediction, )
 
     is_annotation_prediction_dict_computed = False
     annotation_prediction_dict = {}


### PR DESCRIPTION
* Add attribute_classification adapter convert outputs of attribute classification models to `ContainerPrediction` which contains multiple `ClassificationPrediction`s with their scores.
* Add precision, recall, accuracy for attribute classification models. Each metric takes `ContainerAnnotation` with `ClassificationAnnotation`and `ContainerPrediction` with `ClassificationPrediction` and outputs its metric scores per attribute and their mean optionally.
* Update REAMD.md