### PR TITLE
Publish the third set of candidate models for OpenVINO 2020.4

### DIFF
--- a/demos/python_demos/segmentation_demo/segmentation_demo.py
+++ b/demos/python_demos/segmentation_demo/segmentation_demo.py
@@ -103,10 +103,6 @@ def main():
     #     this requires additional operation and more memory.
     net.input_info[input_blob].precision = "U8"
 
-    # Work around a bug in the IE GPU plugin. Without this,
-    # load_network fails for semantic-segmentation-adas-0001.
-    net.outputs[out_blob].precision = "FP32"
-
     # Read and pre-process input images
     n, c, h, w = net.input_info[input_blob].input_data.shape
     images = np.ndarray(shape=(n, c, h, w))

--- a/models/intel/action-recognition-0001/action-recognition-0001-decoder/model.yml
+++ b/models/intel/action-recognition-0001/action-recognition-0001-decoder/model.yml
@@ -19,27 +19,27 @@ task_type: action_recognition
 files:
   - name: FP32/action-recognition-0001-decoder.xml
     size: 120115
-    sha256: 5ba0a8641aa873f14387874474fb46cb9a3f522270cde80058b70d09fd803429
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
+    sha256: 5c9b6f4a964eee45fd9c85013ec09a87663ee804366b78cd0eaa1c3ebbd0b2bd
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
   - name: FP32/action-recognition-0001-decoder.bin
     size: 30238792
     sha256: b80f65cf6661e4b8aa4df77b48ec83b06f3064c54e1b0d1a1768ca80ddfd4321
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
   - name: FP16/action-recognition-0001-decoder.xml
     size: 120079
-    sha256: 339d415fcfd1190597390e6b3e10c39e0bc03ed81702e32de49de1461f439f25
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
+    sha256: 12caf2259a2010222089ffb47b64ff754fa7fd8dabf9eda2086f1c55e1e786da
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
   - name: FP16/action-recognition-0001-decoder.bin
     size: 15119528
     sha256: 149fdd1c15deaa55cbd2410c9c0d33675e196a0bf8551d4fc8e9cdf89dbca85a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
   - name: FP16-INT8/action-recognition-0001-decoder.xml
-    size: 254153
-    sha256: 22f0f83634adca87b410230eafb0c87f26543739ff5aba0d9b95785f535daade
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-decoder/FP16-INT8/action-recognition-0001-decoder.xml
+    size: 254116
+    sha256: 6afa75162e1dd5ff082d2690246a504843cb27f3e4e9cb5acab3f458a5679454
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16-INT8/action-recognition-0001-decoder.xml
   - name: FP16-INT8/action-recognition-0001-decoder.bin
     size: 7601348
     sha256: 629ba410a251ebd63b50192dab859057794090545fa836764bbcd33d5d4db3f1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-decoder/FP16-INT8/action-recognition-0001-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16-INT8/action-recognition-0001-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/action-recognition-0001/action-recognition-0001-encoder/model.yml
+++ b/models/intel/action-recognition-0001/action-recognition-0001-encoder/model.yml
@@ -20,26 +20,26 @@ files:
   - name: FP32/action-recognition-0001-encoder.xml
     size: 98493
     sha256: 77da2382403dd4064dfbb02e5d4a1af6bf21d83f75cc2693f7ec48e447765ade
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
   - name: FP32/action-recognition-0001-encoder.bin
     size: 85104664
     sha256: c33e24b3f74918104eeafc106ee7f0b56804f03b87098c14ad66af6386cdb648
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
   - name: FP16/action-recognition-0001-encoder.xml
     size: 98453
     sha256: fd458be625130ec7dbf1ad26dc63b6fa47bc0c6c8d65f920365f1a51ea0bd772
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
   - name: FP16/action-recognition-0001-encoder.bin
     size: 42552332
     sha256: 57d374b873dc87c72e5baab53245d59f1b866f6e2c3e670c923537f45018782c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
   - name: FP16-INT8/action-recognition-0001-encoder.xml
-    size: 285839
-    sha256: 4343576e527c7084204b2f3e3638ae2db00fc292220f955ef09185d9433e32b0
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-encoder/FP16-INT8/action-recognition-0001-encoder.xml
+    size: 285858
+    sha256: 6a1ec253c04aa8d27a34e768ae3fcbf7ec89805d13ad48b232fd8c20a47df50e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16-INT8/action-recognition-0001-encoder.xml
   - name: FP16-INT8/action-recognition-0001-encoder.bin
     size: 21318880
     sha256: b1c437c1fe247e0c254960299b795bb900cc69fa52cb6ec5cc60072840ceec23
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/action-recognition-0001/action-recognition-0001-encoder/FP16-INT8/action-recognition-0001-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16-INT8/action-recognition-0001-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/age-gender-recognition-retail-0013/model.yml
+++ b/models/intel/age-gender-recognition-retail-0013/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/age-gender-recognition-retail-0013.xml
     size: 29965
-    sha256: cb07e65a94954e5818c1099c62b2f401877131c5a01e5da25f5207e18c8db2a3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
+    sha256: 0fa0d63a66bb4e5ea3388b2acc0b9121c9249850f7f2e0eb162fa3d52a4d52ae
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
   - name: FP32/age-gender-recognition-retail-0013.bin
     size: 8552076
     sha256: c7177ca11ad924b0bb34dacb92676b72acac1cb36a71bc336a951116556b6910
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
   - name: FP16/age-gender-recognition-retail-0013.xml
     size: 29955
-    sha256: 6fbec827d51102c28daafed15a5660489b50e218f946670ba7f6c1891410fd91
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
+    sha256: f0a15e3a76e8727fa6b9d18520e1fdeadb697a2346bf9ebc53c3997c0f7b732b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
   - name: FP16/age-gender-recognition-retail-0013.bin
     size: 4276038
     sha256: 401101e0a01b3d68add39deae833bcf9f54238d37dd13e3fb1534aa8fbe4719d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
   - name: FP16-INT8/age-gender-recognition-retail-0013.xml
     size: 72463
-    sha256: 4b2b4a5bd06df4e828e378da21b18dccc32e9f4dea839525075470d3446a7e72
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/age-gender-recognition-retail-0013/FP16-INT8/age-gender-recognition-retail-0013.xml
+    sha256: d0e0dd1e16c42a4539658bf532a7bab90933b7f69c5b3228fb4f253adad7e703
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/age-gender-recognition-retail-0013/FP16-INT8/age-gender-recognition-retail-0013.xml
   - name: FP16-INT8/age-gender-recognition-retail-0013.bin
     size: 2278546
     sha256: c36b800fbacbb70343d38f2d25aa28140325bc463a0b2bbf7167d62fcbae1b85
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/age-gender-recognition-retail-0013/FP16-INT8/age-gender-recognition-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/age-gender-recognition-retail-0013/FP16-INT8/age-gender-recognition-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/asl-recognition-0004/model.yml
+++ b/models/intel/asl-recognition-0004/model.yml
@@ -18,27 +18,19 @@ task_type: action_recognition
 files:
   - name: FP32/asl-recognition-0004.xml
     size: 275873
-    sha256: 7951b8fcaa532048ea438e043ff082f633b1ee105d030a95aa67f98ac000d2a9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/asl-recognition-0004/FP32/asl-recognition-0004.xml
+    sha256: 4aa02a9fc20575b37e6e4f4922195769eecb4f362b3bcb4de16a7ee8f3cef328
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/asl-recognition-0004/FP32/asl-recognition-0004.xml
   - name: FP32/asl-recognition-0004.bin
     size: 16530600
     sha256: 0fb8a3f15377f9961940e3391d781bd68051441e8a634699dc83739bafadf4a3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/asl-recognition-0004/FP32/asl-recognition-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/asl-recognition-0004/FP32/asl-recognition-0004.bin
   - name: FP16/asl-recognition-0004.xml
     size: 275722
-    sha256: c91e4d56fcef0c5010d74102baa18955a0a0e8451c5bcd4308c86299ff76246d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/asl-recognition-0004/FP16/asl-recognition-0004.xml
+    sha256: 56eeda1df3dc45cf2d82b149909370194a430fb129b06121938b6668e12ac594
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/asl-recognition-0004/FP16/asl-recognition-0004.xml
   - name: FP16/asl-recognition-0004.bin
     size: 8265312
     sha256: 698ee599c9869c9b759eb52b2229fd29a5845f763a420668d914e973ce762fee
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/asl-recognition-0004/FP16/asl-recognition-0004.bin
-  - name: FP16-INT8/asl-recognition-0004.xml
-    size: 700378
-    sha256: 1ca0b1ab89c92435d150bc634168ed0968f9ec12e655819a95a3018e9b40aea4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/asl-recognition-0004/FP16-INT8/asl-recognition-0004.xml
-  - name: FP16-INT8/asl-recognition-0004.bin
-    size: 4238967
-    sha256: 86085b3a6797e442f758f179cdbe6ca5e39b25791a721572145957721065c9b6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/asl-recognition-0004/FP16-INT8/asl-recognition-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/asl-recognition-0004/FP16/asl-recognition-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-fp32-0001/model.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-fp32-0001/model.yml
@@ -1,0 +1,37 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+description: >-
+  BERT-large pretrained on lower-cased English text using Whole-Word-Masking and fine-tuned
+  on the SQuAD v1.1 training set (93.21% F1 -  87.2% EM on the v1.1 dev set).
+task_type: question_answering
+files:
+  - name: FP32/bert-large-uncased-whole-word-masking-squad-fp32-0001.xml
+    size: 957439
+    sha256: 56a42d02fee9bd7c0186eca5de4b87f0d7910f978819b12c1737bb007a0ab48b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-fp32-0001/FP32/bert-large-uncased-whole-word-masking-squad-fp32-0001.xml
+  - name: FP32/bert-large-uncased-whole-word-masking-squad-fp32-0001.bin
+    size: 1335853368
+    sha256: 1a4b0dfb42daf7f45716100dacaa1c4de76c7b1b8c49c0dc91668b1dcba22534
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-fp32-0001/FP32/bert-large-uncased-whole-word-masking-squad-fp32-0001.bin
+  - name: FP16/bert-large-uncased-whole-word-masking-squad-fp32-0001.xml
+    size: 956663
+    sha256: 5239773cfc34e6bdeb128579996a84794bf1ba2cea382c7f54c8662301a3f9e6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-fp32-0001/FP16/bert-large-uncased-whole-word-masking-squad-fp32-0001.xml
+  - name: FP16/bert-large-uncased-whole-word-masking-squad-fp32-0001.bin
+    size: 667926792
+    sha256: 338bb2d6780262bbd2efb34d858ac2972e46aa0261afdda5e2c4c3bdff4c0231
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-fp32-0001/FP16/bert-large-uncased-whole-word-masking-squad-fp32-0001.bin
+framework: dldt
+license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/model.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/model.yml
@@ -19,20 +19,20 @@ description: >-
 task_type: question_answering
 files:
   - name: FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
-    size: 1721691
-    sha256: a63e40018700cd6368bca74c596d260fc1225920e41cee0520d5d71c128b77fe
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001/FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001.xml
+    size: 1721676
+    sha256: cea1d22e94eceb6b0e1d66d443fb962b09a6bec0db329890091bff0dfa6c2f1e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
   - name: FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
     size: 429880400
     sha256: 46ac59b544cb493a82c53403b99221d9846ed02576bbe396626d08f71e6cd9bb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001/FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
   - name: FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
-    size: 1720819
-    sha256: daf0272dc864e7c60654cfb3e49091f24b356194a1c5aad84f1dedfed372dccd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001/FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001.xml
+    size: 1720804
+    sha256: 36ee8876b6ba91f01957d35eb5edf3e2e28bbfe10af94d8c5e09fcb399f7bc10
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
   - name: FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
     size: 365936426
     sha256: 3aaf68028a346ddab9ceab754a21d37dd140f2bb667e3810a7e673bca773ecf7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001/FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-0001/model.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-0001/model.yml
@@ -21,19 +21,19 @@ task_type: question_answering
 files:
   - name: FP32/bert-small-uncased-whole-word-masking-squad-0001.xml
     size: 542073
-    sha256: 39dd4ea66f2a6a24aae8cb1c6ba516e335cd0ceff2d78982a86c4cc705f8b287
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-small-uncased-whole-word-masking-squad-0001/FP32/bert-small-uncased-whole-word-masking-squad-0001.xml
+    sha256: 7f422a8b9f3042fb1dd3e792d7fa5329da000533535a77fe5eae7e0ef8e838a9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP32/bert-small-uncased-whole-word-masking-squad-0001.xml
   - name: FP32/bert-small-uncased-whole-word-masking-squad-0001.bin
     size: 231774488
     sha256: 9a594879b9e997ca383a086271aa7df52be8e03fb47e78b300f2226d848847ac
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-small-uncased-whole-word-masking-squad-0001/FP32/bert-small-uncased-whole-word-masking-squad-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP32/bert-small-uncased-whole-word-masking-squad-0001.bin
   - name: FP16/bert-small-uncased-whole-word-masking-squad-0001.xml
     size: 541511
-    sha256: 28a4e3e42e9970447a868bdc3cd91adf464a0bddb6bf9e73a59f654d82012c56
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-small-uncased-whole-word-masking-squad-0001/FP16/bert-small-uncased-whole-word-masking-squad-0001.xml
+    sha256: d32b1e47d5fc9dc337a8fc5c4f5657067fb3ddc8f2fed82a6db38a47da54bf79
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP16/bert-small-uncased-whole-word-masking-squad-0001.xml
   - name: FP16/bert-small-uncased-whole-word-masking-squad-0001.bin
     size: 115887352
     sha256: 4f8494a799c37462648fa1fe0e616ce9f90a3d0848c455b9c3d2a638ef72b714
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/bert-small-uncased-whole-word-masking-squad-0001/FP16/bert-small-uncased-whole-word-masking-squad-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP16/bert-small-uncased-whole-word-masking-squad-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/model.yml
@@ -18,27 +18,27 @@ task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-decoder.xml
     size: 124015
-    sha256: 6c31a26dfc7b3fd4e7cabf0b82531e0fcc02b4f89bec66ddfda713346f830b14
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
+    sha256: 347dac80ec8c5248c22502f075a92afc48d42513dfb36f16f18a6118af76397e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
   - name: FP32/driver-action-recognition-adas-0002-decoder.bin
     size: 29436444
     sha256: 2ebfdba5782f676e95559aa5d84b2fb5403f0c4bf8b1e271ad0b18cef9b80c14
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
   - name: FP16/driver-action-recognition-adas-0002-decoder.xml
     size: 123979
-    sha256: 08305eb3917ff26c6c074cbff27cc7ccb10be73fc50e368881688d139c3728ee
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
+    sha256: 5d4f18474a0e3557982e665c69d072858a17b0c1bb780ef6ea335a9ac5eb9e96
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
   - name: FP16/driver-action-recognition-adas-0002-decoder.bin
     size: 14718346
     sha256: d912e7b7a9a2b9018671204d970bdacd3df87586d5ffe412737d18f668fc53fd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
   - name: FP16-INT8/driver-action-recognition-adas-0002-decoder.xml
-    size: 304589
-    sha256: 3b99af7b8945022767bd047889ff104bb665085ad241d501fa9bf58695a35b17
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16-INT8/driver-action-recognition-adas-0002-decoder.xml
+    size: 304566
+    sha256: 07c332e3f9c016beac7b5d094cf8e9859bf67e11b803a4292f9ec2159fbdc8d4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16-INT8/driver-action-recognition-adas-0002-decoder.xml
   - name: FP16-INT8/driver-action-recognition-adas-0002-decoder.bin
     size: 7398868
     sha256: 981f4f8becf0352122d95a5163eb591282386cc68aa090c90412409fa76feb80
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16-INT8/driver-action-recognition-adas-0002-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16-INT8/driver-action-recognition-adas-0002-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/model.yml
@@ -18,27 +18,27 @@ task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-encoder.xml
     size: 128425
-    sha256: 26c28f64dff3f2d9a7efc759793a8dd350c323b818a558dac8936668bd4f5eb7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
+    sha256: 3281637ac1a75e14287bcfcad27893477bf6847970be6b6218c825e18d021c42
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
   - name: FP32/driver-action-recognition-adas-0002-encoder.bin
     size: 11450776
     sha256: 12bf9bfebc74719d42bc2190bd00064ecf41b820df891040fcaa57f5eb4cffcb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
   - name: FP16/driver-action-recognition-adas-0002-encoder.xml
     size: 128365
-    sha256: 82ae845377875e4c978a2cd1775a27aa871f12b70ae89004fa2996140fc30544
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
+    sha256: 821f7a013a1a1b658f1c27b68b7d12f990df1e1b11e659ee2d652e037291b2a6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
   - name: FP16/driver-action-recognition-adas-0002-encoder.bin
     size: 5725388
     sha256: 165b34437d1c73bf5adf356ddc18fb6bb11b4d99d8db0921dd25894d886535ef
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
   - name: FP16-INT8/driver-action-recognition-adas-0002-encoder.xml
     size: 405542
-    sha256: 6c1c73c358e91a97de27d5ccbc9be5a3675941fb90f59bc9877b5809b7d13c55
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16-INT8/driver-action-recognition-adas-0002-encoder.xml
+    sha256: a8e112d48c77b2f645c3d2d8affa586bedcc8992c4c09e505ce395a5967f056c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16-INT8/driver-action-recognition-adas-0002-encoder.xml
   - name: FP16-INT8/driver-action-recognition-adas-0002-encoder.bin
     size: 2970016
     sha256: 48acb50bd3a69495f095be4888e2c24dedbbf0ee148c79a12b8636b47f612a5c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16-INT8/driver-action-recognition-adas-0002-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16-INT8/driver-action-recognition-adas-0002-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/emotions-recognition-retail-0003/model.yml
+++ b/models/intel/emotions-recognition-retail-0003/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: object_attributes
 files:
   - name: FP32/emotions-recognition-retail-0003.xml
-    size: 37804
-    sha256: 2f16138680fa56adbc741d3c4e6025bab6ecaab928567ec0c17391c2d790d4b5
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
+    size: 37806
+    sha256: 3761c73a85451c00a2fb3fa51c0c11c0fec90bd80f0246c2f854a026fd7ae8fe
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
   - name: FP32/emotions-recognition-retail-0003.bin
     size: 9930028
     sha256: bcb9b1a910fa3cd18a638bb1dbb0597c4ef7a080d1b83008c8e8c2c3c42b99dd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
   - name: FP16/emotions-recognition-retail-0003.xml
-    size: 37786
-    sha256: 8beb08d687a843dbde301abc984e04d5be2ad43d0aeb468f67f2eefdb59d875d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
+    size: 37785
+    sha256: c4f1dd801ac6b5f2190d529fa3ba9342b1c3ad9532b4346ec3491d1d7b8d9d52
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
   - name: FP16/emotions-recognition-retail-0003.bin
     size: 4965014
     sha256: e62fb4b819b3b3ad8aafcd308d4353db2f164a1a31d78de6cf5970837aeb6f7b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
   - name: FP16-INT8/emotions-recognition-retail-0003.xml
     size: 116349
-    sha256: c76199e9fb28e31c3dee2e5033a78924c77dd80578c5f98e5be03eed749dbaa0
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/emotions-recognition-retail-0003/FP16-INT8/emotions-recognition-retail-0003.xml
+    sha256: 78955218a727adc72108204237b1783858fce8167c685c0ea72b424d95c44bd4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/emotions-recognition-retail-0003/FP16-INT8/emotions-recognition-retail-0003.xml
   - name: FP16-INT8/emotions-recognition-retail-0003.bin
     size: 2494128
     sha256: 210c2a00ae1e977a17c4c2f59c54b3f5f99186b84c9312641ec230e699beb681
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/emotions-recognition-retail-0003/FP16-INT8/emotions-recognition-retail-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/emotions-recognition-retail-0003/FP16-INT8/emotions-recognition-retail-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0100/model.yml
+++ b/models/intel/face-detection-0100/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0100.xml
     size: 166304
-    sha256: 96113a603e1c0dc9f24eb8acb7a6492ca42f67ddd2e505e929adb36e8b000fa9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0100/FP32/face-detection-0100.xml
+    sha256: 15667914f0990bc7c612322cd0b4367863c8be859de5893319423ea021797a6e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0100/FP32/face-detection-0100.xml
   - name: FP32/face-detection-0100.bin
     size: 7269228
     sha256: 7d5fd2fa42701043a6ddfcc91cc7731643a0d8a2db75a15494725eca72a6d6be
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0100/FP32/face-detection-0100.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0100/FP32/face-detection-0100.bin
   - name: FP16/face-detection-0100.xml
     size: 166241
-    sha256: 0ece73c884f7e225edc93ee515bc9b2a5bb7649b810e1fcfd209352641862228
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0100/FP16/face-detection-0100.xml
+    sha256: 1cb41d6e35afe6a952c9db09545a765b50027157a3e05bce105bd633adf3bf95
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0100/FP16/face-detection-0100.xml
   - name: FP16/face-detection-0100.bin
     size: 3634686
     sha256: 578dd437bde96e5fb383c706ebf066a440ef5755aff77d77b3dd9a94475b8b2e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0100/FP16/face-detection-0100.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0100/FP16/face-detection-0100.bin
   - name: FP16-INT8/face-detection-0100.xml
     size: 474196
-    sha256: 55610d95f9395c803608eb8aa09d9d31b1639c9f610b6b2abe3a106acfa5777e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0100/FP16-INT8/face-detection-0100.xml
+    sha256: 29dc46b903c97b5871323aacef646d77e7d6a0d3e15dfd90f713975080a8d161
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0100/FP16-INT8/face-detection-0100.xml
   - name: FP16-INT8/face-detection-0100.bin
     size: 1921685
     sha256: 98f84852cc4552ec332ec69d55d00a9ce6ef0f55a7e0579ad3f0085fcec58bdd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0100/FP16-INT8/face-detection-0100.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0100/FP16-INT8/face-detection-0100.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0102/model.yml
+++ b/models/intel/face-detection-0102/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0102.xml
     size: 166465
-    sha256: 9035352b0546a00338534a2f001d813f5d6df97df4f2c6608ca73b2040d80769
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0102/FP32/face-detection-0102.xml
+    sha256: 9559089ece6c5874b2cf894bd8651e578c76fecf5ad0f38fa19cfa702cd4ba7e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0102/FP32/face-detection-0102.xml
   - name: FP32/face-detection-0102.bin
     size: 7269228
     sha256: e0bca26bd58e01dcfa895677b977f525cc108f10d7ca6024439490e4032ed34d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0102/FP32/face-detection-0102.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0102/FP32/face-detection-0102.bin
   - name: FP16/face-detection-0102.xml
     size: 166402
-    sha256: f9d3b2a88ac5984d7d4e671321b7cd9c41023ce1679b0e294c4e5b6b3581c936
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0102/FP16/face-detection-0102.xml
+    sha256: 1e231a20d5af6457ce9abe61cd655ba490196f4caf143b0137afefe3f521785f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0102/FP16/face-detection-0102.xml
   - name: FP16/face-detection-0102.bin
     size: 3634686
     sha256: 2d103d470f063a0bdf3592a0d03809aeaa6d05c1379576149d265d6a44e967c1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0102/FP16/face-detection-0102.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0102/FP16/face-detection-0102.bin
   - name: FP16-INT8/face-detection-0102.xml
     size: 474417
-    sha256: ab33262a3db3d610a2a4cb1cc24a6d03b6e930d10f6a87e4a25b335d15e7275f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0102/FP16-INT8/face-detection-0102.xml
+    sha256: 43a3f763113512d73c436986a1ff95446bebd0563aee1ce775da4c870ab1dc64
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0102/FP16-INT8/face-detection-0102.xml
   - name: FP16-INT8/face-detection-0102.bin
     size: 1921685
     sha256: 6cb84c342eca0a88e78b23bcda9f26999040c9b52a213758e7e7412c7682a876
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0102/FP16-INT8/face-detection-0102.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0102/FP16-INT8/face-detection-0102.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0104/model.yml
+++ b/models/intel/face-detection-0104/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0104.xml
     size: 166568
-    sha256: 38e01559882ccd13434769ef8eb703ee4150e74e77f7cb85808ba139274c8428
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0104/FP32/face-detection-0104.xml
+    sha256: a0da0925a317057d16b7598e7a16987dcc825f3fd8ce3e3d6486732da2b4fea3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0104/FP32/face-detection-0104.xml
   - name: FP32/face-detection-0104.bin
     size: 7269228
     sha256: b29df2eece8d1fd7c888590a75e707a3a747242755747f0e956dfe22b16d8355
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0104/FP32/face-detection-0104.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0104/FP32/face-detection-0104.bin
   - name: FP16/face-detection-0104.xml
     size: 166505
-    sha256: 0c63aa322d6bf11ab9391af3d37740d069d0e20c84524ca6b34c717f41a55737
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0104/FP16/face-detection-0104.xml
+    sha256: b28d5a4c584a501f651d230d767a2d4161dc7bc5af2be92902e8cd271bbe2302
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0104/FP16/face-detection-0104.xml
   - name: FP16/face-detection-0104.bin
     size: 3634686
     sha256: 45018aefd27ba3150fe17b0f5b0fb255abdd9bae088f6f65551f40aad25e0908
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0104/FP16/face-detection-0104.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0104/FP16/face-detection-0104.bin
   - name: FP16-INT8/face-detection-0104.xml
     size: 474544
-    sha256: 9f43abbb153bd2c14071d73032a355e025ad8e02d457213b38d5d80e0eff44d8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0104/FP16-INT8/face-detection-0104.xml
+    sha256: 2d49f429498f7cb3532974debfe7be6c7fe7aff3f95b3cc417008884db36c2fb
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0104/FP16-INT8/face-detection-0104.xml
   - name: FP16-INT8/face-detection-0104.bin
     size: 1921683
     sha256: 6628122c4a1943dd3ca8c626e13d26dcaa2ff21ded5d1c7412918251bc09a2a1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0104/FP16-INT8/face-detection-0104.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0104/FP16-INT8/face-detection-0104.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0105/model.yml
+++ b/models/intel/face-detection-0105/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0105.xml
     size: 541857
-    sha256: a0fbc65a671fe10ed10a52e6658bb45ce4d5bfd4e4a5a12d6b90c39af8138031
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0105/FP32/face-detection-0105.xml
+    sha256: 0f15f804477eda22aaeedaa48ce64accc97078c20acce83dd59bdeab306b9d95
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0105/FP32/face-detection-0105.xml
   - name: FP32/face-detection-0105.bin
     size: 8107676
     sha256: 6fc73650201677f90381f01448f41be5187e7f4993eb2064bb23b63c75c5380f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0105/FP32/face-detection-0105.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0105/FP32/face-detection-0105.bin
   - name: FP16/face-detection-0105.xml
     size: 541670
-    sha256: 38f2348e60df5fcc5b87b931323218ecf26e465d38cf5f3f6888aba196447f61
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0105/FP16/face-detection-0105.xml
+    sha256: f0b797ac00d23e50801098360702862ae9b72fdd7925332530e71ab7f03267b0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0105/FP16/face-detection-0105.xml
   - name: FP16/face-detection-0105.bin
     size: 4054012
     sha256: 93bfabf0e8dfe73bd30fbedd1327ef28b8d2b32dc6baff410392b3ad514f734c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0105/FP16/face-detection-0105.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0105/FP16/face-detection-0105.bin
   - name: FP16-INT8/face-detection-0105.xml
     size: 1171268
-    sha256: 9642f2d5c10520aabc632fb6d43b5fc4a2188c24b8ce3370bc2ca862850c92f6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0105/FP16-INT8/face-detection-0105.xml
+    sha256: 3df9b70e65c96b25f7cfe14a2a88365bbb36d24e8e3da284e7eed34ea70043c9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0105/FP16-INT8/face-detection-0105.xml
   - name: FP16-INT8/face-detection-0105.bin
     size: 2144004
     sha256: 6aa155ff421e55e0f719b2948d013f3f0ca35d852296cbe9c41bb8a304b84dad
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0105/FP16-INT8/face-detection-0105.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0105/FP16-INT8/face-detection-0105.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0106/model.yml
+++ b/models/intel/face-detection-0106/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0106.xml
     size: 1124280
-    sha256: b20eb66a4553b9eab26654aef263ae334877c04e93f73fd8e6e00454d3cb3833
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0106/FP32/face-detection-0106.xml
+    sha256: 1073a1655bf4175a580b7f0488d3122fe2062d3192efe635d7294f43ede5feae
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0106/FP32/face-detection-0106.xml
   - name: FP32/face-detection-0106.bin
     size: 255198408
     sha256: 2a8776f4454e33383d5765d2529a012fdbb2bbdc6e67fc84656b0f345b94a90d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0106/FP32/face-detection-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0106/FP32/face-detection-0106.bin
   - name: FP16/face-detection-0106.xml
     size: 1123922
-    sha256: 4eb5da6f99618aa7d63bdb0a69dbc9d717bf55d0f951e045ec187484efa936bf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0106/FP16/face-detection-0106.xml
+    sha256: 500729ff596316b218016fdf3da421bf0be87a5fbb665ec1c89844e282bb94b3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0106/FP16/face-detection-0106.xml
   - name: FP16/face-detection-0106.bin
     size: 127599614
     sha256: e00c8db98cef215afbfef5f7e39d36f1d3d775dd17d0d7907c74a75536cbb874
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0106/FP16/face-detection-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0106/FP16/face-detection-0106.bin
   - name: FP16-INT8/face-detection-0106.xml
-    size: 2385616
-    sha256: 91eb4033e48133d32e7761e3dca5d23153d202dd3d29521bedba8f1c795429bb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0106/FP16-INT8/face-detection-0106.xml
+    size: 2385688
+    sha256: 8d787040f6ec1e2b6649b180c295c2e2391ebeecac9c76bd19c2dfd1144bf88e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0106/FP16-INT8/face-detection-0106.xml
   - name: FP16-INT8/face-detection-0106.bin
     size: 64272550
     sha256: 2b0ff3ffdaef96b1e82c53eb30320111b47faa13d9d21b3a079102a7ec6732f2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-0106/FP16-INT8/face-detection-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-0106/FP16-INT8/face-detection-0106.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-adas-0001/model.yml
+++ b/models/intel/face-detection-adas-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-adas-0001.xml
     size: 224662
-    sha256: 8a46cd258038af7d2ebe27162cd2f3484a3b4f6b19be85e25279169dbbc2c869
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
+    sha256: c472d86e570f6af2f10fa8c3d38b02436468925e0193dd2727e8ed2cce5809b2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
   - name: FP32/face-detection-adas-0001.bin
     size: 4212072
     sha256: 811a332d80dc1891dc8254192e03de6a6de821af1cf0c1968f7632022d340524
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
   - name: FP16/face-detection-adas-0001.xml
     size: 224626
-    sha256: 1c743e5fd11f3702c01520dafefe3a09d9962e2270d18fd065eb6915fcbfb013
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
+    sha256: 36cb0d602da99da5786e13915b3f7489f72b850c1f62804c4848d0998d151a70
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
   - name: FP16/face-detection-adas-0001.bin
     size: 2106088
     sha256: df0f5799d801c6afb355d1c4771693c782efbb58d2eb2238982eac8fe84bc821
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
   - name: FP16-INT8/face-detection-adas-0001.xml
     size: 522574
-    sha256: 1e2c76b7131daea974c28d28693678434a621479eeb77ce7d7561c20ebd1e190
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-0001/FP16-INT8/face-detection-adas-0001.xml
+    sha256: d7bf0a9973aac33609ffb7cf34a2c1457b251add1f599b3af69d90ccd450ef74
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-0001/FP16-INT8/face-detection-adas-0001.xml
   - name: FP16-INT8/face-detection-adas-0001.bin
     size: 1100296
     sha256: 7d3396eb28d928f8e7a8caf7536cb6e402b3f13f2090c57b5832c4bb9da5226c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-0001/FP16-INT8/face-detection-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-0001/FP16-INT8/face-detection-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-adas-binary-0001/model.yml
+++ b/models/intel/face-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/face-detection-adas-binary-0001.xml
     size: 116647
     sha256: fde8c465a5e3f3425fb567d31b9591ff8be589930c8488639f8feddf7f0301f2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.xml
   - name: FP32-INT1/face-detection-adas-binary-0001.bin
     size: 1840444
     sha256: 0e0742b61fb924e937a8974da8a2e15cc6afc15630afa3f220676ee7a3a99700
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-adas-binary-0001/FP32-INT1/face-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0004/model.yml
+++ b/models/intel/face-detection-retail-0004/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/face-detection-retail-0004.xml
-    size: 100493
-    sha256: eaa92e1addf344796fe075588789fc55e7e54fea2e4089e4a8fa6cf2655881cd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
+    size: 100492
+    sha256: 772e6e75894e10a9ce52af67ac6657b0073725338303bc4edb94540679858e57
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
   - name: FP32/face-detection-retail-0004.bin
     size: 2352984
     sha256: 89349ce12dd21c5263fb302cd3ffd4b73c35ea12ed98aff863d03a2cf3a32464
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
   - name: FP16/face-detection-retail-0004.xml
     size: 100451
-    sha256: 47fa88c19236caf0b5691b4c7ac514496d2575911757824306c1d06f4e1ce03a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
+    sha256: 12b9517c1c727edb29a3def629169b9fab08579f97d032a34f977fe1f4d19a32
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
   - name: FP16/face-detection-retail-0004.bin
     size: 1176544
     sha256: ab7def342edab22e69ba1ef4e971983ea4e0f337c43b0a49c7ef3a7627f6cf1a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
   - name: FP16-INT8/face-detection-retail-0004.xml
-    size: 247925
-    sha256: c7967750af2dc036a4053416eb16e43fc47c079af0ac596afc67bc37c7e6d16e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0004/FP16-INT8/face-detection-retail-0004.xml
+    size: 247901
+    sha256: 4da02423abb6c98db9ef74d91282448a60a4a1864f9aac8a6d33e4506476c043
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0004/FP16-INT8/face-detection-retail-0004.xml
   - name: FP16-INT8/face-detection-retail-0004.bin
     size: 600348
     sha256: 7f772fe6694b22092993b1496426a43ce869b31eff07e0c75ab2a0e7f01f61fb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0004/FP16-INT8/face-detection-retail-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0004/FP16-INT8/face-detection-retail-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0005/model.yml
+++ b/models/intel/face-detection-retail-0005/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-retail-0005.xml
     size: 146206
-    sha256: 7a3bd6eca367fa94320111764126c674cb01a3d58e3e9266fb058ee1d3ed5c19
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
+    sha256: c6537f042599d71fa7b5155bbc7b32475763b38f33687af752edb3b67d2e6b2a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
   - name: FP32/face-detection-retail-0005.bin
     size: 4083172
     sha256: f2fb7361294881e84d7eb7d3a79defaf05b729a57b50b6e286e9c3781f3e3718
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
   - name: FP16/face-detection-retail-0005.xml
     size: 146125
-    sha256: 80e949a9a068054506dbf24a65fc0202de46832e72cc715079dadfa6b653085d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
+    sha256: 1a4136e4d8853d779e324190375baeb020acddf618c03405535979da9a435aed
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
   - name: FP16/face-detection-retail-0005.bin
     size: 2041658
     sha256: c795fca3473685ed0d5022f4cb8a186c475e67a18063d8597532623a4df5b9c0
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
   - name: FP16-INT8/face-detection-retail-0005.xml
-    size: 435527
-    sha256: 5c14e8805ed8c3268aba9f8d948e3a780c2ffa24fab38628921631f712dee147
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0005/FP16-INT8/face-detection-retail-0005.xml
+    size: 435489
+    sha256: dd23b8390d1342ed30e5680f9866280a48435e1fcb6810c4db88aa4b04312aa7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0005/FP16-INT8/face-detection-retail-0005.xml
   - name: FP16-INT8/face-detection-retail-0005.bin
     size: 1098853
     sha256: 58c529abb68aa91ab3bf5f5ee8bd58b76a804d41cdc759db2c069826df173b9a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-detection-retail-0005/FP16-INT8/face-detection-retail-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-detection-retail-0005/FP16-INT8/face-detection-retail-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/face-reidentification-retail-0095/model.yml
+++ b/models/intel/face-reidentification-retail-0095/model.yml
@@ -18,27 +18,27 @@ task_type: face_recognition
 files:
   - name: FP32/face-reidentification-retail-0095.xml
     size: 225818
-    sha256: a1c7662cd74dd31fefebba8e665ede9fa0953231b0983b29a571e860857e312f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
+    sha256: c668e0a792757a5cdfe9a650eeac16e1df89d59763de10620d5c970e0a3b9ee9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
   - name: FP32/face-reidentification-retail-0095.bin
     size: 4427256
     sha256: 5ac2b046dd8644be5bf26677fbe3db955a0777a777ed6767c772d665f21d89b8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
   - name: FP16/face-reidentification-retail-0095.xml
     size: 225714
-    sha256: 39e878756a03354948e3284cbd6a048fc717d5529a8122d9c6b906d5dff3402c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
+    sha256: 474c49dca9c29c02ae2a6c4d4d79a81febcfe4fc061c18d00aa3bfbc978a761a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
   - name: FP16/face-reidentification-retail-0095.bin
     size: 2213724
     sha256: c2f8a7b9268e5b5236574d6fda2216df43c03acaa39c078848a98fbb707ae0a3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
   - name: FP16-INT8/face-reidentification-retail-0095.xml
     size: 671327
-    sha256: 76feb26a5b07bcfb414868711cf5a60995f607e5b9af28a0f8b86f424a0dc2ca
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-reidentification-retail-0095/FP16-INT8/face-reidentification-retail-0095.xml
+    sha256: 96836a71ee6abf327b97e5f110eba53fe4f31effaf41b5ec70b37795cf31476f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-reidentification-retail-0095/FP16-INT8/face-reidentification-retail-0095.xml
   - name: FP16-INT8/face-reidentification-retail-0095.bin
     size: 1180984
     sha256: c8cd09e09fea188a33d4d78b8293d6654c57d4e2a6fc1147d4ed6176b5d56c40
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/face-reidentification-retail-0095/FP16-INT8/face-reidentification-retail-0095.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/face-reidentification-retail-0095/FP16-INT8/face-reidentification-retail-0095.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/facial-landmarks-35-adas-0002/model.yml
+++ b/models/intel/facial-landmarks-35-adas-0002/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/facial-landmarks-35-adas-0002.xml
     size: 237289
-    sha256: 6ebd1da2bf100e2603fc65c3cc3f6f259f8d9890d47604eb7ad081778e9424e0
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
+    sha256: 84723fbb63a19d764d0669fdbac167585b516c59a1de4e01bdce5ba2eb5d64f4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
   - name: FP32/facial-landmarks-35-adas-0002.bin
     size: 18381152
     sha256: e1a325159eb1a0a7cd918d1a1d4cde250c2f6626737aa76597fb405e37af87c6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
   - name: FP16/facial-landmarks-35-adas-0002.xml
     size: 237152
-    sha256: 9e832463a55942e6ff487c5d1076ed581d2f4b8de97afaa0f612e00ba2f941ef
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
+    sha256: 0b8adefa360b8908450ee7472425b3a32a9e772482a868d6d0d25f5141a92c95
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
   - name: FP16/facial-landmarks-35-adas-0002.bin
     size: 9190584
     sha256: 69952f73ba3239f8692ee41514ceff793a014e2a7a777faa570f0a8aaf17278d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
   - name: FP16-INT8/facial-landmarks-35-adas-0002.xml
     size: 644943
-    sha256: 73760b72f9db4cdc345fd520a04564553641ec1ea39cee96c110ec5797d03376
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/facial-landmarks-35-adas-0002/FP16-INT8/facial-landmarks-35-adas-0002.xml
+    sha256: e3262bc8a9c526d3bde68b370f8a3107385c730f67773ac1c4693904b18c9f97
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/facial-landmarks-35-adas-0002/FP16-INT8/facial-landmarks-35-adas-0002.xml
   - name: FP16-INT8/facial-landmarks-35-adas-0002.bin
     size: 4634174
     sha256: f66ed3a2e328726b5bf7344b47c61c59af75ffd57ea60ca705663bc5cb217116
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/facial-landmarks-35-adas-0002/FP16-INT8/facial-landmarks-35-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/facial-landmarks-35-adas-0002/FP16-INT8/facial-landmarks-35-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/model.yml
+++ b/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/faster-rcnn-resnet101-coco-sparse-60-0001.xml
     size: 307498
-    sha256: badf97bea61d3486aae35bfc1e3e8f506b55712fbcc099f0ef19a74fb35b5757
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/faster-rcnn-resnet101-coco-sparse-60-0001/FP32/faster-rcnn-resnet101-coco-sparse-60-0001.xml
+    sha256: eb16fa73bbe9410d2a4ae812b207c677d39e94bfbd21909b3fb729ba7ccc7b5b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP32/faster-rcnn-resnet101-coco-sparse-60-0001.xml
   - name: FP32/faster-rcnn-resnet101-coco-sparse-60-0001.bin
     size: 211169860
     sha256: 8e87058055b98323c4c824049f2a156250318615219968d6e4186ab9662ca3b4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/faster-rcnn-resnet101-coco-sparse-60-0001/FP32/faster-rcnn-resnet101-coco-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP32/faster-rcnn-resnet101-coco-sparse-60-0001.bin
   - name: FP16/faster-rcnn-resnet101-coco-sparse-60-0001.xml
     size: 307337
-    sha256: 4c96cee5156593516246e5918d4c9c388d19dcef2574d0d0b6925ac1ffb7c18c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/faster-rcnn-resnet101-coco-sparse-60-0001/FP16/faster-rcnn-resnet101-coco-sparse-60-0001.xml
+    sha256: 3de0f6c78d79df1d96f523d5946ab2298743026fc12d20e720c9f0fab19ce480
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16/faster-rcnn-resnet101-coco-sparse-60-0001.xml
   - name: FP16/faster-rcnn-resnet101-coco-sparse-60-0001.bin
     size: 105585006
     sha256: 93aa4a2d9a446d1f750f575358d29c70c1dc9edc64db74751ebc44967d24460a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/faster-rcnn-resnet101-coco-sparse-60-0001/FP16/faster-rcnn-resnet101-coco-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16/faster-rcnn-resnet101-coco-sparse-60-0001.bin
   - name: FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.xml
     size: 857169
-    sha256: b18b31657601bda23d06a8ae368e6e45feb9a180158970cbf5013e8f6220d4fa
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/faster-rcnn-resnet101-coco-sparse-60-0001/FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.xml
+    sha256: fd1c427391783b0be9b0d6e0563cbdd271ef3e8bc865b15cd3e3b4dd2e4972bc
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.xml
   - name: FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.bin
     size: 53063839
     sha256: 4d839335c33b3d15ac3cef22087bb8e15223ecd7e47b46c6ba5da9573bf2afa9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/faster-rcnn-resnet101-coco-sparse-60-0001/FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/gaze-estimation-adas-0002/model.yml
+++ b/models/intel/gaze-estimation-adas-0002/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/gaze-estimation-adas-0002.xml
     size: 66107
-    sha256: 0540f1248ad359622f242bc65806e820ceff5fb70337cff4ffb5b295a9dd3c2d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
+    sha256: 599b7cf501b2caf79d8d305c5d052785df09d455259db8decaf50024f4a78e72
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
   - name: FP32/gaze-estimation-adas-0002.bin
     size: 7529364
     sha256: cca54f935f3245ddb459d936e732324a077a50dc47b54ad99a70f1adf083e905
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
   - name: FP16/gaze-estimation-adas-0002.xml
     size: 66066
-    sha256: 4b80849f1bcf6dcaa98bcb22bf5b1fe966345030989cdee9bdabbb4b341a8d11
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
+    sha256: 5d8b6ee437e2bf578a59c23b5cde6919482147678137b69d0ebce0df99a8ff37
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
   - name: FP16/gaze-estimation-adas-0002.bin
     size: 3764726
     sha256: d525d095e8ba70dca20ca46d37ac586afc9f8808bbede3d380fdb7d030c16c7b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
   - name: FP16-INT8/gaze-estimation-adas-0002.xml
     size: 141962
-    sha256: 215d853112c4d8514676800bf031c91fe335434e1e3ca7d9b39bf235901effe1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/gaze-estimation-adas-0002/FP16-INT8/gaze-estimation-adas-0002.xml
+    sha256: d13cae429c694a5cff123a72003877c60cc46960f0e0b516176d4ca82aad6238
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/gaze-estimation-adas-0002/FP16-INT8/gaze-estimation-adas-0002.xml
   - name: FP16-INT8/gaze-estimation-adas-0002.bin
     size: 2056792
     sha256: 2da58550a894409460aed225dd5c6432cc8aab36fb9f2a8f34698414efd9a10b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/gaze-estimation-adas-0002/FP16-INT8/gaze-estimation-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/gaze-estimation-adas-0002/FP16-INT8/gaze-estimation-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/handwritten-japanese-recognition-0001/model.yml
+++ b/models/intel/handwritten-japanese-recognition-0001/model.yml
@@ -18,27 +18,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/handwritten-japanese-recognition-0001.xml
     size: 41904
-    sha256: 6a2c152cd6ad98f9543b0299d21673de5d1dc8f4d21dd6ada111f50e2749e145
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-japanese-recognition-0001/FP32/handwritten-japanese-recognition-0001.xml
+    sha256: 2ca54b0f49b6a04188d20f4e7c7460aff6c06209b9d86331acbc60e1b4b967b4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-japanese-recognition-0001/FP32/handwritten-japanese-recognition-0001.xml
   - name: FP32/handwritten-japanese-recognition-0001.bin
     size: 67969208
     sha256: be6f7eea5945af691277a1f3849f024ed6d3bb84c395bc66ed8e9da0346c063d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-japanese-recognition-0001/FP32/handwritten-japanese-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-japanese-recognition-0001/FP32/handwritten-japanese-recognition-0001.bin
   - name: FP16/handwritten-japanese-recognition-0001.xml
     size: 41892
-    sha256: a441cd737729011f36cd6b0e9ea597e8d51e3e1ca77e993179086506bcd26c98
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-japanese-recognition-0001/FP16/handwritten-japanese-recognition-0001.xml
+    sha256: 74cd85bd1ad9302db5422838c632fdebdc678d14ac3204484c48064072eb4713
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-japanese-recognition-0001/FP16/handwritten-japanese-recognition-0001.xml
   - name: FP16/handwritten-japanese-recognition-0001.bin
     size: 33984640
     sha256: c98a73664e3e71151cad86bfb2dc434b3c2e6c6517716268d97ea0e9a3969e89
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-japanese-recognition-0001/FP16/handwritten-japanese-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-japanese-recognition-0001/FP16/handwritten-japanese-recognition-0001.bin
   - name: FP16-INT8/handwritten-japanese-recognition-0001.xml
     size: 106890
-    sha256: 47b4030ca50510d4115bdc4a4d92965c5846603df7ba4d00356f17b8b969f6f4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.xml
+    sha256: 7b92ed6081e81d389d11e179e188bfec606d37f3f30eb978860eacf00f9b48a3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.xml
   - name: FP16-INT8/handwritten-japanese-recognition-0001.bin
     size: 17035722
     sha256: 834bbf5d55f40dde936e6402cf3c515c65884070f94fb6044ed44c883f205488
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/handwritten-score-recognition-0003/model.yml
+++ b/models/intel/handwritten-score-recognition-0003/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/handwritten-score-recognition-0003.xml
     size: 81064
-    sha256: 7f8526a37e30a5c6e93afcbff34274ca7451b3a7aa720c993d6733a31bea58ef
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
+    sha256: 4a914988402dac3a1c02ffc3b33da5ad224aa6ad28f8b95de31b1d9c948d441a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
   - name: FP32/handwritten-score-recognition-0003.bin
     size: 41121956
     sha256: 55350eecb10ea7c95b495a44dcd78b8287e124abed4689956aea23bff062b8ff
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
   - name: FP16/handwritten-score-recognition-0003.xml
     size: 81039
-    sha256: 2db0b54e30bde9027952d2bb77050c9fdd0c943778794b18cb702b3348e9bed9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
+    sha256: 562eb43ed5d34762b32eba03241317c2baa90153147a1ab71f0dfb8419eb0c21
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
   - name: FP16/handwritten-score-recognition-0003.bin
     size: 20561030
     sha256: b19f78f990bbfd7d86c52c075a094a18578de3243b5d531692bf8bd9afd4d9f4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
   - name: FP16-INT8/handwritten-score-recognition-0003.xml
     size: 121086
-    sha256: b8db935d05baca438019bc0cd919e703cc3695c6a3c1b6443489f64cbaeafd2c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-score-recognition-0003/FP16-INT8/handwritten-score-recognition-0003.xml
+    sha256: c039e60c2c26ef4f7b49dee787ee66c42c0f3e7f89e4ba8c4999d8a0eb937086
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-score-recognition-0003/FP16-INT8/handwritten-score-recognition-0003.xml
   - name: FP16-INT8/handwritten-score-recognition-0003.bin
     size: 15016854
     sha256: f245f460702608cfe20528419a9d1ba8ca23a220047742e4d1478f5da15815f8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/handwritten-score-recognition-0003/FP16-INT8/handwritten-score-recognition-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/handwritten-score-recognition-0003/FP16-INT8/handwritten-score-recognition-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/head-pose-estimation-adas-0001/model.yml
+++ b/models/intel/head-pose-estimation-adas-0001/model.yml
@@ -18,27 +18,27 @@ task_type: head_pose_estimation
 files:
   - name: FP32/head-pose-estimation-adas-0001.xml
     size: 50594
-    sha256: 853774342fa03b9213d28108766a797b0c5f65576bd425b82ee4522e39380d31
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
+    sha256: b0c52480bd6347fbef05c7c0cffc85942ae6156f004f82445d73cd93967f3ba5
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
   - name: FP32/head-pose-estimation-adas-0001.bin
     size: 7647604
     sha256: ccab5d2be86f29e5be616aca68e6584cf07bc39f46d189f4794e20f8080dc10c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
   - name: FP16/head-pose-estimation-adas-0001.xml
-    size: 50581
-    sha256: 6eb84138062abc71ffc77b8976f85402f160d255bc605bf857eea28b5038d171
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
+    size: 50583
+    sha256: 2f0f880b8623efcafd573181ce26dcbf561c9d3f16bfe02678f385071918a09a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
   - name: FP16/head-pose-estimation-adas-0001.bin
     size: 3823810
     sha256: 3616849b370b235e54b88798c053fc482cd5665faa569ee0c0d6435405d476be
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
   - name: FP16-INT8/head-pose-estimation-adas-0001.xml
-    size: 83281
-    sha256: 6e2f347ccc8f5b46ce0e720fb09d54f06143efe28a393497b3a4250cf12c77c2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/head-pose-estimation-adas-0001/FP16-INT8/head-pose-estimation-adas-0001.xml
+    size: 83279
+    sha256: 0b2c998db70535dac83d04f31549e1161ff7b1d5cd6590692cfa3ed976118d67
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/head-pose-estimation-adas-0001/FP16-INT8/head-pose-estimation-adas-0001.xml
   - name: FP16-INT8/head-pose-estimation-adas-0001.bin
     size: 2075098
     sha256: 54e8d3aa1828e0a6ea242eaaf88b4a3b131d3e62120a6dddfa286fec7fc7916f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/head-pose-estimation-adas-0001/FP16-INT8/head-pose-estimation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/head-pose-estimation-adas-0001/FP16-INT8/head-pose-estimation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/human-pose-estimation-0001/model.yml
+++ b/models/intel/human-pose-estimation-0001/model.yml
@@ -18,27 +18,27 @@ task_type: human_pose_estimation
 files:
   - name: FP32/human-pose-estimation-0001.xml
     size: 144308
-    sha256: 7ac1fdaad27a711f59ac7a275c5960098696498c60ee9c2d67bb76190a8e79c1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
+    sha256: 919b3e21cf2b35270f84ae8a3eb6cd504a79fbe95c878d7323022e40dd80a2d3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
   - name: FP32/human-pose-estimation-0001.bin
     size: 16394712
     sha256: 6a277f9564dd7f296c84deefed785de2b43639ca1f0d03281367606033ba9aa6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
   - name: FP16/human-pose-estimation-0001.xml
     size: 144236
-    sha256: 11bb18757f86bc2b9959746613f66ce08cfe3194952c1a2931148431a71f5b07
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
+    sha256: 09ea08e2021cc7305ef452d3d9d8c7098e9225afb76ab555dd47bf6617fe9081
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
   - name: FP16/human-pose-estimation-0001.bin
     size: 8197356
     sha256: c1c828d5d1ea2b03035692a8600f06d787fe1a20e79dac159c4293ed7063a382
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
   - name: FP16-INT8/human-pose-estimation-0001.xml
-    size: 437391
-    sha256: 4b85f124d82a2bbc73cdb66c1e436c922e8326c8d12a43790b5ab07b3ea7dccb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/human-pose-estimation-0001/FP16-INT8/human-pose-estimation-0001.xml
+    size: 437387
+    sha256: 991db90af8cdd1b86842f8a638e64d34abfc3044cb147b8530b72717e5f887a5
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/human-pose-estimation-0001/FP16-INT8/human-pose-estimation-0001.xml
   - name: FP16-INT8/human-pose-estimation-0001.bin
     size: 4170034
     sha256: 41ebd78a0770b6d1bfe134ce35b08561062e6723d99f7c029ec34d24ff4eacb4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/human-pose-estimation-0001/FP16-INT8/human-pose-estimation-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/human-pose-estimation-0001/FP16-INT8/human-pose-estimation-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/icnet-camvid-ava-0001/model.yml
+++ b/models/intel/icnet-camvid-ava-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/icnet-camvid-ava-0001.xml
     size: 210587
-    sha256: 399cbd551958347bdeb33d6b0b781b1eeb4c8aab7a0e810613dc4550eec94a6c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-0001/FP32/icnet-camvid-ava-0001.xml
+    sha256: d4435742b827a44e0fac50563afeba5111391bc4ad878689ec871dc66dea6ccc
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-0001/FP32/icnet-camvid-ava-0001.xml
   - name: FP32/icnet-camvid-ava-0001.bin
     size: 106816756
     sha256: 07baba823966d3c4cbd08d59187c8e53d9c3b9455d2d11ccea1f0b3756ae892e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-0001/FP32/icnet-camvid-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-0001/FP32/icnet-camvid-ava-0001.bin
   - name: FP16/icnet-camvid-ava-0001.xml
     size: 210495
-    sha256: 03067958430cc8225ff7abebc027416bb36c0e8effb8eb44a21d30551e469c37
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-0001/FP16/icnet-camvid-ava-0001.xml
+    sha256: 92c22246f759877f7641f96d4e14dc01dac304b3e3004e03a9909967af26d1f3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-0001/FP16/icnet-camvid-ava-0001.xml
   - name: FP16/icnet-camvid-ava-0001.bin
     size: 53408464
     sha256: 88a3d1f2cdc585073d1dc4af0217ddf924fcb191e65d89d64687ad2eb4b4bdc3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-0001/FP16/icnet-camvid-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-0001/FP16/icnet-camvid-ava-0001.bin
   - name: FP16-INT8/icnet-camvid-ava-0001.xml
     size: 593016
-    sha256: 8eaa131113d8c0f98c478cda58c51641edd828c3feae1aefd0c04a949663d61d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-0001/FP16-INT8/icnet-camvid-ava-0001.xml
+    sha256: 56af0a5266268e0ea98adf084b2c884f107f81528844b44fd754f8219aa36690
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-0001/FP16-INT8/icnet-camvid-ava-0001.xml
   - name: FP16-INT8/icnet-camvid-ava-0001.bin
     size: 26847354
     sha256: 913bfe698687a43870093b6f79fc76d4efa247fb8460783033ef861cafbb3965
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-0001/FP16-INT8/icnet-camvid-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-0001/FP16-INT8/icnet-camvid-ava-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/icnet-camvid-ava-sparse-30-0001/model.yml
+++ b/models/intel/icnet-camvid-ava-sparse-30-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/icnet-camvid-ava-sparse-30-0001.xml
     size: 210607
-    sha256: f326db4e15516531de247cc2d6dbed1d6cf875d180b7c9a5ceb92d9093185b8c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-30-0001/FP32/icnet-camvid-ava-sparse-30-0001.xml
+    sha256: 52b10ce17bab3ec7bcba9fa363b02df0d44abf5b5d81511090c21b0d890b783b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP32/icnet-camvid-ava-sparse-30-0001.xml
   - name: FP32/icnet-camvid-ava-sparse-30-0001.bin
     size: 106816756
     sha256: eaf6274b44f26eeda4e593e3868641cf8cada3db92178e0a05c2bfb7ea35215d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-30-0001/FP32/icnet-camvid-ava-sparse-30-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP32/icnet-camvid-ava-sparse-30-0001.bin
   - name: FP16/icnet-camvid-ava-sparse-30-0001.xml
     size: 210515
-    sha256: 0b23417d4566892b84db1ed7737b0442adc08f862a07507c4b49df7d488e4ccf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-30-0001/FP16/icnet-camvid-ava-sparse-30-0001.xml
+    sha256: f73dc6196c6429f3206aefdfad11931f8307f3eb08d7981a58d094d555152a3a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16/icnet-camvid-ava-sparse-30-0001.xml
   - name: FP16/icnet-camvid-ava-sparse-30-0001.bin
     size: 53408464
     sha256: ec1ef20ce5cf46e163fa0d1366eaad01c4e0ab3ab2d4ca960a1939e9922249c1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-30-0001/FP16/icnet-camvid-ava-sparse-30-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16/icnet-camvid-ava-sparse-30-0001.bin
   - name: FP16-INT8/icnet-camvid-ava-sparse-30-0001.xml
     size: 593068
-    sha256: 940041bc5e235dbcf9117313c7780c1489cfaafd375d227b8a8d3a8a692c8c10
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-30-0001/FP16-INT8/icnet-camvid-ava-sparse-30-0001.xml
+    sha256: 0ac72a3db9dc8a9282e50c887e3e17501e5552b8f03ffe4b8d883718e51aed78
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16-INT8/icnet-camvid-ava-sparse-30-0001.xml
   - name: FP16-INT8/icnet-camvid-ava-sparse-30-0001.bin
     size: 26847348
     sha256: 37b1544f8be27b10409c6a4b841d27d8fa14b8378101f071c93df173ff976de7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-30-0001/FP16-INT8/icnet-camvid-ava-sparse-30-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16-INT8/icnet-camvid-ava-sparse-30-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/icnet-camvid-ava-sparse-60-0001/model.yml
+++ b/models/intel/icnet-camvid-ava-sparse-60-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/icnet-camvid-ava-sparse-60-0001.xml
     size: 210607
-    sha256: d65001e0bb53eab57ca1cd063f1e2932112cb0eca578b5371574937cabd36c4f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-60-0001/FP32/icnet-camvid-ava-sparse-60-0001.xml
+    sha256: ff559aa6ea29b3456c39c334ee69dc9a230a026d335816d7d234ec249f6de30a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP32/icnet-camvid-ava-sparse-60-0001.xml
   - name: FP32/icnet-camvid-ava-sparse-60-0001.bin
     size: 106816756
     sha256: eed6911e4a4e56613ea01317d386f51b7f5529f944b65a97aeb045f7afa4b9eb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-60-0001/FP32/icnet-camvid-ava-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP32/icnet-camvid-ava-sparse-60-0001.bin
   - name: FP16/icnet-camvid-ava-sparse-60-0001.xml
     size: 210515
-    sha256: 8483abd5066335c9ea227d5f0f744fe442c52ffa9cec76c847aaa60fdb82508b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-60-0001/FP16/icnet-camvid-ava-sparse-60-0001.xml
+    sha256: 803d001052b97e6568bf5c78498b7333abc714a08f619048f02247b67d148ced
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16/icnet-camvid-ava-sparse-60-0001.xml
   - name: FP16/icnet-camvid-ava-sparse-60-0001.bin
     size: 53408464
     sha256: 7a5d41199e2a121f67251bd7a4acb41f72033e24611b3333956f89bf27697e3b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-60-0001/FP16/icnet-camvid-ava-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16/icnet-camvid-ava-sparse-60-0001.bin
   - name: FP16-INT8/icnet-camvid-ava-sparse-60-0001.xml
     size: 593068
-    sha256: 0b65aaf67fa289ad08ec76d08fe181d059c7956411fee5e17b2c9402c2fb64dd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-60-0001/FP16-INT8/icnet-camvid-ava-sparse-60-0001.xml
+    sha256: 726e6d19790186558de0f0eb28a998c4a40fffcd202731f5573b5d22d61878de
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16-INT8/icnet-camvid-ava-sparse-60-0001.xml
   - name: FP16-INT8/icnet-camvid-ava-sparse-60-0001.bin
     size: 26847350
     sha256: b77c8aad9abcf16704356746d5831e32893e90ad6fbcdad44fa834e5745a6b49
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/icnet-camvid-ava-sparse-60-0001/FP16-INT8/icnet-camvid-ava-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16-INT8/icnet-camvid-ava-sparse-60-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/image-retrieval-0001/model.yml
+++ b/models/intel/image-retrieval-0001/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/image-retrieval-0001.xml
     size: 142367
-    sha256: 96d7404b08a400dcd5d878a3f86042049585b201eceec7dc2c7f43b87d9046db
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/image-retrieval-0001/FP32/image-retrieval-0001.xml
+    sha256: f1c726e4a8d5003c200a26aa9c8a728c60aba7d98d5be5f7b1fc6ef24288686c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/image-retrieval-0001/FP32/image-retrieval-0001.xml
   - name: FP32/image-retrieval-0001.bin
     size: 10139176
     sha256: 193674816f857bd7143667e6330b9171057048deadf933d81633c7e68db5b4fe
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/image-retrieval-0001/FP32/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/image-retrieval-0001/FP32/image-retrieval-0001.bin
   - name: FP16/image-retrieval-0001.xml
     size: 142300
-    sha256: 4d909061ea9bba928077335f912282a5cb55fc31f1e0441f9ad10b5b6f9a9c1f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/image-retrieval-0001/FP16/image-retrieval-0001.xml
+    sha256: 6f0fe395e935fc28f5661b2203dc816273ff28839e3c2f4562e0d9827ab707c2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/image-retrieval-0001/FP16/image-retrieval-0001.xml
   - name: FP16/image-retrieval-0001.bin
     size: 5069656
     sha256: bc1ea805f260ee74ad9c1ce7e344848188d089d03be5d1ffb95e9d9380c53d45
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/image-retrieval-0001/FP16/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/image-retrieval-0001/FP16/image-retrieval-0001.bin
   - name: FP16-INT8/image-retrieval-0001.xml
     size: 408696
-    sha256: db80c94dadb83adc5183fcff444624e259c7ec47eadc4626685aff23216b79a7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/image-retrieval-0001/FP16-INT8/image-retrieval-0001.xml
+    sha256: 72ba4edee63cc30ec96a16f231304e8a33d688fc80ca28fdd8b23493e437257f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/image-retrieval-0001/FP16-INT8/image-retrieval-0001.xml
   - name: FP16-INT8/image-retrieval-0001.bin
     size: 2643089
     sha256: 11ab3a8f85279be1b08e32822d982fe58be12822c4e3efa289565a0058172a77
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/image-retrieval-0001/FP16-INT8/image-retrieval-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/image-retrieval-0001/FP16-INT8/image-retrieval-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0010/model.yml
+++ b/models/intel/instance-segmentation-security-0010/model.yml
@@ -20,27 +20,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0010.xml
     size: 506066
-    sha256: 65581798771856cc18478839863cefef451ad4ae2d97acfc75d39125d106fc40
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.xml
+    sha256: efe4e41311eeedc4e604c56ede1e827190590b1e98d1607b6f78cea342a473c0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.xml
   - name: FP32/instance-segmentation-security-0010.bin
     size: 688762104
     sha256: e3bcb00c3fe9ba6cb0f3833a0e8fd28331a049b2ff977c412dd11d2d4411b65e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0010/FP32/instance-segmentation-security-0010.bin
   - name: FP16/instance-segmentation-security-0010.xml
     size: 505857
-    sha256: f38258d36ef7a64436a3aff18c3b5882055d91a8589bb124e2258bb975b58c1b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.xml
+    sha256: fa4b0fad36d3689531add76ced649f3a5655fca3fcf221f0a53dd75aafb3984d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.xml
   - name: FP16/instance-segmentation-security-0010.bin
     size: 344381290
     sha256: d7f9a9c1494bc1feffc457a16dcc0285c1918d7e73a88fc66a5cc768c4615195
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0010/FP16/instance-segmentation-security-0010.bin
   - name: FP16-INT8/instance-segmentation-security-0010.xml
     size: 1323563
-    sha256: e447a6508d10f5ac714658ac968e25367637e12f1caab6dbc842add7316aea04
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0010/FP16-INT8/instance-segmentation-security-0010.xml
+    sha256: 218d068fb4fbd6ffa37d92de8d7c3fe4b9f3b01f5616709254f99ba14e00867f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0010/FP16-INT8/instance-segmentation-security-0010.xml
   - name: FP16-INT8/instance-segmentation-security-0010.bin
     size: 176560838
     sha256: 2afdcef04c99da86cfbb8e3e057db6baa619a6f875a5bf1fcd00cd237cd33a1a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0010/FP16-INT8/instance-segmentation-security-0010.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0010/FP16-INT8/instance-segmentation-security-0010.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0050/model.yml
+++ b/models/intel/instance-segmentation-security-0050/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0050.xml
     size: 289772
-    sha256: 9f53e5f9a87622f01cdccf010e0a49bd904b70ddb22650fd86d13a11fe92b3a1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.xml
+    sha256: 2ef6a5a8ad7c308da045c8283477ecfb21e0ee26e807cf6460a348ca90df5b59
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.xml
   - name: FP32/instance-segmentation-security-0050.bin
     size: 121497432
     sha256: d19d52955a973c5210b7b8cf9170fadf4c812329740f04733ae200cd62a8a175
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0050/FP32/instance-segmentation-security-0050.bin
   - name: FP16/instance-segmentation-security-0050.xml
     size: 289662
-    sha256: b262b3bf38d467652dc6c66fcd477423a476f996ceefb6805c1f806a369c8ddf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.xml
+    sha256: 950423b06d5564ec343273547304ef2ba79e26b901bcc78df16fab984704bf39
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.xml
   - name: FP16/instance-segmentation-security-0050.bin
     size: 60748778
     sha256: 52e0aa71864aae1ff9277c692476383b208526031464adb661751263752122df
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0050/FP16/instance-segmentation-security-0050.bin
   - name: FP16-INT8/instance-segmentation-security-0050.xml
     size: 724832
-    sha256: 3d993375c2d5323f7cc783fdf2a5e8df4df4e6be2e7e9c55601477cd3a89c460
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0050/FP16-INT8/instance-segmentation-security-0050.xml
+    sha256: da468de9676abedfc5f116bc8d359d898b5c10c4179b874d63dbace7e7582712
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0050/FP16-INT8/instance-segmentation-security-0050.xml
   - name: FP16-INT8/instance-segmentation-security-0050.bin
     size: 30597942
     sha256: 74f7be4f151234d05d689dfaa432aa253071c16db26d4c9ab5387af08950d193
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0050/FP16-INT8/instance-segmentation-security-0050.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0050/FP16-INT8/instance-segmentation-security-0050.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0083/model.yml
+++ b/models/intel/instance-segmentation-security-0083/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0083.xml
     size: 532421
-    sha256: 9ca1a1243b243e50096f6e8a4b6232f115e9980377bc02b4bf0591465e2f51a8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.xml
+    sha256: 235011128a6219ca315dcfd6389ef6fcc7c8e182f0f249dda0683496ec9876b2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.xml
   - name: FP32/instance-segmentation-security-0083.bin
     size: 564274520
     sha256: 585dc900a8f7722fdd7b896f1956186dedc4d63580b68844a91205cc3c96afad
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0083/FP32/instance-segmentation-security-0083.bin
   - name: FP16/instance-segmentation-security-0083.xml
     size: 532218
-    sha256: 8a20be963873a67314b84a12757566fd2b5158bc0ab2b51e32bb3dcdc291cc80
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.xml
+    sha256: 6a6a3f736db70ab57c03e3fe508999f6074c732114c6513b1cf31e8fb734ae81
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.xml
   - name: FP16/instance-segmentation-security-0083.bin
     size: 282137322
     sha256: d94d2c2ad4df561d380a71f4fa4fbcfe462c94f3d36098452e39b8b7586572bb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0083/FP16/instance-segmentation-security-0083.bin
   - name: FP16-INT8/instance-segmentation-security-0083.xml
     size: 1469339
-    sha256: 3e122ce6496e6533bf5676577e6fc63e06ceb7cb5383d22d12c723c7b7446718
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0083/FP16-INT8/instance-segmentation-security-0083.xml
+    sha256: 1fa5b68317b3c575dfdcd89eb98d8b79f31fe4a79d4488d80fd1f014f1ca5251
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0083/FP16-INT8/instance-segmentation-security-0083.xml
   - name: FP16-INT8/instance-segmentation-security-0083.bin
     size: 142099022
     sha256: aa3f86d96ce3c37c2d76b0735683d8c7405778c0b65828b22b6dde72691c07c4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-0083/FP16-INT8/instance-segmentation-security-0083.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-0083/FP16-INT8/instance-segmentation-security-0083.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-1025/model.yml
+++ b/models/intel/instance-segmentation-security-1025/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-1025.xml
     size: 712182
-    sha256: 2a34245f1ed054dbb0d2cc3af835c10bb83e67d3c288f950c4af9346fd8289bb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-1025/FP32/instance-segmentation-security-1025.xml
+    sha256: 8cc7fb47e9e14ce8ec56f8b9aa1e04c305e88725c1e0346f5d67f164c18d8fb9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-1025/FP32/instance-segmentation-security-1025.xml
   - name: FP32/instance-segmentation-security-1025.bin
     size: 107603504
     sha256: 00da04c43ffb5861917893c6ac217c208fb959c1ec3defa038b2f2d9b4fd6a50
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-1025/FP32/instance-segmentation-security-1025.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-1025/FP32/instance-segmentation-security-1025.bin
   - name: FP16/instance-segmentation-security-1025.xml
     size: 711897
-    sha256: cf20497756e5ad6cc5f0c61e0d9f97542d9b4da79f884fd80ef8c2dc050c436e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-1025/FP16/instance-segmentation-security-1025.xml
+    sha256: 8976a3c739fa5ce58b3be046141b256f7bf3eaa4bae75226aadeb3d0a6252816
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-1025/FP16/instance-segmentation-security-1025.xml
   - name: FP16/instance-segmentation-security-1025.bin
     size: 53801914
     sha256: 2f431f672343f91db0fe8b462cd7d46dfbc32f81948d906e5c0ce4e76b7f90c1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-1025/FP16/instance-segmentation-security-1025.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-1025/FP16/instance-segmentation-security-1025.bin
   - name: FP16-INT8/instance-segmentation-security-1025.xml
-    size: 2275445
-    sha256: 750910aae365d9a06c67bc1b3befc7c0c5e8c79d7c49e78842f9a8237f5e77b3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-1025/FP16-INT8/instance-segmentation-security-1025.xml
+    size: 2275413
+    sha256: 8d1aec88e0fca05845c50bf105419fc7549dae16a21a72943944f0de2f3c44d1
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-1025/FP16-INT8/instance-segmentation-security-1025.xml
   - name: FP16-INT8/instance-segmentation-security-1025.bin
     size: 27464984
     sha256: e5a66758ee285e72a741b137aa939c5e2154c0b575a7cdb79d1ce956b5869dcf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/instance-segmentation-security-1025/FP16-INT8/instance-segmentation-security-1025.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/instance-segmentation-security-1025/FP16-INT8/instance-segmentation-security-1025.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/landmarks-regression-retail-0009/model.yml
+++ b/models/intel/landmarks-regression-retail-0009/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/landmarks-regression-retail-0009.xml
     size: 42664
-    sha256: d1d16bd24dc6f205c8f7dfcafafe2b155ece1c3c1efc6e128b9afa15049f581e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
+    sha256: 2a7da35ca6b4284dc9358f7c93c69112da923d21f4b932ef609426ca4c356f05
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
   - name: FP32/landmarks-regression-retail-0009.bin
     size: 762464
     sha256: 743d6045dd1c8df90649d2e19ce40ee41de18b799e261bb11682e1d9ef124b5d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
   - name: FP16/landmarks-regression-retail-0009.xml
     size: 42645
-    sha256: 8b5a389673f5fa97c6cc258e05a53e31f5e0e79881c6d4b48444a9a01823c784
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
+    sha256: 66697184c9f2ecc9bf75f0dce8c62a20efbfc41b696178ac95268ba7e610f118
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
   - name: FP16/landmarks-regression-retail-0009.bin
     size: 381248
     sha256: 973b13e64b3576f754a690266b069438b531bc657233d09d7b382ca36e6cf1e4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
   - name: FP16-INT8/landmarks-regression-retail-0009.xml
     size: 77650
-    sha256: c79fa7b162266f34b7ddd177dda7f9797c1e2eace8ca7c666417cef37c3bc930
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/landmarks-regression-retail-0009/FP16-INT8/landmarks-regression-retail-0009.xml
+    sha256: 013d2c04e7b0bd866a6b43488f4ed33b8dd4e4520b8eea6ac33a71c80804a38b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/landmarks-regression-retail-0009/FP16-INT8/landmarks-regression-retail-0009.xml
   - name: FP16-INT8/landmarks-regression-retail-0009.bin
     size: 244886
     sha256: aca78082b78413736ebe272bb4c84b723d6a5f30b72dee5e5e3bd46f3a2c5d78
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/landmarks-regression-retail-0009/FP16-INT8/landmarks-regression-retail-0009.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/landmarks-regression-retail-0009/FP16-INT8/landmarks-regression-retail-0009.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/license-plate-recognition-barrier-0001/model.yml
+++ b/models/intel/license-plate-recognition-barrier-0001/model.yml
@@ -18,27 +18,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/license-plate-recognition-barrier-0001.xml
     size: 48868
-    sha256: bb3423a8dbec63dcb5a413a8faa0586961d894c3997ceb99f3c365b594f4861f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
+    sha256: d03995527134c3401270de791585c1e58bd2a3f1889dc094999bf369ff8a57ed
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
   - name: FP32/license-plate-recognition-barrier-0001.bin
     size: 4871940
     sha256: 3ef022a17b5f303c676c9c3a23669d09a257a54acdb894b6db295acc141cc4dd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
   - name: FP16/license-plate-recognition-barrier-0001.xml
     size: 48849
-    sha256: 2ab1cb5881590c2158fbc279b1a1d8bb4a8f08a1b9ea1018850574b276f307a9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
+    sha256: 90ac5eeafe3f3ec96a5f7b67c74dddd6ac6c84318eb4ab9354fd4c16bf9fdb97
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
   - name: FP16/license-plate-recognition-barrier-0001.bin
     size: 2436038
     sha256: 184d9312c71b660639898edb46b85a99477e8d6a756b2b611e71a3afad5f25c1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
   - name: FP16-INT8/license-plate-recognition-barrier-0001.xml
     size: 125323
-    sha256: 7ec0b6bfbb37acbf22e754638fee3c22124b6feeeeb03feab2b1b335a91e0ab9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/license-plate-recognition-barrier-0001/FP16-INT8/license-plate-recognition-barrier-0001.xml
+    sha256: f2cf4e7c0d920fbc55a3359d7363085dfe33784d13f7aa2051f6634fb174dfc4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/license-plate-recognition-barrier-0001/FP16-INT8/license-plate-recognition-barrier-0001.xml
   - name: FP16-INT8/license-plate-recognition-barrier-0001.bin
     size: 2040578
     sha256: 103b57e80fea656e268c1fbc887db19ffecebf0f3424d48e628d669066f03503
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/license-plate-recognition-barrier-0001/FP16-INT8/license-plate-recognition-barrier-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/license-plate-recognition-barrier-0001/FP16-INT8/license-plate-recognition-barrier-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
+++ b/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.xml
     size: 233227
-    sha256: 0c23e0e565eb3b9b8999c2e21e3a713d9d6b55a198e0d2a902e9dd59ebdd0757
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
+    sha256: c7ce0a9c3f5cc55ec9631171de8f67caac21b7e833dc1c4dd58b9d20db2f897e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 6598568
     sha256: 24b06d7ecc98d1d58fead4e1c2bc30501693d17ec516119393b61a351011525c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.xml
     size: 233181
-    sha256: f1fb89fc57c2c6ccd659ec94d1e6314f7da4565fc57ebbdcd1023fc701ee1d60
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
+    sha256: 20cdf305a11840423550606f4933c4c380b62844b800f84f5a229bd33648b98f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 3299336
     sha256: 3f9739b91277bc916f29b17d043115c6669e113e5d60d61589063d8054c40d7d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
     size: 491143
-    sha256: bc429024d852353716cad8bfde1eb134c835b6215e1c7d733b067c9d136794d3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-and-vehicle-detector-adas-0001/FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
+    sha256: 316fc0cfb890562938d526f93501466136c0f22c9edd6f59ece7de67ed416c86
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 1705676
     sha256: ef5da5b8add2897be722ef2dc8c3e825cab94ba9ddd509d238ad30f0e5838f74
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-and-vehicle-detector-adas-0001/FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-detection-adas-0002/model.yml
+++ b/models/intel/pedestrian-detection-adas-0002/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/pedestrian-detection-adas-0002.xml
     size: 233110
-    sha256: 9abc23374b246ce06d24e2c037bf4caae09f60023cb639378f221043df1100ec
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
+    sha256: 59882530a3c91df23b5e4777bea6bd5a07aaca619af6bb50c7ac30970aae50ba
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
   - name: FP32/pedestrian-detection-adas-0002.bin
     size: 4660248
     sha256: 249c964cbe38135cc5f2682288978652dd93aa4918e7043f96f894790f11c265
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
   - name: FP16/pedestrian-detection-adas-0002.xml
     size: 233061
-    sha256: 9806072de2667b00d84aeb3007fe73593a42e50811bd11e59037ba0c020e07ee
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
+    sha256: a345985420d2dc276b5d90e14e883f08da4b5accf181c94add2077ec6566fd96
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
   - name: FP16/pedestrian-detection-adas-0002.bin
     size: 2330176
     sha256: 693753b7466da913b537016b31e3012f8ce6a885ac0897e3986eeca66d4ef8e6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
   - name: FP16-INT8/pedestrian-detection-adas-0002.xml
     size: 490829
-    sha256: 3e7b6cab0d2e54e13bdeae10867c8d8523c0b96c8baaff4e7d00b79f023b2f93
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-0002/FP16-INT8/pedestrian-detection-adas-0002.xml
+    sha256: 01543ba6d087209a7586e38162b69061c3f4d8ff37e90e9c3dc4c4e2fad7f5ed
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-0002/FP16-INT8/pedestrian-detection-adas-0002.xml
   - name: FP16-INT8/pedestrian-detection-adas-0002.bin
     size: 1212526
     sha256: 6039d1786a10b3e18e3ada8ed1f9dcad70040034d6a23cf08bb408f2827214ab
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-0002/FP16-INT8/pedestrian-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-0002/FP16-INT8/pedestrian-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-detection-adas-binary-0001/model.yml
+++ b/models/intel/pedestrian-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/pedestrian-detection-adas-binary-0001.xml
     size: 114635
     sha256: e64e7ce32c87e1c698b50abb8f2cf1d96c7651d45fc20bac09c417e046afa7f4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.xml
   - name: FP32-INT1/pedestrian-detection-adas-binary-0001.bin
     size: 2338004
     sha256: 7c2761ca3859ef55a80d9ed924225df7ba363fcb151e4ec2f7d1061b70bdb374
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/pedestrian-detection-adas-binary-0001/FP32-INT1/pedestrian-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-attributes-recognition-crossroad-0230/model.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0230/model.yml
@@ -19,27 +19,19 @@ task_type: object_attributes
 files:
   - name: FP32/person-attributes-recognition-crossroad-0230.xml
     size: 173347
-    sha256: 44cd1f5a7d8ead694aedde6763a042b8b196963055b415d93b771d6700accaa4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
+    sha256: aa398ff00049b812c2109bda1af782b0241642f2935d27a6b08278c433d923e6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
   - name: FP32/person-attributes-recognition-crossroad-0230.bin
     size: 2939232
     sha256: 669cff5a6af5afa9d6f54cfacb4286ba545f1d439e8328776e35e9c1fbeabc95
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
   - name: FP16/person-attributes-recognition-crossroad-0230.xml
     size: 173262
-    sha256: da00457a96f8d93066d2527260483e22290d60213ba32f07c98c6ee34faeeb6f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
+    sha256: 85655daaa0be59bb8bcca4e06c8266157c7e59df61a7912c4e7329756d84e9e9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
   - name: FP16/person-attributes-recognition-crossroad-0230.bin
     size: 1469624
     sha256: 61327cb5748a234c0320456e83dc8e42756c3a9856f15580a111493da47366fc
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
-  - name: FP16-INT8/person-attributes-recognition-crossroad-0230.xml
-    size: 494746
-    sha256: 6cfe46e344ddec6256a58ebc5e37453db0eddb55c8daf316cb8b2d7d6bb6ffd9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-attributes-recognition-crossroad-0230/FP16-INT8/person-attributes-recognition-crossroad-0230.xml
-  - name: FP16-INT8/person-attributes-recognition-crossroad-0230.bin
-    size: 753566
-    sha256: e14e483f2da461d0cafe48e2e21809832b6c2109ad66e564a24f6221676a58c2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-attributes-recognition-crossroad-0230/FP16-INT8/person-attributes-recognition-crossroad-0230.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0100/model.yml
+++ b/models/intel/person-detection-0100/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0100.xml
     size: 166331
-    sha256: 84fcee4abef002dc58ebd2d505ebe2dab7ab54c9591531c6e7dc3d4d312a8735
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0100/FP32/person-detection-0100.xml
+    sha256: 5736145f1ee50b710adb960efc2a7b8d075081acf497d1b832607cb40f65b813
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0100/FP32/person-detection-0100.xml
   - name: FP32/person-detection-0100.bin
     size: 7269228
     sha256: c73940897661c4b56ac0b3f35310cacc49e1130e11bfd39873a7dcdfb9af4e8e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0100/FP32/person-detection-0100.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0100/FP32/person-detection-0100.bin
   - name: FP16/person-detection-0100.xml
     size: 166268
-    sha256: c8ba0fa35e88fede07a6b055ef3ab63632ec9e07854be7e897293d98f918e075
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0100/FP16/person-detection-0100.xml
+    sha256: 4a1ab1f9d2edb7b42e1bf2ece245dbc757722cdb4bafb3ba057b00c4e5ff8119
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0100/FP16/person-detection-0100.xml
   - name: FP16/person-detection-0100.bin
     size: 3634686
     sha256: 526de9daea25c06b8afb49bc51a974e7d4bd093598968659697d15926d46a113
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0100/FP16/person-detection-0100.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0100/FP16/person-detection-0100.bin
   - name: FP16-INT8/person-detection-0100.xml
     size: 473314
-    sha256: 9d8151639f63f034f7c5f1e258f9c80ec29a98a648292f56888d9ef82665adc7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0100/FP16-INT8/person-detection-0100.xml
+    sha256: 3183eab6b6f55326a7976d79a405010266c52c0fee626b99d4480b174f3ec407
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0100/FP16-INT8/person-detection-0100.xml
   - name: FP16-INT8/person-detection-0100.bin
     size: 1921679
     sha256: 27a371f17389992e467dd95b413a6c0b87e98d84c274215d61d4f7d888cce8b6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0100/FP16-INT8/person-detection-0100.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0100/FP16-INT8/person-detection-0100.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0101/model.yml
+++ b/models/intel/person-detection-0101/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0101.xml
     size: 166517
-    sha256: d96257bbb60fd0433fe69627634849b786401055393d34071a98295265b0d162
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0101/FP32/person-detection-0101.xml
+    sha256: 240012dbd668922266e1b8b8f6a5ba33486906eb208eff2f1a110207001e663a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0101/FP32/person-detection-0101.xml
   - name: FP32/person-detection-0101.bin
     size: 7269228
     sha256: 1dfe54898fce492d79284a668bb0f31a2da97f8dbe5f6a99e111d41f7548306a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0101/FP32/person-detection-0101.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0101/FP32/person-detection-0101.bin
   - name: FP16/person-detection-0101.xml
     size: 166454
-    sha256: 43217f53b8f3dba023416cb46a721a4a79c9ec2b5d8c93039a8717fbe38b8fff
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0101/FP16/person-detection-0101.xml
+    sha256: ddf97ada6a3164dd1c0c3534df3a9bb3061dbeb28b7e810d9de3fde5d2a8dec5
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0101/FP16/person-detection-0101.xml
   - name: FP16/person-detection-0101.bin
     size: 3634686
     sha256: 09aa5ed2e88e785d7084dbb8971cadcc231f24c1810a7b48e4aa0476f587c56d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0101/FP16/person-detection-0101.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0101/FP16/person-detection-0101.bin
   - name: FP16-INT8/person-detection-0101.xml
     size: 473560
-    sha256: 4d81a1293c9b01b1b995d780f0bffddc98fcff2bb4c5d922f38268535f217b31
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0101/FP16-INT8/person-detection-0101.xml
+    sha256: d8e6e918693a5a7a2cd7421d361dc204fcfe21ffd3bc99bdf300ceb47b8ed388
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0101/FP16-INT8/person-detection-0101.xml
   - name: FP16-INT8/person-detection-0101.bin
     size: 1921681
     sha256: 40f51e4b57bbc9080e79d7d17dd56c88c49997ce75065142ae6e0ec6d5ebd162
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0101/FP16-INT8/person-detection-0101.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0101/FP16-INT8/person-detection-0101.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0102/model.yml
+++ b/models/intel/person-detection-0102/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0102.xml
     size: 166596
-    sha256: 59699a093ff2fe705a0200a014d27053e33b866d765a699c8e5c83b7284eae6a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0102/FP32/person-detection-0102.xml
+    sha256: 7bc40fc54758453fc4f84847c82a0d93f1be6019da5346ee5d04ff10ad3341b6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0102/FP32/person-detection-0102.xml
   - name: FP32/person-detection-0102.bin
     size: 7269228
     sha256: e100bf6ec1c2b0dce8a4819b4af471679235259cc08c7ef04eb71006c27e22c3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0102/FP32/person-detection-0102.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0102/FP32/person-detection-0102.bin
   - name: FP16/person-detection-0102.xml
     size: 166533
-    sha256: e776b624b07255a4729f7cf231362238c9442a165fdcf6ba77129138f905b152
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0102/FP16/person-detection-0102.xml
+    sha256: e9ccb2533747c61bf49960403c8315da139145e8dd08c7008f9e07e6a677eda1
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0102/FP16/person-detection-0102.xml
   - name: FP16/person-detection-0102.bin
     size: 3634686
     sha256: d1161cd50de36af9271f1cb43576daf4b6bc630dc4c8a878b23aebb9ab655091
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0102/FP16/person-detection-0102.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0102/FP16/person-detection-0102.bin
   - name: FP16-INT8/person-detection-0102.xml
     size: 473669
-    sha256: c46230af4fa9310a3328e7690ee710fe610cff84a5a288bdf32d027072689d85
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0102/FP16-INT8/person-detection-0102.xml
+    sha256: 6ccdacf9e2c22267fed9d8d042f4a5bde3c53aaa5872d163d871d6e489f821c9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0102/FP16-INT8/person-detection-0102.xml
   - name: FP16-INT8/person-detection-0102.bin
     size: 1921683
     sha256: 2910df765ce1c5e412952d9168b9d8aa5f4ec213a5aad6450be8ee1f95e54dfb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0102/FP16-INT8/person-detection-0102.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0102/FP16-INT8/person-detection-0102.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0106/model.yml
+++ b/models/intel/person-detection-0106/model.yml
@@ -18,19 +18,19 @@ task_type: detection
 files:
   - name: FP32/person-detection-0106.xml
     size: 926028
-    sha256: 761092e41e37689c2b781b6c8c6f9ea93f2911a290a805b1f211e04ef6f44a29
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0106/FP32/person-detection-0106.xml
+    sha256: 9fb9534f9bc3a123ae5167c1b04f4279c09f2e775c19501a873f765d93758414
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0106/FP32/person-detection-0106.xml
   - name: FP32/person-detection-0106.bin
     size: 276524288
     sha256: bbe4d3e579f013dd45e98c5d1b71bf24b8e0a707e50e6a8f0e3180f47c53b27e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0106/FP32/person-detection-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0106/FP32/person-detection-0106.bin
   - name: FP16/person-detection-0106.xml
     size: 925013
-    sha256: 3869ae645b4110d7a44761948dffaeb234663fc4313d20dfd1c11dbab326f9db
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0106/FP16/person-detection-0106.xml
+    sha256: d58f01ffe089dd7b472037e8280ffd6cc9d86116d1800a4122e52809c033d250
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0106/FP16/person-detection-0106.xml
   - name: FP16/person-detection-0106.bin
     size: 138262516
     sha256: be2fd576c4818126d33a08f6cc3f56b23f10ac049c6cca7961a89ebfe5441b27
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-0106/FP16/person-detection-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-0106/FP16/person-detection-0106.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0005/model.yml
+++ b/models/intel/person-detection-action-recognition-0005/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0005.xml
-    size: 657370
-    sha256: 7ec72a5d69ebc18fe047d4b5b3cba69e16bacb79ccdab080cf33a55da1544681
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
+    size: 657372
+    sha256: 45bf2f2833c643b2f76788dfb9c35aed573edf80fb86568cf7c4a2ad4cc2f301
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
   - name: FP32/person-detection-action-recognition-0005.bin
     size: 7800360
     sha256: 2982e6c2683229a450d674c362cc11abd640dce4e39e95925c7957a28011f147
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
   - name: FP16/person-detection-action-recognition-0005.xml
-    size: 657127
-    sha256: 90d076629ebeca6051cf008dadc1af2519f7d2ccb9cfc580afe72c0b2c915e9f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
+    size: 657128
+    sha256: b54530fdba1355b9b36d0dfab94e7e65da4b99cccd2380d343a1d03fe7118531
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
   - name: FP16/person-detection-action-recognition-0005.bin
     size: 3900234
     sha256: 159f52fdd28bef5a3ef3edd998fe08fd4d51c4a3fb2b9134b82a09f6a252c378
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
   - name: FP16-INT8/person-detection-action-recognition-0005.xml
-    size: 1812045
-    sha256: f8213c5fe0bf9df60466933c6e77c7b896d7330127b7b262f6b95e61c86c3696
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0005/FP16-INT8/person-detection-action-recognition-0005.xml
+    size: 1812017
+    sha256: 4a3165d21fb7904cf7c7bb613e665f4fb33c5f1922de64c7cd92ba15df6fe58a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0005/FP16-INT8/person-detection-action-recognition-0005.xml
   - name: FP16-INT8/person-detection-action-recognition-0005.bin
     size: 2055078
     sha256: ba3cc63889f30598af5eebf41e6ce6d553764dbe3d38ecf3392cbdfebfd2e5a6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0005/FP16-INT8/person-detection-action-recognition-0005.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0005/FP16-INT8/person-detection-action-recognition-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0006/model.yml
+++ b/models/intel/person-detection-action-recognition-0006/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0006.xml
     size: 754510
-    sha256: da715890fe3e0db0937b3a378ecc5d926bd63936024ac2edc9b234315be7dc53
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.xml
+    sha256: 7ad0a92f09bfe24f1e9830927e750038adc62944e1ad93035dada4deea9190ce
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.xml
   - name: FP32/person-detection-action-recognition-0006.bin
     size: 7458352
     sha256: 888d01b994c58baa65ab20b948439620222512ee49d45e6f443f271d7637f603
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.bin
   - name: FP16/person-detection-action-recognition-0006.xml
     size: 754232
-    sha256: c7194f03fdc4ca69f665d569470d571185e54e4ce5697f3bf495de1789b837d2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.xml
+    sha256: 1447377649eb11bfec463e295892be20da3e9e0900e15e2716b3dfb391ff29d3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.xml
   - name: FP16/person-detection-action-recognition-0006.bin
     size: 3729222
     sha256: 6752e639f4035582f77209a6030cded78ec4869b628ad9cdde1907d8cfd13368
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.bin
   - name: FP16-INT8/person-detection-action-recognition-0006.xml
-    size: 2034882
-    sha256: 12b6d014d8875fc7b21d8e284f8459f8e6451f89c8ae7bd44bf173a883d65883
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0006/FP16-INT8/person-detection-action-recognition-0006.xml
+    size: 2034878
+    sha256: 7acf6bb79c77c1c30641b2343d56aaa1ecc7c800c1b0249097ed3528cfbb2d38
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0006/FP16-INT8/person-detection-action-recognition-0006.xml
   - name: FP16-INT8/person-detection-action-recognition-0006.bin
     size: 1982776
     sha256: 79ae53bf1f80644eee9f59d80cba1c27473419ee1c21e40fcd9ead8568364c5d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-0006/FP16-INT8/person-detection-action-recognition-0006.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-0006/FP16-INT8/person-detection-action-recognition-0006.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-teacher-0002/model.yml
+++ b/models/intel/person-detection-action-recognition-teacher-0002/model.yml
@@ -18,28 +18,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-teacher-0002.xml
-    size: 657379
-    sha256: c335d5a329257de0eda146246577d2482c9baebe963f1dc8422aae00d2f02ba9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
+    size: 657380
+    sha256: fb84fdf67b583c0439066c78824ac3086b8dfdd3300393c4482474c457948d6a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
   - name: FP32/person-detection-action-recognition-teacher-0002.bin
     size: 7800360
     sha256: ebe9c7cdca28a408302b3b1f241afdc670abc251bd692c13a3140c78b08b0498
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
   - name: FP16/person-detection-action-recognition-teacher-0002.xml
     size: 657136
-    sha256: a29279bc9ca5ec2ac679c1760f179365727ededb303b0beacd3f9f47c3611a8a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
+    sha256: a969b06746d619331354063307384fa2d00c8ae881ab4a6299ecd40cca8557e3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
   - name: FP16/person-detection-action-recognition-teacher-0002.bin
     size: 3900234
     sha256: 190e9b71ae02e022c6afe2dc9fb59939066e046234ff35f4ceab6ddfabab7883
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
   - name: FP16-INT8/person-detection-action-recognition-teacher-0002.xml
-    size: 1812308
-    sha256: c41fcb3d876d9d6599237cc7845da0adee4c79a60e5133f6474a828a6407ce4c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-teacher-0002/FP16-INT8/person-detection-action-recognition-teacher-0002.xml
+    size: 1812280
+    sha256: ef1f0e3380cce06509c8530102b709d0a3e5848db252541a6c01a386904e0cb1
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-teacher-0002/FP16-INT8/person-detection-action-recognition-teacher-0002.xml
   - name: FP16-INT8/person-detection-action-recognition-teacher-0002.bin
     size: 2055070
     sha256: 90e00113ddc993a70dd760602a83cb79cc2847070a3ae010dcb2f63ee8d484b3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-action-recognition-teacher-0002/FP16-INT8/person-detection-action-recognition-teacher-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-action-recognition-teacher-0002/FP16-INT8/person-detection-action-recognition-teacher-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-asl-0001/model.yml
+++ b/models/intel/person-detection-asl-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-asl-0001.xml
     size: 577331
-    sha256: 37c59821882b4b95eab13c9b402274e3a2012217b6844b460ca26dcec0c57914
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-asl-0001/FP32/person-detection-asl-0001.xml
+    sha256: d32ac23244f553a9b91cf011a0a2868ddee6d9e81eb3b8d3c06ed7e71f7a7588
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-asl-0001/FP32/person-detection-asl-0001.xml
   - name: FP32/person-detection-asl-0001.bin
     size: 4026560
     sha256: a4b66bac54bdefe542e1a646f62bb77dc88d506ef538e41a326eb1b538586298
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-asl-0001/FP32/person-detection-asl-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-asl-0001/FP32/person-detection-asl-0001.bin
   - name: FP16/person-detection-asl-0001.xml
     size: 577174
-    sha256: e1e53634f22d59c671084885a2ff81c5813f25ebcbef6c0db44fef3efa30388f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-asl-0001/FP16/person-detection-asl-0001.xml
+    sha256: 9339e2a80954987b1c9056c5d547b8fb7934d9847fd841f762ba2798c0ef106e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-asl-0001/FP16/person-detection-asl-0001.xml
   - name: FP16/person-detection-asl-0001.bin
     size: 2013592
     sha256: c4701dfddd0ab7ec4b699b5a27a077ab178785219d1551f31fe231b79db4586a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-asl-0001/FP16/person-detection-asl-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-asl-0001/FP16/person-detection-asl-0001.bin
   - name: FP16-INT8/person-detection-asl-0001.xml
     size: 1204270
-    sha256: cb07e4118ac7f7eadda648d00bb9448fd7788b962871a8f066c1f1f4e2071f61
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.xml
+    sha256: 7215ad4b62b8ee3ae0924e8288e6b4de599e5723d81bc2a18b12132bc86dcbf6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.xml
   - name: FP16-INT8/person-detection-asl-0001.bin
     size: 1058520
-    sha256: 325307068760a5131f99045047ef70cccb9fb03f5a3d56fca063a968b9ff99f8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.bin
+    sha256: b3c9cec655f44e132bd044dc57314827d237b799d115445964e8b08159cd0d49
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-raisinghand-recognition-0001/model.yml
+++ b/models/intel/person-detection-raisinghand-recognition-0001/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-raisinghand-recognition-0001.xml
-    size: 657376
-    sha256: 96e419072878940b0df830ca357079532fad00884db6e25942311f8e8f6de104
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
+    size: 657377
+    sha256: e07dab419caa4a13fe792c037b180cb4698290df14dff63bbd70ddb18cad4769
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
   - name: FP32/person-detection-raisinghand-recognition-0001.bin
     size: 7799848
     sha256: 5183cc9d4d71e208a2cc70db9ea98bf14657d07b2bfafd050aeae9687e4359c4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
   - name: FP16/person-detection-raisinghand-recognition-0001.xml
     size: 657133
-    sha256: 85b1ab13a4d08d5673c43bdaf8599eb02a3f9cd48b88a0cccd4969f17763abe2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
+    sha256: fc626268b09ed4c60c18090b2cb20213f6d8c2e7b169fe04334f75b1e176e13a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
   - name: FP16/person-detection-raisinghand-recognition-0001.bin
     size: 3899978
     sha256: 601543473374722d45eb56b3aa8f7f250f33e1bb548d63e392332441e97c87d8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
   - name: FP16-INT8/person-detection-raisinghand-recognition-0001.xml
-    size: 1812272
-    sha256: 955df45881504886894f13e2d7572947dec9d638424f89fb22541ffaeb4a4134
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-raisinghand-recognition-0001/FP16-INT8/person-detection-raisinghand-recognition-0001.xml
+    size: 1812255
+    sha256: 7d5f2a5877d30ef848e3ca50fffd619979b1df1beb139e8c52b1bbc8e712275e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-raisinghand-recognition-0001/FP16-INT8/person-detection-raisinghand-recognition-0001.xml
   - name: FP16-INT8/person-detection-raisinghand-recognition-0001.bin
     size: 2054948
     sha256: 495844e53b0680750535abf5fb754647b0e5d6013b6493417471bd12b641f732
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-raisinghand-recognition-0001/FP16-INT8/person-detection-raisinghand-recognition-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-raisinghand-recognition-0001/FP16-INT8/person-detection-raisinghand-recognition-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0002/model.yml
+++ b/models/intel/person-detection-retail-0002/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-retail-0002.xml
     size: 267874
-    sha256: 3d505d88f3b7d2d48cd6751d90abe664a5cd9252bd9d386fe3c6737e2b4c6ba8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
+    sha256: 5e5bb7010bf62bd8a9a0ce9aa188256f1a5e9cdc37706ab3101d7a47c8c53221
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
   - name: FP32/person-detection-retail-0002.bin
     size: 12976100
     sha256: 8150eb7ea3352abb272276deb3ce64d0414464e9f4bf02739ec4f2770b8acb75
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
   - name: FP16/person-detection-retail-0002.xml
     size: 267751
-    sha256: f1cdba09b2a22d88fa1e2e06f1efd60793f246361925854a821dd68b40e8c5eb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
+    sha256: 4f84c39da43a81185ec6390ad8f1ae90187cf10fca8eb3cbe2118132aa82507a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
   - name: FP16/person-detection-retail-0002.bin
     size: 6488130
     sha256: 32008b134ea50eb70a4f97d74562a0a2c542d3c30f19a5d7ef1b57e8615d7039
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
   - name: FP16-INT8/person-detection-retail-0002.xml
     size: 740295
-    sha256: c5d4e38b968c4b6e985f3d09790c86ea44e815d9fbdfee60276a026c895ac53f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0002/FP16-INT8/person-detection-retail-0002.xml
+    sha256: 4167c6958de4dd257da39a6d8ba15e6e40daf8d49cd2aebc86dead85d3bbecae
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0002/FP16-INT8/person-detection-retail-0002.xml
   - name: FP16-INT8/person-detection-retail-0002.bin
     size: 3298356
     sha256: 9946108061a67e67385a2a9dca6b40af9e5a1b1f21bd0bdeee768000cc398acb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0002/FP16-INT8/person-detection-retail-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0002/FP16-INT8/person-detection-retail-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0013/model.yml
+++ b/models/intel/person-detection-retail-0013/model.yml
@@ -17,28 +17,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-detection-retail-0013.xml
-    size: 357047
-    sha256: 0a545bae6a0df680cae509b349a84088b3b9a7e574e890d133d6532402ced63c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
+    size: 357048
+    sha256: 0a31d1ac55a665ef144c5b257b101adbf752ed42f255313ef038088831152978
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
   - name: FP32/person-detection-retail-0013.bin
     size: 2891364
     sha256: 6f09cb7061328942f9d5e9fc81631a4234be66a26daa50cd672d4077ee82ad44
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
   - name: FP16/person-detection-retail-0013.xml
-    size: 356892
-    sha256: 70e80da1bc2441f37c1e60296a0c6148eca8cf6ade17f6bce9bea751731d4f36
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
+    size: 356893
+    sha256: f39baf2b4fd6e80a0e20c87a300cdcbb2ab06d78ad020e628a45c7cdfed3cee6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
   - name: FP16/person-detection-retail-0013.bin
     size: 1445736
     sha256: 56eeccbeb3f27144046edacb95b459d60f3930f54051ef5b9e5253923c07b672
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
   - name: FP16-INT8/person-detection-retail-0013.xml
     size: 981016
-    sha256: 055cce0c974d56dff52732059e4b69787678339fab539a44a31dea32bdcab833
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0013/FP16-INT8/person-detection-retail-0013.xml
+    sha256: b0ff299eb4f3743febd778b36ae5266ba66152b790a01c12aeaf8bbfd1865458
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0013/FP16-INT8/person-detection-retail-0013.xml
   - name: FP16-INT8/person-detection-retail-0013.bin
     size: 770362
     sha256: 5d8c63480b116846e3354abe8d4e00406f9b0fe9b3a8d224a907dfb2fc506c62
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-detection-retail-0013/FP16-INT8/person-detection-retail-0013.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-detection-retail-0013/FP16-INT8/person-detection-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0248/model.yml
+++ b/models/intel/person-reidentification-retail-0248/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0248.xml
     size: 428598
-    sha256: e5e6e135d20b684ca86bc735a27f032c91a29c8886018b4a04ceeeb4b0bbcfbc
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0248/FP32/person-reidentification-retail-0248.xml
+    sha256: 48efa816bcaf7e53859d974be6f6281bb9ff0543a94c0901a66bb3e186d35e64
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0248/FP32/person-reidentification-retail-0248.xml
   - name: FP32/person-reidentification-retail-0248.bin
     size: 728532
     sha256: 1418aaaaac4fd890cc4560c7b1f827c9593fe8939600dd5196e5f07756bf904f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0248/FP32/person-reidentification-retail-0248.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0248/FP32/person-reidentification-retail-0248.bin
   - name: FP16/person-reidentification-retail-0248.xml
     size: 428387
-    sha256: 84fe8aea09f478489dd9630bbe887b41fe2f7fb2a4d44d5aba413dd8c8ce27b2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0248/FP16/person-reidentification-retail-0248.xml
+    sha256: c6ca0a35b570d536d5051626f46174ae9ac84ae7229098b3fbdf789e331e170e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0248/FP16/person-reidentification-retail-0248.xml
   - name: FP16/person-reidentification-retail-0248.bin
     size: 364300
     sha256: d54f4dbc371525de4968b3f82c5a1383bd43c4426f08a7d1c44a9fbb53c6a95e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0248/FP16/person-reidentification-retail-0248.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0248/FP16/person-reidentification-retail-0248.bin
   - name: FP16-INT8/person-reidentification-retail-0248.xml
     size: 1311843
-    sha256: a728f8e60f0e4987b1e742e808100e11cea689ff96b6f309674f7f56e8966ffe
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0248/FP16-INT8/person-reidentification-retail-0248.xml
+    sha256: 00b9432f17ba7abd5941ebc7aabcdfbfe723c3cfedcca8b9e03bd356d483bb49
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0248/FP16-INT8/person-reidentification-retail-0248.xml
   - name: FP16-INT8/person-reidentification-retail-0248.bin
     size: 214400
-    sha256: 841e389903fd8ec0c8d43f81bda2bf38ad56c2ef4ce1efd0160da605610a0170
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0248/FP16-INT8/person-reidentification-retail-0248.bin
+    sha256: 022f3e25617ad75c28369113c91e4ce1d607c8ecf60d6e5c1d0ebf64ff550f3b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0248/FP16-INT8/person-reidentification-retail-0248.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0265/model.yml
+++ b/models/intel/person-reidentification-retail-0265/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0265.xml
     size: 434572
-    sha256: 82d12890bfe1e26f539f849276b5a8fe529eb6d11c468b7b92872488266ee178
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0265/FP32/person-reidentification-retail-0265.xml
+    sha256: 506011e6956448b66d559db4f34f54a51ca89e1622588703de77a1e3272a8b61
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0265/FP32/person-reidentification-retail-0265.xml
   - name: FP32/person-reidentification-retail-0265.bin
     size: 8357596
     sha256: 76d28f4a95fc53d0f7859b7d8312d20c473573cd42b41722d136961a0c6254e9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0265/FP32/person-reidentification-retail-0265.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0265/FP32/person-reidentification-retail-0265.bin
   - name: FP16/person-reidentification-retail-0265.xml
     size: 434454
-    sha256: a5e43f04b162ffd351a203ba262c56aaf4e04ec6d393c0c5290f577f4895d479
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0265/FP16/person-reidentification-retail-0265.xml
+    sha256: bc0b9e59b2985f04d4f30ecbc0e6f721f6471ccb2567bcafd3c16b535d5f4eaa
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0265/FP16/person-reidentification-retail-0265.xml
   - name: FP16/person-reidentification-retail-0265.bin
     size: 4178912
     sha256: 9cae831102140a9f96e4fff03ac7febb364819677a429c177ad5619eaefa3e31
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0265/FP16/person-reidentification-retail-0265.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0265/FP16/person-reidentification-retail-0265.bin
   - name: FP16-INT8/person-reidentification-retail-0265.xml
     size: 1360415
-    sha256: 334092db96b2804aa0c07f8bcc6e94d0d1b5e4e1ae21f7509fcfcf16bd22a891
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0265/FP16-INT8/person-reidentification-retail-0265.xml
+    sha256: c4faed7907baec9149fef7e5954b3d294ce21f3cfda18dd0511858ecf75033bd
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0265/FP16-INT8/person-reidentification-retail-0265.xml
   - name: FP16-INT8/person-reidentification-retail-0265.bin
     size: 2202906
-    sha256: d82a1c9ba023d45d37b3b0b959495004c3557a654605dd28f416f4365adb4604
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0265/FP16-INT8/person-reidentification-retail-0265.bin
+    sha256: eaf97b4cc6d15d5afa5b5610a3a5b9a40d3aee7aaa57c1d390390713cf7986c0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0265/FP16-INT8/person-reidentification-retail-0265.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0267/model.yml
+++ b/models/intel/person-reidentification-retail-0267/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0267.xml
     size: 433735
-    sha256: d3d5964e40f42ef80294e4b6f69c2daff2e6b1e0c4d957dbf21ada249566bb81
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0267/FP32/person-reidentification-retail-0267.xml
+    sha256: eae7a13ecf543d0d1bb96de38c872ea9338b5810347dcab71a0843302343d97e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0267/FP32/person-reidentification-retail-0267.xml
   - name: FP32/person-reidentification-retail-0267.bin
     size: 2362232
     sha256: 9007515925bd6926b3387a76bb8efcd805749180e5fc74cbe4e9751ac992f3c9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0267/FP32/person-reidentification-retail-0267.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0267/FP32/person-reidentification-retail-0267.bin
   - name: FP16/person-reidentification-retail-0267.xml
     size: 433422
-    sha256: 742e1e301bfb5d02861dddcc5ad57e9651497fcc98ab5f17d1b8dc1688732202
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0267/FP16/person-reidentification-retail-0267.xml
+    sha256: d71a908cceedcb478f472ba34482df659364ba64b22921c562b519e36ad68e78
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0267/FP16/person-reidentification-retail-0267.xml
   - name: FP16/person-reidentification-retail-0267.bin
     size: 1181230
     sha256: 51373e025ef47fd1aa2c9dc0a0808426be049fd4b6abc150edbf67cf2372dce1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0267/FP16/person-reidentification-retail-0267.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0267/FP16/person-reidentification-retail-0267.bin
   - name: FP16-INT8/person-reidentification-retail-0267.xml
-    size: 1357417
-    sha256: 224aa788e25c37dbac2cb7cd5821d63243959bf12c745a3006efa1e956f4fa22
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0267/FP16-INT8/person-reidentification-retail-0267.xml
+    size: 1357487
+    sha256: 002d71e4a7f0b028d8309fde47b6dc1a3a35c8611fe98dc29248a34f2dbe9fa9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0267/FP16-INT8/person-reidentification-retail-0267.xml
   - name: FP16-INT8/person-reidentification-retail-0267.bin
-    size: 647634
-    sha256: 2043a952a687441622c326208ca35055a5be5a916a5b68056c14a85d1a1b37b0
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0267/FP16-INT8/person-reidentification-retail-0267.bin
+    size: 653170
+    sha256: 45a3f2c5565a33a57137bd9d8b4229f6e688118e5d8b64e52fefe2d287721ff3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0267/FP16-INT8/person-reidentification-retail-0267.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0270/model.yml
+++ b/models/intel/person-reidentification-retail-0270/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0270.xml
     size: 433852
-    sha256: 1342acf05a86d869c5e85b758412b80c5d92c2c18e75fdc0631e3d00d9ef7f0d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0270/FP32/person-reidentification-retail-0270.xml
+    sha256: 6025ee62390251c0b84751097ebdb28b4ec36f318c392f00fa8f5cee2188882e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0270/FP32/person-reidentification-retail-0270.xml
   - name: FP32/person-reidentification-retail-0270.bin
     size: 4905096
     sha256: 8e3daad4139b7f38f99c8d305f970bfeff80ed8e0dbc5192500be2feee7acddf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0270/FP32/person-reidentification-retail-0270.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0270/FP32/person-reidentification-retail-0270.bin
   - name: FP16/person-reidentification-retail-0270.xml
     size: 433687
-    sha256: 9e28da67d457be371b648264e086ec61b6510b5cbfe1ebeba6ea2149a6ef1905
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0270/FP16/person-reidentification-retail-0270.xml
+    sha256: ade3eb2a8fb76caaa410f67b84f53e0d97691c18058f231c132e208d3246d372
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0270/FP16/person-reidentification-retail-0270.xml
   - name: FP16/person-reidentification-retail-0270.bin
     size: 2452678
     sha256: e927d5ff87d72a2fd7b9140630a94c04a728e1a751638e69cf36509ae0aa1e0b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0270/FP16/person-reidentification-retail-0270.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0270/FP16/person-reidentification-retail-0270.bin
   - name: FP16-INT8/person-reidentification-retail-0270.xml
     size: 1357942
-    sha256: 6f8068b180447bf5db2d946d591f676f7f19a06ca7bc9e6b2c765c3867d0b94a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0270/FP16-INT8/person-reidentification-retail-0270.xml
+    sha256: 256e0e6887f773d748cb882674049a2022856afcf173967a3776c477eaf5a6aa
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0270/FP16-INT8/person-reidentification-retail-0270.xml
   - name: FP16-INT8/person-reidentification-retail-0270.bin
     size: 1311288
-    sha256: d098a474509fde7bd965cd189b819083793fdec34de21fe2467976b2cd6b26f4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-reidentification-retail-0270/FP16-INT8/person-reidentification-retail-0270.bin
+    sha256: 39168e8d743ea9f355a32014b8bf27d93534650efe9b6c56e9da051a3bc08182
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-reidentification-retail-0270/FP16-INT8/person-reidentification-retail-0270.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
@@ -19,28 +19,28 @@ description: >-
 task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.xml
-    size: 355018
-    sha256: 8a4cd26fe4f4fe90741dfde563cd86a58a8c48c8d2ec2f4bd8c176b78a4bf1b5
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
+    size: 355020
+    sha256: 63648101d22a16b747dd84746b710d5c6904e835e2772ae457638adb385a4768
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.bin
     size: 4713980
     sha256: 178e05f0635b0ee35b577a9dd31ea6da2a2a842635793f1ad18907d00f3a966a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.xml
-    size: 354844
-    sha256: f9451dc4d582a50a6a4a50719ffa2386805b5084d32e14f298a0db4765b78e7d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
+    size: 354846
+    sha256: 8ff7dc29ae70931ea96cca917dcddcd4c5e084a502c9ee18c1771ded8dc77465
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.bin
     size: 2357042
     sha256: a074ff0cad298ed9c35d0ce6ed58e09ee05216b907c97e6bb50f1b77a046bcfd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-0078.xml
     size: 1011087
-    sha256: e0c601e5221d86e7a3bfbfd8082ed4c5ffea4227368737bed1c11591d54465f3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-0078/FP16-INT8/person-vehicle-bike-detection-crossroad-0078.xml
+    sha256: 7b3c59e8c40c2aab75ea04d7a0fbf1f03cf0a68e6a247915ddf677042165a14e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16-INT8/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-0078.bin
     size: 1228809
     sha256: faf5ead607a011f5b15fd77e885565215fff6b0600c234f28369d509bbfab673
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-0078/FP16-INT8/person-vehicle-bike-detection-crossroad-0078.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16-INT8/person-vehicle-bike-detection-crossroad-0078.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
@@ -19,27 +19,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.xml
     size: 192020
-    sha256: 800bb875940d6c96dc028faa149626c415156ea633bb56190ec9a1a5b6a2a26e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
+    sha256: 7a89006865a57a02cef2f49dffbca280df4479b0a3c979d9913765ea3aa4076f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.bin
     size: 11548044
     sha256: 50d7ecad9439c021a3a76c7367b3a63bb0023ea3fa1601d357bfd74688afc8e3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.xml
     size: 191903
-    sha256: eae4f88ccdf7da8365f308d64bc4a4a5190843fe2d5f49f8da500021d2892f19
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
+    sha256: 6e4cf6015890245db5e166bdb6aae946907d10e001c2cfd189f87acd63cf0015
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.bin
     size: 5774094
     sha256: cd8b513c4c9c655e3a141e1c3fdf6b88e1523d14f0534885575972c264a704b7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-1016.xml
     size: 533098
-    sha256: e4fd7f8e09ec650da302b23173a06eb1f47619f974d4242703addbd63c0d60d0
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-1016/FP16-INT8/person-vehicle-bike-detection-crossroad-1016.xml
+    sha256: cfb526d44350693212676bf411dcc926d07d30528c450823c09803b4b0d394ec
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16-INT8/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-1016.bin
     size: 3024967
     sha256: 2cc45b5f6acfc4f1634c3330a98a115abc386b2b2ca7506441faa17d13e59ba4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/person-vehicle-bike-detection-crossroad-1016/FP16-INT8/person-vehicle-bike-detection-crossroad-1016.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16-INT8/person-vehicle-bike-detection-crossroad-1016.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/product-detection-0001/model.yml
+++ b/models/intel/product-detection-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/product-detection-0001.xml
     size: 267000
-    sha256: 213078f62f9a4c15b27001e3bdb3f42079320c8b77940291e47e3c41f39ff831
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/product-detection-0001/FP32/product-detection-0001.xml
+    sha256: 503cabb801aac2dc70b4a117cc6867f4d395cf9dd73d0dc36ebc1125bc98ca6f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/product-detection-0001/FP32/product-detection-0001.xml
   - name: FP32/product-detection-0001.bin
     size: 12850076
     sha256: 57f7eacfb44827b62f1a26aeb766ae16774f5f22f226e3b66057224fc9f7976f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/product-detection-0001/FP32/product-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/product-detection-0001/FP32/product-detection-0001.bin
   - name: FP16/product-detection-0001.xml
     size: 266815
-    sha256: ae40c5fc0ba28dea88fea05d2e8c53296be0916aaa27237516bc630dd071c55c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/product-detection-0001/FP16/product-detection-0001.xml
+    sha256: 641296b21a6d72934e319b0af9b6d9a8eabb00faff8d7ee06dd1e26e32196c67
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/product-detection-0001/FP16/product-detection-0001.xml
   - name: FP16/product-detection-0001.bin
     size: 6425110
     sha256: 4fc35731862955f24b15d4ce89593b7c94d7cbd3affb058fb9bd2f21df9100c6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/product-detection-0001/FP16/product-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/product-detection-0001/FP16/product-detection-0001.bin
   - name: FP16-INT8/product-detection-0001.xml
     size: 698204
-    sha256: 9e04e53278aa5657119292f1b22c4b722a20fb1d3396b8a97bcf233ae6f23654
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/product-detection-0001/FP16-INT8/product-detection-0001.xml
+    sha256: 04fdd13e657be86c18c5d07a196816af0a20b3ebf42331bdb8e833831f399996
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/product-detection-0001/FP16-INT8/product-detection-0001.xml
   - name: FP16-INT8/product-detection-0001.bin
     size: 3364229
     sha256: 5697831f2e88740c9a07544ff2b6a98e02d0daaa52db1093ae4d788227030138
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/product-detection-0001/FP16-INT8/product-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/product-detection-0001/FP16-INT8/product-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
@@ -18,19 +18,19 @@ task_type: classification
 files:
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
     size: 93520
-    sha256: b651bdec378e83d03677530a0c2600dfe0fb8b4bf2dbba625db2334b2c23a153
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
+    sha256: 96421eb0e780452d4f72403a0a6b430ecbe16707f08912ede151c6e746be5037
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 4190944
     sha256: e73467a8a6c5dcd1e8a3715c6be1bc39196da1a35cd1f92b144187abc3824a91
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
     size: 93494
-    sha256: dead20fe824e9079e0193baabf7c53586ed3469cc5aec51d1674629a16005e68
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
+    sha256: 83bc260a9dc58d91d777c25d9b4560ed1c5e339c0b7b8f544c1e339ea1d5a8c5
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 2782080
     sha256: 57a2767a0dd7eddb59830b93a01ce5f6ef0906abb252602f89f7dd28071a6dd5
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/resnet50-binary-0001/model.yml
+++ b/models/intel/resnet50-binary-0001/model.yml
@@ -18,19 +18,19 @@ task_type: classification
 files:
   - name: FP32-INT1/resnet50-binary-0001.xml
     size: 228267
-    sha256: e58f3c1dce046b8f8a9930c73c140a2e9a254038cc8e649e60deff8a654e6380
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
+    sha256: 54cef9acbd162947951712555b3263e48d05cbae1ae24b64917492d5a3396df9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
   - name: FP32-INT1/resnet50-binary-0001.bin
     size: 22112976
     sha256: 4990997515b220ea4f1e16609b93646a99d73c08af1b997b4f6dbc6a528fb834
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
   - name: FP16-INT1/resnet50-binary-0001.xml
     size: 228173
-    sha256: e10ff431e7fa095e0c28ce1d24028d6baf594b30e03ca6ea50a83796c5f8d7da
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
+    sha256: 48886d94a762b039fa00dba6b474f3e88be2beade0350bdf6253997c109d09c2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
   - name: FP16-INT1/resnet50-binary-0001.bin
     size: 12348784
     sha256: cb98ba6a96cc46d1eae9786e964b1fad2b41d74470c2032a1961fb66ece91332
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/road-segmentation-adas-0001/model.yml
+++ b/models/intel/road-segmentation-adas-0001/model.yml
@@ -19,27 +19,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/road-segmentation-adas-0001.xml
     size: 357646
-    sha256: 15e3e8cd4723e00a6e49193839eae76e1937324e7c2659b0a2d2c9448b9b800f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
+    sha256: c78d4d83245e999654598b6aea4a010695a704fe385dea2e809957ac25895ca9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
   - name: FP32/road-segmentation-adas-0001.bin
     size: 737200
     sha256: ae43e7d5dd1ad62cbe62a2d8aa5dd3721b7581f26763ba3c69660da2a91c3d87
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
   - name: FP16/road-segmentation-adas-0001.xml
     size: 357491
-    sha256: bebc9eb256dd9b70297f6793468c827785d9351e6e68e8bf8f280ea45b75a1ea
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
+    sha256: 81fee6f0909fb6196b2c898d338161eb9cc30411bcdb3a59aca4c6f3e5dc579c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
   - name: FP16/road-segmentation-adas-0001.bin
     size: 368632
     sha256: ddbc38aaee27ed8166d1190519380a91cdea8cf7f4bc71585d939fd6ead6b159
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
   - name: FP16-INT8/road-segmentation-adas-0001.xml
     size: 1117249
-    sha256: 4b4d458e99d0b78839abbc3970446415ce3a7858dcc5cd590c85ed2c33b244a6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/road-segmentation-adas-0001/FP16-INT8/road-segmentation-adas-0001.xml
+    sha256: c471f291d895b14f779d9813f4f0a34bf1492f423e2b67fb30f2ae204b282a7d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/road-segmentation-adas-0001/FP16-INT8/road-segmentation-adas-0001.xml
   - name: FP16-INT8/road-segmentation-adas-0001.bin
     size: 212302
     sha256: 1a5aaba1ff8ff83f28f226af0d60de3fa8441ab270d832c35a2fbf36a02629d9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/road-segmentation-adas-0001/FP16-INT8/road-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/road-segmentation-adas-0001/FP16-INT8/road-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/semantic-segmentation-adas-0001/model.yml
+++ b/models/intel/semantic-segmentation-adas-0001/model.yml
@@ -20,19 +20,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/semantic-segmentation-adas-0001.xml
     size: 182122
-    sha256: b3814caf92d676cfef3255e979b5fde6370336d32fe212f37b353d5e5844f2e9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
+    sha256: 37de7af68c0372fbb8d6f13bf9549ebf220e3fe9b527f14b53e5d9d2101e7a38
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
   - name: FP32/semantic-segmentation-adas-0001.bin
     size: 26743564
     sha256: 6d2592c07c91ed1de76c683a2c5753c89f0a61c215bc553f2a6b30faa05b37ba
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
   - name: FP16/semantic-segmentation-adas-0001.xml
     size: 182041
-    sha256: 141533716e602a14f8dac98ba1eeca4a01a9458abc3babe444c34bc574955575
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
+    sha256: bd4fa04e92549ac3f827683c3aa24f2b993e07498fe5d469c78b232abe2d0d83
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
   - name: FP16/semantic-segmentation-adas-0001.bin
     size: 13371824
     sha256: a6366b6cd8e6456bdea4d2709e4d062c434a94cfabb62905dfbb4cd50b3df5d5
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
+  - name: FP16-INT8/semantic-segmentation-adas-0001.xml
+    size: 531125
+    sha256: d73df39e12e242f93fbd3598ff3ca82965ba2bbb1f19adca7ccd1987d4c5d21f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/semantic-segmentation-adas-0001/FP16-INT8/semantic-segmentation-adas-0001.xml
+  - name: FP16-INT8/semantic-segmentation-adas-0001.bin
+    size: 6757686
+    sha256: 62e42ac2a2f5270d82c1294ec8083e4e4d36abfe8271be9c80b453481aa31daa
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/semantic-segmentation-adas-0001/FP16-INT8/semantic-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1032/model.yml
+++ b/models/intel/single-image-super-resolution-1032/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1032.xml
     size: 75038
-    sha256: c040657e0372178ff3ec3266d671710d15e02ee4867e2473e8d1b9fc02b6996f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
+    sha256: 70dca8afc1d777cdc5a0a72fd08b482cab9057f9ae4542cd230cc0176d9b8a5f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
   - name: FP32/single-image-super-resolution-1032.bin
     size: 119436
     sha256: d09c215077e7a95d15636c79d006039ffaacfaf1889ea07668cbf21120295287
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
   - name: FP16/single-image-super-resolution-1032.xml
     size: 74969
-    sha256: b667c8a0d70d432f5e77acf61d72aaf53128d35c982572947e7aad560be27b79
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
+    sha256: 5327d4e08eac8832beee9f3b47cb9dc194f424b8cb5b16b1f79ffcd42a3831d0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
   - name: FP16/single-image-super-resolution-1032.bin
     size: 59762
     sha256: a52a4549011480d90246bbe6118718ee485c130480bbf5f7befdb3d5a2a1f057
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
   - name: FP16-INT8/single-image-super-resolution-1032.xml
-    size: 169929
-    sha256: 38d6769cf66f522d8a401ba26b91618c362153f9319454d85a1729546f1f1a71
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1032/FP16-INT8/single-image-super-resolution-1032.xml
+    size: 169937
+    sha256: 7e2a4b31e1c07b0c004ce9eb19e5f5641f5baa280a09d793357e095bf02f26f0
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1032/FP16-INT8/single-image-super-resolution-1032.xml
   - name: FP16-INT8/single-image-super-resolution-1032.bin
     size: 31046
     sha256: 1d682f21ba03adafd8d2e3d73def2133d69a39d4c6a8592c7d2f74804e2a6d65
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1032/FP16-INT8/single-image-super-resolution-1032.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1032/FP16-INT8/single-image-super-resolution-1032.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1033/model.yml
+++ b/models/intel/single-image-super-resolution-1033/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1033.xml
     size: 53136
-    sha256: e1b59f14f9e5c21857735f0139d9ef9cdc8c0e9a5643cd1a1b5d6025253e90b4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
+    sha256: 1295b0c647b6dddbb0c48d2820ed02819c60081013df4df663322f7c80a9bd57
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
   - name: FP32/single-image-super-resolution-1033.bin
     size: 121772
     sha256: 38d59d276acf2ebf3307d4079d1a0aeed23a45756f7174f0ac436298872519da
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
   - name: FP16/single-image-super-resolution-1033.xml
     size: 53097
-    sha256: 5e668f0e80ca33eb07a8458b0e1330e7bc4ca5085f9c3bcf4b3791ffe0ec5eb1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
+    sha256: 075d08862c3380473f0d7be673edbd895922af7b46af2c9f3ab785f4605424b3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
   - name: FP16/single-image-super-resolution-1033.bin
     size: 60930
     sha256: 94dccc9df4225512e1cf253413bad614abc862d9273be2ff1d8419524e27945e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
   - name: FP16-INT8/single-image-super-resolution-1033.xml
     size: 146187
-    sha256: 58aeb4220b8289a66ab1652aec3bc79ae0fb34caea0799d911d5d7e88df389a1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1033/FP16-INT8/single-image-super-resolution-1033.xml
+    sha256: de06fdb9f32cb5fa5e39cba78008dc8fcedc965cc63195a2b70c0af197fb50c6
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1033/FP16-INT8/single-image-super-resolution-1033.xml
   - name: FP16-INT8/single-image-super-resolution-1033.bin
     size: 31671
     sha256: a3996c564de5fe142b6e77a6f89fae671f5383db3b7dbe63043c3ddd0000bd7d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/single-image-super-resolution-1033/FP16-INT8/single-image-super-resolution-1033.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/single-image-super-resolution-1033/FP16-INT8/single-image-super-resolution-1033.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0003/model.yml
+++ b/models/intel/text-detection-0003/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-detection-0003.xml
     size: 203872
-    sha256: fa6f8940e3f64daa02f099ceb89452aa18788d9c2a4abec25c7a92b0b0ecb4c7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0003/FP32/text-detection-0003.xml
+    sha256: 0d332b970a8bfd6a62f4a5a3ab16f2e0102ee19d4b89187d24f5abb8823c9283
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0003/FP32/text-detection-0003.xml
   - name: FP32/text-detection-0003.bin
     size: 26986280
     sha256: 1e2d51382f34750d5c878195e2fdac3207c3de58e74ad56ea624ed9ed2e3efb8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0003/FP32/text-detection-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0003/FP32/text-detection-0003.bin
   - name: FP16/text-detection-0003.xml
     size: 203792
-    sha256: 262e15f11384d240625f520007f656a55be603042ea59d8031f679956a22cefe
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0003/FP16/text-detection-0003.xml
+    sha256: 5ba24ff719cf165f92fd08f71f0efd3b1fdd976568dc0997c2c5af6e15eb75b4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0003/FP16/text-detection-0003.xml
   - name: FP16/text-detection-0003.bin
     size: 13493056
     sha256: 30b6597325c90bdb48abd7873f71fb1d56f8233ff9d53305d177c2b9546b59a8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0003/FP16/text-detection-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0003/FP16/text-detection-0003.bin
   - name: FP16-INT8/text-detection-0003.xml
     size: 633212
-    sha256: 668458cd5ac1055f543c4c83fce83fb77a132cf311e0009889039d584b67a547
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0003/FP16-INT8/text-detection-0003.xml
+    sha256: fc52fd4661d3b335ff29519239e49826847dc4a4d57c56b4ff99eb0e0506fdf4
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0003/FP16-INT8/text-detection-0003.xml
   - name: FP16-INT8/text-detection-0003.bin
     size: 6894798
     sha256: 731ef9e22ff6f4905cac6720eef882a594564bf87e5698aeb99f3ea88b5c3666
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0003/FP16-INT8/text-detection-0003.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0003/FP16-INT8/text-detection-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0004/model.yml
+++ b/models/intel/text-detection-0004/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-detection-0004.xml
     size: 183641
-    sha256: c11d314f97cc8f3956b69098cdeecf8483b29a5d77f03f90ed2045b318c6d4ef
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0004/FP32/text-detection-0004.xml
+    sha256: e17451d5b0a254082a64ab7e11db69d366485e0afc1735fab92a9cf4d5f49f94
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0004/FP32/text-detection-0004.xml
   - name: FP32/text-detection-0004.bin
     size: 17312168
     sha256: 6da328c7675c2d1568cbb50b2c1643c8ba6194461b01b3461216c77e1258c7d5
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0004/FP32/text-detection-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0004/FP32/text-detection-0004.bin
   - name: FP16/text-detection-0004.xml
     size: 183510
-    sha256: a068d705e04ff010e640937965c084bfe056e3c2c646f153cb6bda201602fa34
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0004/FP16/text-detection-0004.xml
+    sha256: c79f67be38c15ac9463534c6472807e868d4eb7b82cfe053f5d4b0017ea6575a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0004/FP16/text-detection-0004.xml
   - name: FP16/text-detection-0004.bin
     size: 8656000
     sha256: 54f0a45a2b0903c59ebb4a68ceadac3037ac137bec7677dae1a5089dd164b40c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0004/FP16/text-detection-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0004/FP16/text-detection-0004.bin
   - name: FP16-INT8/text-detection-0004.xml
     size: 515583
-    sha256: 4e623b3205b57255e2aa6dd77e0410a96b59f1d49da38d15e48d8bc36401e61f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0004/FP16-INT8/text-detection-0004.xml
+    sha256: a1d86a141d2939edc736063aa9b7d53ff9334e39b1e3f097bb70efb5ec14146c
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0004/FP16-INT8/text-detection-0004.xml
   - name: FP16-INT8/text-detection-0004.bin
     size: 4475516
     sha256: 65518f1d75ed54963e8f4e13a5e36c7f845a2fb18db39bc0d695193e24e5220e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-detection-0004/FP16-INT8/text-detection-0004.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-detection-0004/FP16-INT8/text-detection-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-image-super-resolution-0001/model.yml
+++ b/models/intel/text-image-super-resolution-0001/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/text-image-super-resolution-0001.xml
     size: 11301
-    sha256: ed502d11ad8d088a1f6e8eadbc1b0a74b3e7476620249c0020fb34750887b712
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.xml
+    sha256: 4194b05a97f9c6338d5ae33d9f17e4f095c6b393e68e925d1924d4fb142de107
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.xml
   - name: FP32/text-image-super-resolution-0001.bin
     size: 10836
     sha256: b9405f0bce254c61f0487b0fa53c89621dc440cbc560c7dc92506900b62d6af5
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
   - name: FP16/text-image-super-resolution-0001.xml
     size: 11291
-    sha256: 1fc81d4aace2259b2635946b5247dfea91beda7576bef03bdb16fdb5798031a4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.xml
+    sha256: b3ca836a488e0c01f7cac9dfc477370a9ec8ef2df7f940f84aa7e66750db27ba
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.xml
   - name: FP16/text-image-super-resolution-0001.bin
     size: 5418
     sha256: f203818d73b933e5004aff85aeb84783dbf0be9e5c296d2995fc0678ff719e9c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
   - name: FP16-INT8/text-image-super-resolution-0001.xml
     size: 27379
-    sha256: 08bca7e2b86ccf14f26660c741a0c3d59ae0388216964c36ccbe6575d6ed876e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-image-super-resolution-0001/FP16-INT8/text-image-super-resolution-0001.xml
+    sha256: b9c827feaef68e9c161c584cef69351649ad8376b9694051a5750b4e87efcd15
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-image-super-resolution-0001/FP16-INT8/text-image-super-resolution-0001.xml
   - name: FP16-INT8/text-image-super-resolution-0001.bin
     size: 4224
     sha256: 8c1ec28bb810a0ad4de8d9c4d2c37939cfe1a64bbb36d4a9379815c154f8339f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-image-super-resolution-0001/FP16-INT8/text-image-super-resolution-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-image-super-resolution-0001/FP16-INT8/text-image-super-resolution-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-recognition-0012/model.yml
+++ b/models/intel/text-recognition-0012/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/text-recognition-0012.xml
     size: 98164
-    sha256: 757d32483da9f6760d0683468fb583f1dea329210120d8e128c212c05c2a4769
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-recognition-0012/FP32/text-recognition-0012.xml
+    sha256: 42ac45d8104d9c6f717623dbfde4e81d460e492779398d2cd73416e7a18ab7ef
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-recognition-0012/FP32/text-recognition-0012.xml
   - name: FP32/text-recognition-0012.bin
     size: 47470852
     sha256: b0d99549692baeea3e83709a671844a365b15bd40e36d9a5d3ef5368a69d2897
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-recognition-0012/FP32/text-recognition-0012.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-recognition-0012/FP32/text-recognition-0012.bin
   - name: FP16/text-recognition-0012.xml
     size: 98132
-    sha256: 82a7df605a5e36d81885c53e90d3f81357c8ba3cd87a91f483e57aeba0c80a18
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-recognition-0012/FP16/text-recognition-0012.xml
+    sha256: 961e7d3bfc0722746a6f6f57ae998fcab9e61ba5f6a52670bfb46f3a933cfd99
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-recognition-0012/FP16/text-recognition-0012.xml
   - name: FP16/text-recognition-0012.bin
     size: 23735478
     sha256: 33294d251264f6913f0cc1f8a6463318becb5b70757984b461e5a865921b8d65
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-recognition-0012/FP16/text-recognition-0012.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-recognition-0012/FP16/text-recognition-0012.bin
   - name: FP16-INT8/text-recognition-0012.xml
     size: 138140
-    sha256: a69734c4cea663810f1b2701e97627981bbd3c1ba007bf14e3193701211e47a9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-recognition-0012/FP16-INT8/text-recognition-0012.xml
+    sha256: 3fc75308c91d838aee3bbb27776f929b95ec2ae3e995e6206bc8b243944ea737
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-recognition-0012/FP16-INT8/text-recognition-0012.xml
   - name: FP16-INT8/text-recognition-0012.bin
     size: 18179110
     sha256: 4219d1198dc4a9ee32445e1fbd04beed4c0124f031a42613f79436808e69d1a2
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-recognition-0012/FP16-INT8/text-recognition-0012.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-recognition-0012/FP16-INT8/text-recognition-0012.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0002/text-spotting-0002-detector/model.yml
+++ b/models/intel/text-spotting-0002/text-spotting-0002-detector/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-spotting-0002-detector.xml
     size: 295114
-    sha256: 592c51e698036a6d92e04ceb33efd31663e072e465346c332954bfd9c874ac84
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-detector/FP32/text-spotting-0002-detector.xml
+    sha256: 1a79f422774e6c227f5a2fc0fc5a4487babf951e5b812860d80e3807c227058a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-detector/FP32/text-spotting-0002-detector.xml
   - name: FP32/text-spotting-0002-detector.bin
     size: 105906952
     sha256: 975d8baa7b01c134f0300474b01bf4ce900cea1e7b86ddf909881adda8a3afa9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-detector/FP32/text-spotting-0002-detector.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-detector/FP32/text-spotting-0002-detector.bin
   - name: FP16/text-spotting-0002-detector.xml
     size: 294998
-    sha256: e1577169f1ace020c660af579cc1e16aa3c7fbd958a6a1764f524070a1ceb579
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-detector/FP16/text-spotting-0002-detector.xml
+    sha256: af5961e0fdcf54a2191b1fd1f52c5ddfd2842d3cbbe5750d47d817255c25fa32
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-detector/FP16/text-spotting-0002-detector.xml
   - name: FP16/text-spotting-0002-detector.bin
     size: 52953542
     sha256: 0e0e92f8d014fc49d0150bc8cd163fcd35889095d347b3a04eb5444cb2ca9519
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-detector/FP16/text-spotting-0002-detector.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-detector/FP16/text-spotting-0002-detector.bin
   - name: FP16-INT8/text-spotting-0002-detector.xml
     size: 729598
-    sha256: 032e5f7c78dd5991ae1b0addb5e920c9cdcd4ba9830f56bddf066f281c52f6df
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-detector/FP16-INT8/text-spotting-0002-detector.xml
+    sha256: cf99816d093fd59c158ff448e6034211e5934bf6645ece12dcb83ac0c99e8938
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-detector/FP16-INT8/text-spotting-0002-detector.xml
   - name: FP16-INT8/text-spotting-0002-detector.bin
     size: 26678172
     sha256: 248645278fddd01d5d8900e42fa69390de72f7720f8a60a5a3631f7056edf1dd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-detector/FP16-INT8/text-spotting-0002-detector.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-detector/FP16-INT8/text-spotting-0002-detector.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0002/text-spotting-0002-recognizer-decoder/model.yml
+++ b/models/intel/text-spotting-0002/text-spotting-0002-recognizer-decoder/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/text-spotting-0002-recognizer-decoder.xml
     size: 32829
-    sha256: 169c5f0411ef35ac518c6f6e862b0b21ed23364d35851fa996cabce169e29c0c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP32/text-spotting-0002-recognizer-decoder.xml
+    sha256: 315f22ecb2fe5ce7091192a967fb796106a2fe87b6c6a126e20ab3ae0d39414b
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP32/text-spotting-0002-recognizer-decoder.xml
   - name: FP32/text-spotting-0002-recognizer-decoder.bin
     size: 2707796
     sha256: 1b3b9216b3af23b17be501f12ad59e6ebec87cc80d4e9f7772ed8106e5eef30d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP32/text-spotting-0002-recognizer-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP32/text-spotting-0002-recognizer-decoder.bin
   - name: FP16/text-spotting-0002-recognizer-decoder.xml
     size: 32816
-    sha256: 3624e078be6afc3e0a3ddf1b21e1f91885422207ede5b1a2c112074f05704e08
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16/text-spotting-0002-recognizer-decoder.xml
+    sha256: 1d17a46ca9a86cc52de25019e83c6d463e6c1967649d4a9c72973a5012d8d817
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16/text-spotting-0002-recognizer-decoder.xml
   - name: FP16/text-spotting-0002-recognizer-decoder.bin
     size: 1353992
     sha256: 5969ec497262d33ddfa8c6af357ff288fec76747fce5199b402c34a794d379ac
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16/text-spotting-0002-recognizer-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16/text-spotting-0002-recognizer-decoder.bin
   - name: FP16-INT8/text-spotting-0002-recognizer-decoder.xml
     size: 61375
-    sha256: c5f34da96702c63db97f0be232bf8aa29cb7e0053c7f38800091dfa4f33bb97d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16-INT8/text-spotting-0002-recognizer-decoder.xml
+    sha256: f8081ca355e402a0db10953174ddbc311fe49ebca6ac65b02e96fd847104be76
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16-INT8/text-spotting-0002-recognizer-decoder.xml
   - name: FP16-INT8/text-spotting-0002-recognizer-decoder.bin
     size: 1149634
     sha256: 8f9f2125617a0348766d96d3918295db7423bca0e7ca70e10789b180ef29e915
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16-INT8/text-spotting-0002-recognizer-decoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-decoder/FP16-INT8/text-spotting-0002-recognizer-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0002/text-spotting-0002-recognizer-encoder/model.yml
+++ b/models/intel/text-spotting-0002/text-spotting-0002-recognizer-encoder/model.yml
@@ -20,26 +20,26 @@ files:
   - name: FP32/text-spotting-0002-recognizer-encoder.xml
     size: 9872
     sha256: 64bf0782840b07deb70af126f60d1e66b57f661e478faec9ad59fc2c67b9dc37
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP32/text-spotting-0002-recognizer-encoder.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP32/text-spotting-0002-recognizer-encoder.xml
   - name: FP32/text-spotting-0002-recognizer-encoder.bin
     size: 5311488
     sha256: 018e69d5571190031105fe558684ecafb15699002cc3ffc02e125cf8857f818a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP32/text-spotting-0002-recognizer-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP32/text-spotting-0002-recognizer-encoder.bin
   - name: FP16/text-spotting-0002-recognizer-encoder.xml
     size: 9869
     sha256: abfbdc39629f81f57a7e1a08f6421dc8a69c02765cfda17239fcb11273bfc22f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16/text-spotting-0002-recognizer-encoder.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16/text-spotting-0002-recognizer-encoder.xml
   - name: FP16/text-spotting-0002-recognizer-encoder.bin
     size: 2655744
     sha256: 1675893bc936c1af5a03b02380212a68fe9391e2b6d563527e75c100b75f12ca
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16/text-spotting-0002-recognizer-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16/text-spotting-0002-recognizer-encoder.bin
   - name: FP16-INT8/text-spotting-0002-recognizer-encoder.xml
     size: 15945
-    sha256: 213385a63962c487a4a909dd13a8cda1dc7f92306b7f89c703a6dffba7051d43
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16-INT8/text-spotting-0002-recognizer-encoder.xml
+    sha256: 69952b2a65bab4eba2ccd52a91124b954adb70905e94070a2e2c3eed0dd8ea7a
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16-INT8/text-spotting-0002-recognizer-encoder.xml
   - name: FP16-INT8/text-spotting-0002-recognizer-encoder.bin
     size: 2655744
     sha256: 1675893bc936c1af5a03b02380212a68fe9391e2b6d563527e75c100b75f12ca
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16-INT8/text-spotting-0002-recognizer-encoder.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/text-spotting-0002/text-spotting-0002-recognizer-encoder/FP16-INT8/text-spotting-0002-recognizer-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/unet-camvid-onnx-0001/model.yml
+++ b/models/intel/unet-camvid-onnx-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/unet-camvid-onnx-0001.xml
     size: 64393
-    sha256: 6023ebc1248ee20305f2e60549a521907befb9b636acfdeabebb14d017a8606f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/unet-camvid-onnx-0001/FP32/unet-camvid-onnx-0001.xml
+    sha256: 8bf08df40dc9e3476c8956aaa6c31fa8df51cd40f3be999b24088493cdf9e3a1
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/unet-camvid-onnx-0001/FP32/unet-camvid-onnx-0001.xml
   - name: FP32/unet-camvid-onnx-0001.bin
     size: 124129876
     sha256: cf996b45dadfa397f16aad5a7264787e3666a7645eba3653e5c48d42076e86d7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/unet-camvid-onnx-0001/FP32/unet-camvid-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/unet-camvid-onnx-0001/FP32/unet-camvid-onnx-0001.bin
   - name: FP16/unet-camvid-onnx-0001.xml
     size: 64347
-    sha256: 85a70eafc74b43326073144ad036758e8f8a10f35990b36711cee560bc348af3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/unet-camvid-onnx-0001/FP16/unet-camvid-onnx-0001.xml
+    sha256: d3524abc34e3ab4966445c9949a6f16c585dd5017fff6ff7a24ac0039a9507ad
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/unet-camvid-onnx-0001/FP16/unet-camvid-onnx-0001.xml
   - name: FP16/unet-camvid-onnx-0001.bin
     size: 62064942
     sha256: 0c8dda21bc6ad71f6e78dea15d228f1bb293efeb2e97dff8d91ea91d357ca080
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/unet-camvid-onnx-0001/FP16/unet-camvid-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/unet-camvid-onnx-0001/FP16/unet-camvid-onnx-0001.bin
   - name: FP16-INT8/unet-camvid-onnx-0001.xml
     size: 151778
-    sha256: 1e2854a5fd54e036534c5820460da5e33dc4246b631d4f0e9b0f0d8df9d0a2e6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/unet-camvid-onnx-0001/FP16-INT8/unet-camvid-onnx-0001.xml
+    sha256: 65df1c5fca1d930442b036d88320373cbfb02b2cc0f26bb80c6b99790b00f744
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/unet-camvid-onnx-0001/FP16-INT8/unet-camvid-onnx-0001.xml
   - name: FP16-INT8/unet-camvid-onnx-0001.bin
     size: 33848274
     sha256: 82fccb97fa269ac5c7960844327222ca0741443ebcf99918fde3584121bee459
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/unet-camvid-onnx-0001/FP16-INT8/unet-camvid-onnx-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/unet-camvid-onnx-0001/FP16-INT8/unet-camvid-onnx-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/vehicle-attributes-recognition-barrier-0039.xml
     size: 33412
-    sha256: 2d4a944901583a41a34f3f12e1447e37c9577df11e57d65ffbfc7abec2efd088
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
+    sha256: f6cd8caa2dee037f14bd64d85511c15921b9253b9c6c9f4786fba1305e9e35d2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP32/vehicle-attributes-recognition-barrier-0039.bin
     size: 2504020
     sha256: 90faa902e411a7e713477c1e3d6dc4f9b7767e072505ecbc0000b62a6d4a48d0
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP16/vehicle-attributes-recognition-barrier-0039.xml
-    size: 33398
-    sha256: 8779105f37015f91c3025ab3a4b14bf02c0578a185a43d8efbbd43fd9f1ecca3
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
+    size: 33399
+    sha256: bcc4512d669c26fd5274f355f35c8193c3017adda0b71eed159a9f0ba78aa160
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP16/vehicle-attributes-recognition-barrier-0039.bin
     size: 1252018
     sha256: aed57f9cfdfc7dbd8955c5f6b15966bd0131050129835e2046451f06e4bde7b9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP16-INT8/vehicle-attributes-recognition-barrier-0039.xml
     size: 100745
-    sha256: b0635cf36da82671c0d06718ecc649bedfbd26cb5a2efea59b9664cc03ed2edd
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0039/FP16-INT8/vehicle-attributes-recognition-barrier-0039.xml
+    sha256: c8ec0e26836452af6befd82d11a159319cb29fef4a008ba4c47d4f01f5d23190
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16-INT8/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP16-INT8/vehicle-attributes-recognition-barrier-0039.bin
     size: 631126
     sha256: 7a6f5f72ef8c6f82b068ad53acdebe24763bbeb82b5bb795396b9b959c090097
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0039/FP16-INT8/vehicle-attributes-recognition-barrier-0039.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16-INT8/vehicle-attributes-recognition-barrier-0039.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-attributes-recognition-barrier-0042/model.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0042/model.yml
@@ -18,19 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/vehicle-attributes-recognition-barrier-0042.xml
     size: 62798
-    sha256: 0404b265c631241d80cec57ce963cd92c9079f8c602000ccd7fc3046162f5447
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0042/FP32/vehicle-attributes-recognition-barrier-0042.xml
+    sha256: 83973f488614cbb13dd89c7084cde138ded2f30892629e3e2e9586eb54f1f6ee
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP32/vehicle-attributes-recognition-barrier-0042.xml
   - name: FP32/vehicle-attributes-recognition-barrier-0042.bin
     size: 44709476
     sha256: 8f0f1c050fd33c44ad541f917e5f1caf5def6469e0546c11653dbccd15c64e5b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0042/FP32/vehicle-attributes-recognition-barrier-0042.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP32/vehicle-attributes-recognition-barrier-0042.bin
   - name: FP16/vehicle-attributes-recognition-barrier-0042.xml
     size: 62772
-    sha256: 9d99e87953aeffd7583fef44476aa830dd176c83c2b2f9e277dbfb9a5aa38c91
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0042/FP16/vehicle-attributes-recognition-barrier-0042.xml
+    sha256: cdbcb8057b965963ff1b18c967258bf59feec376c20024eff350d62c6640c317
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16/vehicle-attributes-recognition-barrier-0042.xml
   - name: FP16/vehicle-attributes-recognition-barrier-0042.bin
     size: 22354754
     sha256: 577a15af6c709d2461faf2403aeb4cf3108c7a2c03951d99841b8537221613c7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-attributes-recognition-barrier-0042/FP16/vehicle-attributes-recognition-barrier-0042.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16/vehicle-attributes-recognition-barrier-0042.bin
+  - name: FP16-INT8/vehicle-attributes-recognition-barrier-0042.xml
+    size: 174955
+    sha256: d4997002a5d93dc3bdd6102cee67a6bd8ac20b2d28030eec687c7bab1dd26506
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16-INT8/vehicle-attributes-recognition-barrier-0042.xml
+  - name: FP16-INT8/vehicle-attributes-recognition-barrier-0042.bin
+    size: 11201542
+    sha256: ee131854dfac2cb3af3997e67eed425c7ef0bb140935157d40e2ba4f57571920
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16-INT8/vehicle-attributes-recognition-barrier-0042.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-adas-0002/model.yml
+++ b/models/intel/vehicle-detection-adas-0002/model.yml
@@ -19,27 +19,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-detection-adas-0002.xml
     size: 206331
-    sha256: df702de3ef032dedc8d01cb4562aeb2796f96ae71baa43a302e5362ccaacac2c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
+    sha256: 03a3f6484363671a5cd0fe759dba8370a3955d30a042d84c3b7b15aa7a1b3349
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
   - name: FP32/vehicle-detection-adas-0002.bin
     size: 4314552
     sha256: dbe837dc1628ede3da0f4fe1e3a5f9a0457ef55c8bc050ba9ca257cd75d01929
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
   - name: FP16/vehicle-detection-adas-0002.xml
     size: 206285
-    sha256: b1e5c5695532ea45132d2a0182f1ad2db370eab667eca0897970bb04ab4f7a9a
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
+    sha256: 8fe38633e244af3453d3d451bedaf83efaf3f4df5d11b0b7552e4cb26792c8bd
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
   - name: FP16/vehicle-detection-adas-0002.bin
     size: 2157328
     sha256: e119b3bec50bc836f2eb26a56a40a6d5e3c33bde819f3e6d00f829978092742b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
   - name: FP16-INT8/vehicle-detection-adas-0002.xml
     size: 451570
-    sha256: 65628726238548ea65c649fd0e26511a94e177f338605ee4143c3aba37e9c9b9
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-0002/FP16-INT8/vehicle-detection-adas-0002.xml
+    sha256: 9fa501d521fb028a83fa80ffcfac6945b975f857bada7eadc6bb6b82e2e864ff
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-0002/FP16-INT8/vehicle-detection-adas-0002.xml
   - name: FP16-INT8/vehicle-detection-adas-0002.bin
     size: 1123350
     sha256: 2a80c5055cb3385fa25d919a3506ed8457fdefb7f8b6d8c9363f1b9a9c5d198b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-0002/FP16-INT8/vehicle-detection-adas-0002.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-0002/FP16-INT8/vehicle-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-adas-binary-0001/model.yml
+++ b/models/intel/vehicle-detection-adas-binary-0001/model.yml
@@ -20,10 +20,10 @@ files:
   - name: FP32-INT1/vehicle-detection-adas-binary-0001.xml
     size: 105969
     sha256: c98bf5984895b1309861597ec36181446877407cd985bb490e14461f41312670
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.xml
   - name: FP32-INT1/vehicle-detection-adas-binary-0001.bin
     size: 2160500
     sha256: afdd8a2f175b2f19c07083ff23b2e28105f3d1c7dc06a4b1a1d5c2c42b98294f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-detection-adas-binary-0001/FP32-INT1/vehicle-detection-adas-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
+++ b/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
@@ -18,19 +18,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-license-plate-detection-barrier-0106.xml
     size: 212198
-    sha256: 45163cacc1ea7484487a995c40939c69cfdda03521698e6b16fc5a640344503e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
+    sha256: 01c5f4a4720b8e232504cb8ed39251ad314ad180152fd9000de307b776041dc7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP32/vehicle-license-plate-detection-barrier-0106.bin
     size: 2573360
     sha256: c06a1845124a037dd902f933165501616ed8f716d5d311e628c333df50f1928e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
   - name: FP16/vehicle-license-plate-detection-barrier-0106.xml
     size: 212130
-    sha256: 067be216a22dc9039fe9d794b9bfa0015b4fb06d7446e22d4a8f59bf63deda0b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
+    sha256: d93b85ed8efb1b9ca82d7d5b269ac93bf2a327e4f9eb75cb2826ba108092eaf2
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP16/vehicle-license-plate-detection-barrier-0106.bin
     size: 1286738
     sha256: d9b1f186117ea43ff510f243ca8899b8aef1d2c0158de4ba6b699ed13f87eb07
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
+  - name: FP16-INT8/vehicle-license-plate-detection-barrier-0106.xml
+    size: 561238
+    sha256: 6a1d96ebeb05c503401812eb449d767000569985feff8dbd1aa9ec1dce56ecbf
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16-INT8/vehicle-license-plate-detection-barrier-0106.xml
+  - name: FP16-INT8/vehicle-license-plate-detection-barrier-0106.bin
+    size: 693916
+    sha256: 2cbd3cda25a48d8670557bbf2e339e1caecde64e5086afbf7db6e151e30b8976
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16-INT8/vehicle-license-plate-detection-barrier-0106.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/weld-porosity-detection-0001/model.yml
+++ b/models/intel/weld-porosity-detection-0001/model.yml
@@ -19,18 +19,26 @@ files:
   - name: FP32/weld-porosity-detection-0001.xml
     size: 59101
     sha256: e1257399302579e72398540dae191a6ea25adcfd3b791ea8c6788211a0083405
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/weld-porosity-detection-0001/FP32/weld-porosity-detection-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/weld-porosity-detection-0001/FP32/weld-porosity-detection-0001.xml
   - name: FP32/weld-porosity-detection-0001.bin
     size: 44693044
     sha256: 91fd5057ce1213c705518648dbf62e16a59061e8f2dcd02b83a9137d66ba6327
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/weld-porosity-detection-0001/FP32/weld-porosity-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/weld-porosity-detection-0001/FP32/weld-porosity-detection-0001.bin
   - name: FP16/weld-porosity-detection-0001.xml
     size: 59076
     sha256: cc78e649be19a3ce9925b590bb5c191a98c4703f5290e1436e524b303a53ba24
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/weld-porosity-detection-0001/FP16/weld-porosity-detection-0001.xml
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/weld-porosity-detection-0001/FP16/weld-porosity-detection-0001.xml
   - name: FP16/weld-porosity-detection-0001.bin
     size: 22346530
     sha256: 157c06cd80929fc4abec9ffa760345e0dae536a98034e0f45a3b247d285d13cf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/weld-porosity-detection-0001/FP16/weld-porosity-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/weld-porosity-detection-0001/FP16/weld-porosity-detection-0001.bin
+  - name: FP16-INT8/weld-porosity-detection-0001.xml
+    size: 166544
+    sha256: 932b733c739211a987877e302ad92d0fe9c16b35a07adee265c5bf305e0f2208
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/weld-porosity-detection-0001/FP16-INT8/weld-porosity-detection-0001.xml
+  - name: FP16-INT8/weld-porosity-detection-0001.bin
+    size: 11197382
+    sha256: 99ba305a093a17a517112f4de0db5fa5bf6afc0a409d700966017102983d0705
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/weld-porosity-detection-0001/FP16-INT8/weld-porosity-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-ava-0001/model.yml
+++ b/models/intel/yolo-v2-ava-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-ava-0001.xml
     size: 75882
-    sha256: d92cdcb17ddae060e8f6d1a5fb91ed7cde5df42dc94e891bf94d9d91850daa82
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-0001/FP32/yolo-v2-ava-0001.xml
+    sha256: 4840245b8f937fee4d73f820ef0111b84f95ab3ada040f6c36b2d783902ff35e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-0001/FP32/yolo-v2-ava-0001.xml
   - name: FP32/yolo-v2-ava-0001.bin
     size: 202580240
     sha256: ec32cd3d02e629685dc818a8af5734630c1f778a8a715cef93444aeb1bc88132
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-0001/FP32/yolo-v2-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-0001/FP32/yolo-v2-ava-0001.bin
   - name: FP16/yolo-v2-ava-0001.xml
     size: 75853
-    sha256: 511de7da9b4da64131732e263a8bcaaea6d11f3b12e7511a33b8ab0b1a70898f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-0001/FP16/yolo-v2-ava-0001.xml
+    sha256: 273046779fae77bbd39d4d9bfd7e68c2c8dc7ec10f883332aa008a1dbc69dc5f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-0001/FP16/yolo-v2-ava-0001.xml
   - name: FP16/yolo-v2-ava-0001.bin
     size: 101290122
     sha256: 3d64e39d4c0378eaf870834a072725bc9e7320a5cc4ffa3422f13d0dcd170ddf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-0001/FP16/yolo-v2-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-0001/FP16/yolo-v2-ava-0001.bin
   - name: FP16-INT8/yolo-v2-ava-0001.xml
     size: 183915
-    sha256: 5a83abeba6f767ad5690263ec185646fd5ed6b8c3d6deaa1b881558c7becdf0c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-0001/FP16-INT8/yolo-v2-ava-0001.xml
+    sha256: efe56953fb3fbcb4c765580c164a5bd7bd350c45436c94c61b04ecdf9d9616ef
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-0001/FP16-INT8/yolo-v2-ava-0001.xml
   - name: FP16-INT8/yolo-v2-ava-0001.bin
     size: 50697468
     sha256: 8340a0433a6fa888bde2c2ea3004324d8ca71b772bde93fe3388ee0652e7a3d8
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-0001/FP16-INT8/yolo-v2-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-0001/FP16-INT8/yolo-v2-ava-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-ava-sparse-35-0001/model.yml
+++ b/models/intel/yolo-v2-ava-sparse-35-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-ava-sparse-35-0001.xml
     size: 75902
-    sha256: 91b48281275bed31a0a165b2580dca3d5046352741480fc8dc8d1b11a0566e0f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-35-0001/FP32/yolo-v2-ava-sparse-35-0001.xml
+    sha256: ef565ff57dd58bfa5d19934b2c405371264e3c58c0ed7624acffc3e858b8d328
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-35-0001/FP32/yolo-v2-ava-sparse-35-0001.xml
   - name: FP32/yolo-v2-ava-sparse-35-0001.bin
     size: 202580240
     sha256: 3ba29689fd746d99e758ba15e6285d4d6e10e06616ca3113f2f7fbb2c0f85511
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-35-0001/FP32/yolo-v2-ava-sparse-35-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-35-0001/FP32/yolo-v2-ava-sparse-35-0001.bin
   - name: FP16/yolo-v2-ava-sparse-35-0001.xml
     size: 75873
-    sha256: 930d046f3005aab08ef6112103310c5b8ce868bee1dd3b5b87ef156949c62927
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-35-0001/FP16/yolo-v2-ava-sparse-35-0001.xml
+    sha256: 43288a2b447e9a38ed43d2c9122ec5ddd1de2c81c7c40418bda27f48ef67d12d
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16/yolo-v2-ava-sparse-35-0001.xml
   - name: FP16/yolo-v2-ava-sparse-35-0001.bin
     size: 101290122
     sha256: 70b6f76b11edb38761d707555ed50183b36eece352bd01af5d10fdcda7a6ff3b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-35-0001/FP16/yolo-v2-ava-sparse-35-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16/yolo-v2-ava-sparse-35-0001.bin
   - name: FP16-INT8/yolo-v2-ava-sparse-35-0001.xml
     size: 183967
-    sha256: 58c52789229eccc75915e2ede1bbdfd329ef1c95e8de10e44b9b0c3248d2e9ff
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-35-0001/FP16-INT8/yolo-v2-ava-sparse-35-0001.xml
+    sha256: ff6d19acef1b7881078237eb48020d68a5a226f6ab556bbd266ad453695a7a66
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16-INT8/yolo-v2-ava-sparse-35-0001.xml
   - name: FP16-INT8/yolo-v2-ava-sparse-35-0001.bin
     size: 50697470
     sha256: 5723b98a3bb935aab353f18bf9ce68f1e24c0feb513adebbf668ccf612ae761e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-35-0001/FP16-INT8/yolo-v2-ava-sparse-35-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16-INT8/yolo-v2-ava-sparse-35-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-ava-sparse-70-0001/model.yml
+++ b/models/intel/yolo-v2-ava-sparse-70-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-ava-sparse-70-0001.xml
     size: 75902
-    sha256: f03b81de2d7bf79cb3a47995e6f0fc108c9873ac3aa8b6c04c4ec18c055da3cb
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-70-0001/FP32/yolo-v2-ava-sparse-70-0001.xml
+    sha256: 1fe22ed974c09fccec6708f368328e385be5299dcd8165deddaeed9c18ceadf3
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-70-0001/FP32/yolo-v2-ava-sparse-70-0001.xml
   - name: FP32/yolo-v2-ava-sparse-70-0001.bin
     size: 202580240
     sha256: 8af740a7af01a06561f599f4a0b0c9d7e423437bc6acab0f123bce170978e420
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-70-0001/FP32/yolo-v2-ava-sparse-70-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-70-0001/FP32/yolo-v2-ava-sparse-70-0001.bin
   - name: FP16/yolo-v2-ava-sparse-70-0001.xml
     size: 75873
-    sha256: b1aa889e8b85e7c9ec8fa3d59c2e444bbcec968ff1eb32af9c56dc3e5808db53
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-70-0001/FP16/yolo-v2-ava-sparse-70-0001.xml
+    sha256: 2435188fb26e8c1430385c48910724167164bb8ae0ac5324019092573ed9259f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16/yolo-v2-ava-sparse-70-0001.xml
   - name: FP16/yolo-v2-ava-sparse-70-0001.bin
     size: 101290122
     sha256: 4e377e55053fa15b52d8e4012418143c7430b8a337353ef1aeb88cbe9c50a7ff
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-70-0001/FP16/yolo-v2-ava-sparse-70-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16/yolo-v2-ava-sparse-70-0001.bin
   - name: FP16-INT8/yolo-v2-ava-sparse-70-0001.xml
     size: 183964
-    sha256: 2761171e8d0b9d6d34d4efdfbf993faac6d963f42a72570def86c1449530467e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-70-0001/FP16-INT8/yolo-v2-ava-sparse-70-0001.xml
+    sha256: 238eaaf29122207df3481160690ccfae513d40be8f02f59e88b704b8d15c9730
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16-INT8/yolo-v2-ava-sparse-70-0001.xml
   - name: FP16-INT8/yolo-v2-ava-sparse-70-0001.bin
     size: 50697470
     sha256: 7903e972e370adf0f46bbf6bdf0d0afd8e82cfb36547049e50cd79a27660b6ee
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-ava-sparse-70-0001/FP16-INT8/yolo-v2-ava-sparse-70-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16-INT8/yolo-v2-ava-sparse-70-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-ava-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-ava-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-ava-0001.xml
     size: 33280
-    sha256: d6b45989ecb0c78bcfb5df920be07fb657a8339102c15c7394de543df2186fcc
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-0001/FP32/yolo-v2-tiny-ava-0001.xml
+    sha256: 1d08fc262c73132562f7439daf7ecf9d8e541bceea5248a1b07b32050157a23f
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-0001/FP32/yolo-v2-tiny-ava-0001.xml
   - name: FP32/yolo-v2-tiny-ava-0001.bin
     size: 63434896
     sha256: d7d0219f039d9621efccc3c43e6c74ad6222ee7ba526901e9975ba5661433322
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-0001/FP32/yolo-v2-tiny-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-0001/FP32/yolo-v2-tiny-ava-0001.bin
   - name: FP16/yolo-v2-tiny-ava-0001.xml
     size: 33259
-    sha256: 55570e3cef52f4f932ccbc89b95d781151ce7f0785e3fe6b6a717340e6e5ee2e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-0001/FP16/yolo-v2-tiny-ava-0001.xml
+    sha256: 632fb94f6a2e810ac2e2534c566e1944a0b0dabb74cecb32e6497cf065d5a158
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-0001/FP16/yolo-v2-tiny-ava-0001.xml
   - name: FP16/yolo-v2-tiny-ava-0001.bin
     size: 31717450
     sha256: a28d0eced820152c696375390124d6e63ed56048190f29982a0d5fd2ce8d2cf4
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-0001/FP16/yolo-v2-tiny-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-0001/FP16/yolo-v2-tiny-ava-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-ava-0001.xml
     size: 78525
-    sha256: 2f283892dd3c45c68504c2d0913865149095de379b6cfa7f2909389417c77e8c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-0001/FP16-INT8/yolo-v2-tiny-ava-0001.xml
+    sha256: 3c27b852a00e990e828443a059e43417a70f33a4abad8373e3065673ba400230
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-0001/FP16-INT8/yolo-v2-tiny-ava-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-ava-0001.bin
     size: 15874678
     sha256: f6dceee10667e199e04bb75fdf3b0b2a37ae5aadfb6f665b29b044c366a0d03f
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-0001/FP16-INT8/yolo-v2-tiny-ava-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-0001/FP16-INT8/yolo-v2-tiny-ava-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-ava-sparse-30-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-30-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-ava-sparse-30-0001.xml
     size: 33300
-    sha256: 2725ed24fffd9756c1f5de7c3874ae0ccad9c5e2b47a4e68d5a2d2d208fb1ed1
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-30-0001/FP32/yolo-v2-tiny-ava-sparse-30-0001.xml
+    sha256: 85f77fdae888abca8260b89342d0175d0310ebd9153644d113ff73032c2a8570
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP32/yolo-v2-tiny-ava-sparse-30-0001.xml
   - name: FP32/yolo-v2-tiny-ava-sparse-30-0001.bin
     size: 63434896
     sha256: 89199208d5a6491141f1dc469b8b98d0c9d43de22b10f8ab57cbbc656c57d200
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-30-0001/FP32/yolo-v2-tiny-ava-sparse-30-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP32/yolo-v2-tiny-ava-sparse-30-0001.bin
   - name: FP16/yolo-v2-tiny-ava-sparse-30-0001.xml
     size: 33279
-    sha256: 6a6cffdd85f1d0fc5be1b526827028957c23fde7b2a53d3fed8fe4f3c8f9de3c
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-30-0001/FP16/yolo-v2-tiny-ava-sparse-30-0001.xml
+    sha256: 2d31b217b5aad11086bdce79dbaa542fa9ac84643ba87065e7fd2eb0e879bae7
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16/yolo-v2-tiny-ava-sparse-30-0001.xml
   - name: FP16/yolo-v2-tiny-ava-sparse-30-0001.bin
     size: 31717450
     sha256: 026eaff315755ad66f7dca256f99b02e2aed68dcf3fcc2641d403dfd88d21f2d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-30-0001/FP16/yolo-v2-tiny-ava-sparse-30-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16/yolo-v2-tiny-ava-sparse-30-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.xml
     size: 78575
-    sha256: 267667cd0329a9b5f374c020355fea18464295c6615da8a75790ab35355ec52e
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-30-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.xml
+    sha256: 39ca563dd45582bb70ed803c7774b09f5e2851679680ccb37d30f514e0e8a958
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.bin
     size: 15874678
     sha256: a28520da3895d3d2b33027cd15d9d8001f76f337552fecfbf03166227fe94f57
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-30-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-ava-sparse-60-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-60-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-ava-sparse-60-0001.xml
     size: 33332
-    sha256: 07dd784a6fb47660ea941c7df0583233a40d7d9f829d9dcff3c7029e414c5b8d
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-60-0001/FP32/yolo-v2-tiny-ava-sparse-60-0001.xml
+    sha256: bc15384365b7e16045503123110e45980052ce9e020635239eba881b4af084dd
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP32/yolo-v2-tiny-ava-sparse-60-0001.xml
   - name: FP32/yolo-v2-tiny-ava-sparse-60-0001.bin
     size: 63434896
     sha256: a75760129ebfa1954aa8f244020193bab0a7f6f85450435f696f602155eb80b6
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-60-0001/FP32/yolo-v2-tiny-ava-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP32/yolo-v2-tiny-ava-sparse-60-0001.bin
   - name: FP16/yolo-v2-tiny-ava-sparse-60-0001.xml
     size: 33311
-    sha256: 3348fa847447beeec0322b20a960a39b4b7c0703fda042e69c41525948fb06da
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-60-0001/FP16/yolo-v2-tiny-ava-sparse-60-0001.xml
+    sha256: 571a3e4b3e35d393648efd12ec5fd6ffe873f87cf5f89bcf1e65e58d02ef98ae
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16/yolo-v2-tiny-ava-sparse-60-0001.xml
   - name: FP16/yolo-v2-tiny-ava-sparse-60-0001.bin
     size: 31717450
     sha256: df0df94838247c45b8cd1918b52140aff0ffaa1cdecd5450e0f8ee261adaf757
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-60-0001/FP16/yolo-v2-tiny-ava-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16/yolo-v2-tiny-ava-sparse-60-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.xml
     size: 78588
-    sha256: daa40b2c86f9808c0e5d04b5c89f85b027db2bec028b998e4c90ddc045cdc47b
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-60-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.xml
+    sha256: bb9e9143b9f795a347bfa53f35e2a5da0e251281207a0cf6ec4c9bc9e1816942
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.bin
     size: 15874678
     sha256: 7037e6d2d29d8dd3832612d16dd295f03e97ca88e22765e1adbcccebbeedb281
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-ava-sparse-60-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-vehicle-detection-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-vehicle-detection-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-vehicle-detection-0001.xml
     size: 31450
-    sha256: f3b9f52393eebb16b60c2637097f59764bf371a48f9ac595b59104a80addd3d7
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-vehicle-detection-0001/FP32/yolo-v2-tiny-vehicle-detection-0001.xml
+    sha256: 5795bbc941181e34151613275414d44238b596ce526441bd18f95de4dc1d7499
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP32/yolo-v2-tiny-vehicle-detection-0001.xml
   - name: FP32/yolo-v2-tiny-vehicle-detection-0001.bin
     size: 44918056
     sha256: b15e36bcc6763676fd25db67c328242875f0257ef7faf2d3bd8cebfb032151f5
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-vehicle-detection-0001/FP32/yolo-v2-tiny-vehicle-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP32/yolo-v2-tiny-vehicle-detection-0001.bin
   - name: FP16/yolo-v2-tiny-vehicle-detection-0001.xml
     size: 31430
-    sha256: 224bb9421f3e6a002373dd666184be19c6c3deb61b60db7cf1a8e31855eb9740
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-vehicle-detection-0001/FP16/yolo-v2-tiny-vehicle-detection-0001.xml
+    sha256: 502f03b6591ca4168166592882b6552f0e078e5bc1018ec6d808660cd48ed4a9
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16/yolo-v2-tiny-vehicle-detection-0001.xml
   - name: FP16/yolo-v2-tiny-vehicle-detection-0001.bin
     size: 22459030
     sha256: 15aee0ac39cdfeff0f8dfdb85e8b3152331df42d879ba76e9d3c5e7548ca3007
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-vehicle-detection-0001/FP16/yolo-v2-tiny-vehicle-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16/yolo-v2-tiny-vehicle-detection-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.xml
     size: 76025
-    sha256: f52a51ccf89093fbff7286c204c477afd4d6e636ffe1735d392aa8fede8ccd54
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-vehicle-detection-0001/FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.xml
+    sha256: d185ea66bae7f3d9afe59d5da1f22b60c0e47f4fea164992416352efa1b9511e
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.bin
     size: 11244400
     sha256: fef3b00120b62f500fc16bf3c652803f656d3bbfcb7c4ae2be773b5c4149cbaf
-    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/2/yolo-v2-tiny-vehicle-detection-0001/FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.bin
+    source: https://download.01.org/opencv/2020/openvinotoolkit/2020.4/open_model_zoo/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/opencv/open_model_zoo/master/LICENSE


### PR DESCRIPTION
Also, revert a workaround in the Python segmentation demo that isn't necessary anymore.