### PR TITLE
downloader: disable compression when resuming a download

### DIFF
--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -293,6 +293,7 @@ class FileSourceHttp(FileSource):
     def start_download(self, session, chunk_size, offset):
         headers = {}
         if offset != 0:
+            headers['Accept-Encoding'] = 'identity'
             headers['Range'] = 'bytes={}-'.format(offset)
 
         response = session.get(self.url, stream=True, timeout=DOWNLOAD_TIMEOUT, headers=headers)


### PR DESCRIPTION
Requests enables compression by default. However, it's not a good idea to do that when making a range request, because if the server decides to use compression, then it'll return a range from the _compressed_ file, which is useless (you can't decompress a chunk from the middle of a compressed file).

Because of that, I suspect that most servers already either disable compression or don't honor range requests, but just in case, disable it on our side too.