### PR TITLE
Readd the bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001

### DIFF
--- a/models/intel/bert-large-uncased-whole-word-masking-squad-fp32-0001/model.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-fp32-0001/model.yml
@@ -1,0 +1,37 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  BERT-large pretrained on lower-cased English text using Whole-Word-Masking and fine-tuned
+  on the SQuAD v1.1 training set (93.21% F1 -  87.2% EM on the v1.1 dev set).
+task_type: question_answering
+files:
+  - name: FP32/bert-large-uncased-whole-word-masking-squad-fp32-0001.xml
+    size: 957454
+    sha256: d47b4dbf7440ba311acd401039ce3defeda3e7885fb6f62df07e74346d47750f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001/FP32/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001.xml
+  - name: FP32/bert-large-uncased-whole-word-masking-squad-fp32-0001.bin
+    size: 1335853368
+    sha256: 1a4b0dfb42daf7f45716100dacaa1c4de76c7b1b8c49c0dc91668b1dcba22534
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001/FP32/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001.bin
+  - name: FP16/bert-large-uncased-whole-word-masking-squad-fp32-0001.xml
+    size: 956678
+    sha256: 1f1a432fd782eb2690b6cc69defc9cb175b4f4a02d3218b0e6c6b922b1db3f68
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001/FP16/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001.xml
+  - name: FP16/bert-large-uncased-whole-word-masking-squad-fp32-0001.bin
+    size: 667926792
+    sha256: 338bb2d6780262bbd2efb34d858ac2972e46aa0261afdda5e2c4c3bdff4c0231
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001/FP16/bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001.bin
+framework: dldt
+license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE


### PR DESCRIPTION
Since we added resumption support to the Model Downloader, it should now be possible to download this.

This reverts commit 2cd6d66568f1d302c1543a652d383d58dc908409.

FYI: We don't really need to merge this, since we're likely to publish a new version of the models anyway. This PR is just to make sure that the resumption support works and that the model runs.