### PR TITLE
Bump dependency versions

### DIFF
--- a/ci/requirements-ac-test.txt
+++ b/ci/requirements-ac-test.txt
@@ -1,41 +1,41 @@
 # use update-requirements.py to update this file
 
-atomicwrites==1.3.0       # via -r tools/accuracy_checker/requirements-test.in
+atomicwrites==1.4.0       # via -r tools/accuracy_checker/requirements-test.in
 attrs==19.3.0             # via pytest
 cycler==0.10.0            # via matplotlib
 decorator==4.4.2          # via networkx
 editdistance==0.5.3       # via -r tools/accuracy_checker/requirements.in
-imageio==2.8.0            # via scikit-image
-importlib-metadata==1.6.0  # via pluggy, pytest
+imageio==2.9.0            # via scikit-image
+importlib-metadata==1.7.0  # via pluggy, pytest
 joblib==0.14.1            # via scikit-learn
 kiwisolver==1.1.0         # via matplotlib
 matplotlib==3.0.3         # via scikit-image
-more-itertools==8.2.0     # via pytest
+more-itertools==8.4.0     # via pytest
 networkx==2.4             # via scikit-image
 nibabel==3.0.2            # via -r tools/accuracy_checker/requirements.in
 numpy==1.17.5             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, nibabel, pywavelets, scikit-learn, scipy
-packaging==20.3           # via pytest
+packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
-pillow==7.1.1             # via -r tools/accuracy_checker/requirements.in, imageio, scikit-image
+pillow==7.2.0             # via -r tools/accuracy_checker/requirements.in, imageio, scikit-image
 pluggy==0.13.1            # via pytest
 py-cpuinfo==4.0.0         # via -r tools/accuracy_checker/requirements.in
-py==1.8.1                 # via pytest
-pydicom==1.4.2            # via -r tools/accuracy_checker/requirements.in
+py==1.9.0                 # via pytest
+pydicom==2.0.0            # via -r tools/accuracy_checker/requirements.in
 pyparsing==2.4.7          # via matplotlib, packaging
 pytest-mock==2.0.0        # via -r tools/accuracy_checker/requirements-test.in
-pytest==5.4.1             # via -r tools/accuracy_checker/requirements-test.in, pytest-mock
+pytest==5.4.3             # via -r tools/accuracy_checker/requirements-test.in, pytest-mock
 python-dateutil==2.8.1    # via matplotlib
 pywavelets==1.1.1         # via scikit-image
 pyyaml==5.3.1             # via -r tools/accuracy_checker/requirements-core.in
 scikit-image==0.15.0      # via -r tools/accuracy_checker/requirements.in
 scikit-learn==0.22.2.post1  # via -r tools/accuracy_checker/requirements.in
 scipy==1.4.1              # via -r tools/accuracy_checker/requirements.in, scikit-image, scikit-learn
-sentencepiece==0.1.85     # via -r tools/accuracy_checker/requirements.in
+sentencepiece==0.1.91     # via -r tools/accuracy_checker/requirements.in
 shapely==1.7.0            # via -r tools/accuracy_checker/requirements.in
-six==1.14.0               # via cycler, packaging, pathlib2, python-dateutil
-tokenizers==0.7           # via -r tools/accuracy_checker/requirements.in
-tqdm==4.45.0              # via -r tools/accuracy_checker/requirements.in
-wcwidth==0.1.9            # via pytest
+six==1.15.0               # via packaging, pathlib2, python-dateutil
+tokenizers==0.8.0         # via -r tools/accuracy_checker/requirements.in
+tqdm==4.47.0              # via -r tools/accuracy_checker/requirements.in
+wcwidth==0.2.5            # via pytest
 zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/ci/requirements-ac.txt
+++ b/ci/requirements-ac.txt
@@ -3,16 +3,16 @@
 cycler==0.10.0            # via matplotlib
 decorator==4.4.2          # via networkx
 editdistance==0.5.3       # via -r tools/accuracy_checker/requirements.in
-imageio==2.8.0            # via scikit-image
+imageio==2.9.0            # via scikit-image
 joblib==0.14.1            # via scikit-learn
 kiwisolver==1.1.0         # via matplotlib
 matplotlib==3.0.3         # via scikit-image
 networkx==2.4             # via scikit-image
 nibabel==3.0.2            # via -r tools/accuracy_checker/requirements.in
 numpy==1.17.5             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, nibabel, pywavelets, scikit-learn, scipy
-pillow==7.1.1             # via -r tools/accuracy_checker/requirements.in, imageio, scikit-image
+pillow==7.2.0             # via -r tools/accuracy_checker/requirements.in, imageio, scikit-image
 py-cpuinfo==4.0.0         # via -r tools/accuracy_checker/requirements.in
-pydicom==1.4.2            # via -r tools/accuracy_checker/requirements.in
+pydicom==2.0.0            # via -r tools/accuracy_checker/requirements.in
 pyparsing==2.4.7          # via matplotlib
 python-dateutil==2.8.1    # via matplotlib
 pywavelets==1.1.1         # via scikit-image
@@ -20,11 +20,11 @@ pyyaml==5.3.1             # via -r tools/accuracy_checker/requirements-core.in
 scikit-image==0.15.0      # via -r tools/accuracy_checker/requirements.in
 scikit-learn==0.22.2.post1  # via -r tools/accuracy_checker/requirements.in
 scipy==1.4.1              # via -r tools/accuracy_checker/requirements.in, scikit-image, scikit-learn
-sentencepiece==0.1.85     # via -r tools/accuracy_checker/requirements.in
+sentencepiece==0.1.91     # via -r tools/accuracy_checker/requirements.in
 shapely==1.7.0            # via -r tools/accuracy_checker/requirements.in
-six==1.15.0               # via cycler, python-dateutil
-tokenizers==0.7           # via -r tools/accuracy_checker/requirements.in
-tqdm==4.45.0              # via -r tools/accuracy_checker/requirements.in
+six==1.15.0               # via python-dateutil
+tokenizers==0.8.0         # via -r tools/accuracy_checker/requirements.in
+tqdm==4.47.0              # via -r tools/accuracy_checker/requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -1,43 +1,53 @@
 # use update-requirements.py to update this file
 
 absl-py==0.9.0            # via tensorboard, tensorflow
-astor==0.8.1              # via tensorflow
-certifi==2020.4.5.1       # via requests
+astunparse==1.6.3         # via tensorflow
+cachetools==4.1.1         # via google-auth
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 decorator==4.4.2          # via networkx
 defusedxml==0.6.0         # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt
 future==0.18.2            # via -r tools/downloader/requirements-caffe2.in
-gast==0.2.2               # via tensorflow
+gast==0.3.3               # via tensorflow
+google-auth-oauthlib==0.4.1  # via tensorboard
+google-auth==1.18.0       # via google-auth-oauthlib, tensorboard
 google-pasta==0.2.0       # via tensorflow
 graphviz==0.8.4           # via mxnet
-grpcio==1.28.1            # via tensorboard, tensorflow
-h5py==2.10.0              # via keras-applications
-idna==2.9                 # via requests
-keras-applications==1.0.8  # via tensorflow
-keras-preprocessing==1.1.0  # via tensorflow
-markdown==3.2.1           # via tensorboard
+grpcio==1.30.0            # via tensorboard, tensorflow
+h5py==2.10.0              # via tensorflow
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via markdown
+keras-preprocessing==1.1.2  # via tensorflow
+markdown==3.2.2           # via tensorboard
 mxnet==1.5.1              # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt
 networkx==2.4             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt
-numpy==1.18.2             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt, h5py, keras-applications, keras-preprocessing, mxnet, onnx, opt-einsum, scipy, tensorboard, tensorflow, torch, torchvision
-onnx==1.6.0               # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt, -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in
+numpy==1.18.5             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt, h5py, keras-preprocessing, mxnet, onnx, opt-einsum, scipy, tensorboard, tensorflow, torch, torchvision
+oauthlib==3.1.0           # via requests-oauthlib
+onnx==1.7.0               # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt, -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in
 opt-einsum==3.2.1         # via tensorflow
-pillow==7.1.1             # via torchvision
-protobuf==3.6.1           # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt, onnx, tensorboard, tensorflow
-requests==2.23.0          # via mxnet
-scipy==1.4.1              # via -r tools/downloader/requirements-pytorch.in
-six==1.14.0               # via absl-py, google-pasta, grpcio, h5py, keras-preprocessing, onnx, protobuf, tensorboard, tensorflow, test-generator, torchvision
-tensorboard==1.15.0       # via tensorflow
-tensorflow-estimator==1.15.1  # via tensorflow
-tensorflow==1.15.2        # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt
+pillow==7.2.0             # via torchvision
+protobuf==3.12.2          # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt, onnx, tensorboard, tensorflow
+pyasn1-modules==0.2.8     # via google-auth
+pyasn1==0.4.8             # via pyasn1-modules, rsa
+requests-oauthlib==1.3.0  # via google-auth-oauthlib
+requests==2.24.0          # via mxnet, requests-oauthlib, tensorboard
+rsa==4.6                  # via google-auth
+scipy==1.4.1              # via -r tools/downloader/requirements-pytorch.in, tensorflow
+six==1.15.0               # via absl-py, astunparse, google-auth, google-pasta, grpcio, h5py, keras-preprocessing, onnx, protobuf, tensorboard, tensorflow, test-generator, torchvision
+tensorboard-plugin-wit==1.7.0  # via tensorboard
+tensorboard==2.2.2        # via tensorflow
+tensorflow-estimator==2.2.0  # via tensorflow
+tensorflow==2.2.0         # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt
 termcolor==1.1.0          # via tensorflow
 test-generator==0.1.1     # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements.txt
 torch==1.4.0              # via -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in, torchvision
 torchvision==0.5.0        # via -r tools/downloader/requirements-pytorch.in
 typing-extensions==3.7.4.2  # via onnx
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests
 werkzeug==1.0.1           # via tensorboard
-wheel==0.34.2             # via tensorboard, tensorflow
+wheel==0.34.2             # via astunparse, tensorboard, tensorflow
 wrapt==1.12.1             # via tensorflow
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/ci/requirements-demos.txt
+++ b/ci/requirements-demos.txt
@@ -2,56 +2,55 @@
 
 absl-py==0.9.0            # via tensorboard
 attrs==19.3.0             # via pytest
-cachetools==4.1.0         # via google-auth
-certifi==2020.4.5.1       # via requests
+cachetools==4.1.1         # via google-auth
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 cycler==0.10.0            # via matplotlib
-entrypoints==0.3          # via flake8
 flake8-import-order==0.18.1  # via motmetrics
-flake8==3.7.9             # via motmetrics
+flake8==3.8.3             # via motmetrics
 google-auth-oauthlib==0.4.1  # via tensorboard
-google-auth==1.14.0       # via google-auth-oauthlib, tensorboard
-grpcio==1.28.1            # via tensorboard
-idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via pluggy, pytest
+google-auth==1.18.0       # via google-auth-oauthlib, tensorboard
+grpcio==1.30.0            # via tensorboard
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via flake8, markdown, pluggy, pytest
 joblib==0.14.1            # via scikit-learn
 kiwisolver==1.1.0         # via matplotlib
-markdown==3.2.1           # via tensorboard
+markdown==3.2.2           # via tensorboard
 matplotlib==3.0.3         # via -r demos/python_demos/requirements.txt
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
+more-itertools==8.4.0     # via pytest
 motmetrics==1.2.0         # via -r demos/python_demos/requirements.txt
 nibabel==3.0.2            # via -r demos/python_demos/requirements.txt
-numpy==1.18.2 ; python_version >= "3.4"  # via -r ${INTEL_OPENVINO_DIR}/python/requirements.txt, -r demos/python_demos/requirements.txt, matplotlib, motmetrics, nibabel, pandas, scikit-learn, scipy, tensorboard, tensorboardx
+numpy==1.18.5 ; python_version >= "3.4"  # via -r ${INTEL_OPENVINO_DIR}/python/requirements.txt, -r demos/python_demos/requirements.txt, matplotlib, motmetrics, nibabel, pandas, scikit-learn, scipy, tensorboard, tensorboardx
 oauthlib==3.1.0           # via requests-oauthlib
-packaging==20.3           # via pytest
+packaging==20.4           # via pytest
 pandas==0.24.2            # via motmetrics
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
-protobuf==3.11.3          # via tensorboard, tensorboardx
-py-cpuinfo==5.0.0         # via pytest-benchmark
-py==1.8.1                 # via pytest
+protobuf==3.12.2          # via tensorboard, tensorboardx
+py-cpuinfo==7.0.0         # via pytest-benchmark
+py==1.9.0                 # via pytest
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
-pycodestyle==2.5.0        # via flake8, flake8-import-order
-pyflakes==2.1.1           # via flake8
+pycodestyle==2.6.0        # via flake8, flake8-import-order
+pyflakes==2.2.0           # via flake8
 pyparsing==2.4.7          # via matplotlib, packaging
 pytest-benchmark==3.2.3   # via motmetrics
-pytest==5.4.1             # via motmetrics, pytest-benchmark
+pytest==5.4.3             # via motmetrics, pytest-benchmark
 python-dateutil==2.8.1    # via matplotlib, pandas
-pytz==2019.3              # via pandas
+pytz==2020.1              # via pandas
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests==2.23.0          # via requests-oauthlib, tensorboard
-rsa==4.0                  # via google-auth
+requests==2.24.0          # via requests-oauthlib, tensorboard
+rsa==4.6                  # via google-auth
 scikit-learn==0.22.2.post1  # via -r demos/python_demos/requirements.txt
 scipy==1.4.1              # via -r demos/python_demos/requirements.txt, motmetrics, scikit-learn
-six==1.14.0               # via absl-py, google-auth, grpcio, packaging, pathlib2, protobuf, python-dateutil, tensorboard, tensorboardx
-tensorboard-plugin-wit==1.6.0.post3  # via tensorboard
-tensorboard==2.2.0        # via -r demos/python_demos/requirements.txt
-tensorboardx==2.0         # via -r demos/python_demos/requirements.txt
-tqdm==4.45.0              # via -r demos/python_demos/requirements.txt
-urllib3==1.25.8           # via requests
-wcwidth==0.1.9            # via pytest
+six==1.15.0               # via absl-py, google-auth, grpcio, packaging, pathlib2, protobuf, python-dateutil, tensorboard, tensorboardx
+tensorboard-plugin-wit==1.7.0  # via tensorboard
+tensorboard==2.2.2        # via -r demos/python_demos/requirements.txt
+tensorboardx==2.1         # via -r demos/python_demos/requirements.txt
+tqdm==4.47.0              # via -r demos/python_demos/requirements.txt
+urllib3==1.25.9           # via requests
+wcwidth==0.2.5            # via pytest
 werkzeug==1.0.1           # via tensorboard
 wheel==0.34.2             # via tensorboard
 xmltodict==0.12.0         # via motmetrics

--- a/ci/requirements-downloader.txt
+++ b/ci/requirements-downloader.txt
@@ -1,8 +1,8 @@
 # use update-requirements.py to update this file
 
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-idna==2.9                 # via requests
+idna==2.10                # via requests
 pyyaml==5.3.1             # via -r tools/downloader/requirements.in
-requests==2.23.0          # via -r tools/downloader/requirements.in
-urllib3==1.25.8           # via requests
+requests==2.24.0          # via -r tools/downloader/requirements.in
+urllib3==1.25.9           # via requests

--- a/tools/downloader/requirements-caffe2.in
+++ b/tools/downloader/requirements-caffe2.in
@@ -1,3 +1,5 @@
 future
 onnx
-torch
+
+# fix version in order to be compatible with requirements-pytorch.in
+torch<1.5

--- a/tools/downloader/requirements-pytorch.in
+++ b/tools/downloader/requirements-pytorch.in
@@ -1,4 +1,6 @@
 onnx
 scipy           # via torchvision
-torch>=1.4
-torchvision
+
+# can't use higher versions because of https://github.com/pytorch/vision/issues/2132
+torch==1.4.*
+torchvision==0.5.*


### PR DESCRIPTION
Unfortunately, pytorch/vision#2132 prevents us from moving to PyTorch 1.5, so I had to cap it at 1.4.