### PR TITLE
Enable input channel reversal for deeplabv3

### DIFF
--- a/models/public/deeplabv3/accuracy-check.yml
+++ b/models/public/deeplabv3/accuracy-check.yml
@@ -18,7 +18,6 @@ models:
     datasets:
       - name: VOC2012_Segmentation
         preprocessing:
-          - type: bgr_to_rgb
           - type: padding
             size: 513
         postprocessing:

--- a/models/public/deeplabv3/deeplabv3.md
+++ b/models/public/deeplabv3/deeplabv3.md
@@ -47,9 +47,7 @@ Image, name: `mul_1/placeholder_port_1`, shape: [1x3x513x513], format: [BxCxHxW]
     - H - image height
     - W - image width
 
-   Expected color order: RGB.
-
-> **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. Reverse input channels operation via Model Optimizer conversion can not be applied to this model in proper way. For running this model with Open Model Zoo demos, you need to manually rearrange the default channels order in the demo application.
+   Expected color order: BGR.
 
 ## Output
 

--- a/models/public/deeplabv3/model.yml
+++ b/models/public/deeplabv3/model.yml
@@ -26,6 +26,7 @@ postprocessing:
     format: gztar
     file: deeplabv3.tar.gz
 model_optimizer_args:
+  - --reverse_input_channels
   - --input_shape=[1,513,513,3]
   - --input=1:mul_1
   - --output=ArgMax


### PR DESCRIPTION
The Model Optimizer issue that prevented us from doing this has been fixed at some point, so there's nothing preventing us from doing it.

This makes this model's input consistent with most others, and makes it so that people can use it with our segmentation demo without modifying the demo (or losing accuracy).