### PR TITLE
Replace bgr_to_rgb with rgb_to_bgr in several AC configs

### DIFF
--- a/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
@@ -29,7 +29,7 @@ models:
           - type: crop
             size: 224
             use_pillow: True
-          - type: bgr_to_rgb
+          - type: rgb_to_bgr
 
         metrics:
           - name: accuracy@top1

--- a/models/intel/resnet50-binary-0001/accuracy-check.yml
+++ b/models/intel/resnet50-binary-0001/accuracy-check.yml
@@ -29,7 +29,7 @@ models:
           - type: crop
             size: 224
             use_pillow: True
-          - type: bgr_to_rgb
+          - type: rgb_to_bgr
 
         metrics:
           - name: accuracy@top1

--- a/models/intel/unet-camvid-onnx-0001/accuracy-check.yml
+++ b/models/intel/unet-camvid-onnx-0001/accuracy-check.yml
@@ -33,7 +33,7 @@ models:
             dst_width: 480
             use_pillow: True
             interpolation: BILINEAR
-          - type: bgr_to_rgb
+          - type: rgb_to_bgr
 
         postprocessing:
           - type: resize_segmentation_mask


### PR DESCRIPTION
There's no functional difference, but this is more correct in terms of semantics: the `pillow_imread` reader produces RGB images, which we convert to BGR for our networks.